### PR TITLE
Add Postgres DB support

### DIFF
--- a/diff_holdings.py
+++ b/diff_holdings.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import sys
-import sqlite3
-from pathlib import Path
+from adapters.base import connect_db
 
 
 def _fetch_latest_sets(cik: str, db_path: str):
-    conn = sqlite3.connect(db_path)
+    conn = connect_db(db_path)
     cur = conn.execute(
         "SELECT filed, cusip FROM holdings WHERE cik=? ORDER BY filed DESC",
         (cik,),

--- a/etl/edgar_flow.py
+++ b/etl/edgar_flow.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import os
 import json
-import sqlite3
 from pathlib import Path
 
 import boto3
 from prefect import flow, task
 
 from adapters import edgar
+from adapters.base import connect_db
 
 RAW_DIR = Path(os.getenv("RAW_DIR", "./data/raw"))
 RAW_DIR.mkdir(parents=True, exist_ok=True)
@@ -29,7 +29,7 @@ DB_PATH = os.getenv("DB_PATH", "dev.db")
 @task
 async def fetch_and_store(cik: str, since: str):
     filings = await edgar.list_new_filings(cik, since)
-    conn = sqlite3.connect(DB_PATH)
+    conn = connect_db(DB_PATH)
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS holdings (

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ boto3
 black
 ruff
 pre-commit
+psycopg[binary]


### PR DESCRIPTION
## Summary
- add `connect_db` helper that returns a Postgres or SQLite connection
- use `connect_db` in `tracked_call`, `edgar_flow`, and `diff_holdings`
- include `psycopg` in requirements

## Testing
- `pre-commit run --files adapters/base.py etl/edgar_flow.py diff_holdings.py requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682030dae883318acbb4e70de56ca7