### PR TITLE
Stage1 data pipeline enhancements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.3
+    hooks:
+      - id: ruff

--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -15,3 +15,15 @@ docker exec -i <db_container_name> psql -U postgres -f /path/to/schema.sql
 ```
 
 Feel free to open issues or pull requests as you iterate.
+
+## Running the ETL flow
+
+1. Ensure Python 3.12 is available via `pyenv` and install dependencies:
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+2. Trigger the sample EDGAR flow:
+   ```bash
+   python etl/edgar_flow.py
+   ```
+   Parsed rows will be stored in `dev.db` and raw filings uploaded to the `filings` bucket in MinIO.

--- a/diff_holdings.py
+++ b/diff_holdings.py
@@ -1,30 +1,42 @@
-"""Simple diff tool for holdings CSV snapshots."""
+"""Diff the latest two filings for a given CIK."""
 
 from __future__ import annotations
 
 import sys
-import csv
+import sqlite3
 from pathlib import Path
 
 
-def load_rows(path: Path):
-    with path.open() as f:
-        reader = csv.DictReader(f)
-        return {row['cusip']: row for row in reader}
+def _fetch_latest_sets(cik: str, db_path: str):
+    conn = sqlite3.connect(db_path)
+    cur = conn.execute(
+        "SELECT filed, cusip FROM holdings WHERE cik=? ORDER BY filed DESC",
+        (cik,),
+    )
+    rows = cur.fetchall()
+    conn.close()
+    if not rows:
+        raise SystemExit("CIK not found")
+    grouped = {}
+    for filed, cusip in rows:
+        grouped.setdefault(filed, set()).add(cusip)
+    dates = sorted(grouped.keys(), reverse=True)[:2]
+    if len(dates) < 2:
+        raise SystemExit("Need at least two filings")
+    return grouped[dates[0]], grouped[dates[1]]
 
 
-def diff_holdings(current_csv: Path, prior_csv: Path):
-    current = load_rows(current_csv)
-    prior = load_rows(prior_csv)
-    additions = current.keys() - prior.keys()
-    exits = prior.keys() - current.keys()
+def diff_holdings(cik: str, db_path: str = "dev.db"):
+    current, prior = _fetch_latest_sets(cik, db_path)
+    additions = current - prior
+    exits = prior - current
     return additions, exits
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print("Usage: diff_holdings.py current.csv prior.csv")
+    if len(sys.argv) != 2:
+        print("Usage: diff_holdings.py <CIK>")
         sys.exit(1)
-    adds, exits = diff_holdings(Path(sys.argv[1]), Path(sys.argv[2]))
-    print("Additions:", ", ".join(adds))
-    print("Exits:", ", ".join(exits))
+    adds, exits = diff_holdings(sys.argv[1])
+    print("Additions:", ", ".join(sorted(adds)))
+    print("Exits:", ", ".join(sorted(exits)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ httpx
 prefect
 beautifulsoup4
 pytest-asyncio
+boto3
+black
+ruff
+pre-commit

--- a/tests/test_diff_holdings.py
+++ b/tests/test_diff_holdings.py
@@ -1,0 +1,32 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from diff_holdings import diff_holdings
+
+
+def setup_db(tmp_path: Path):
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE holdings (cik TEXT, accession TEXT, filed DATE, nameOfIssuer TEXT, cusip TEXT, value INTEGER, sshPrnamt INTEGER)"
+    )
+    data = [
+        ("0000000000", "a", "2024-01-01", "CorpA", "AAA", 1, 1),
+        ("0000000000", "a", "2024-01-01", "CorpB", "BBB", 1, 1),
+        ("0000000000", "b", "2024-04-01", "CorpA", "AAA", 1, 1),
+        ("0000000000", "b", "2024-04-01", "CorpC", "CCC", 1, 1),
+    ]
+    conn.executemany("INSERT INTO holdings VALUES (?,?,?,?,?,?,?)", data)
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+def test_diff(tmp_path):
+    db_path = setup_db(tmp_path)
+    adds, exits = diff_holdings("0000000000", db_path)
+    assert adds == {"CCC"}
+    assert exits == {"BBB"}

--- a/tests/test_edgar.py
+++ b/tests/test_edgar.py
@@ -1,22 +1,26 @@
-import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-import asyncio
+import sys
 from pathlib import Path
+
 import httpx
 import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import adapters.edgar as edgar
 
 
 @pytest.mark.asyncio
 async def test_parse_sample_xml():
-    raw = Path('tests/data/sample_13f.xml').read_text()
+    raw = Path("tests/data/sample_13f.xml").read_text()
     rows = await edgar.parse(raw)
-    assert rows == [{
-        'nameOfIssuer': 'Example Corp',
-        'cusip': '123456789',
-        'value': 1000,
-        'sshPrnamt': 100,
-    }]
+    assert rows == [
+        {
+            "nameOfIssuer": "Example Corp",
+            "cusip": "123456789",
+            "value": 1000,
+            "sshPrnamt": 100,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -24,12 +28,13 @@ async def test_download_handles_429(monkeypatch):
     class DummyClient:
         async def __aenter__(self):
             return self
+
         async def __aexit__(self, exc_type, exc, tb):
             return False
+
         async def get(self, *a, **k):
-            return httpx.Response(429, request=httpx.Request('GET', 'x'))
+            return httpx.Response(429, request=httpx.Request("GET", "x"))
 
-    monkeypatch.setattr(edgar.httpx, 'AsyncClient', DummyClient)
+    monkeypatch.setattr(edgar.httpx, "AsyncClient", DummyClient)
     with pytest.raises(httpx.HTTPStatusError):
-        await edgar.list_new_filings('0000000000', '2024-01-01')
-
+        await edgar.list_new_filings("0000000000", "2024-01-01")


### PR DESCRIPTION
## Summary
- store EDGAR filing metadata with filed dates
- upload raw filings to MinIO and persist parsed rows in SQLite
- expand README_bootstrap with ETL instructions
- add diff_holdings CLI to compare latest filings
- add Ruff/Black pre‑commit configuration
- test diff_holdings logic

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68681a9fd5788331adf24cb78c0f1f8d