### PR TITLE
Add UK & Canada adapters with registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 pgdata/
 miniodata/
+dev.db

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -1,5 +1,5 @@
 """Adapter package exports."""
 
-from .base import tracked_call
+from .base import tracked_call, get_adapter, connect_db
 
-__all__ = ["tracked_call"]
+__all__ = ["tracked_call", "get_adapter", "connect_db"]

--- a/adapters/canada.py
+++ b/adapters/canada.py
@@ -1,0 +1,37 @@
+"""SEDAR+ Canada adapter."""
+
+from __future__ import annotations
+
+import httpx
+
+from .base import tracked_call
+
+BASE_URL = "https://www.sedarplus.com/api"
+
+
+async def list_new_filings(cik: str, since: str):
+    """List Canadian filings for an issuer."""
+    url = f"{BASE_URL}/filings"
+    params = {"cik": cik, "since": since}
+    async with httpx.AsyncClient() as client:
+        async with tracked_call("ca", url) as log:
+            r = await client.get(url, params=params)
+            log(r)
+        r.raise_for_status()
+        return r.json().get("items", [])
+
+
+async def download(filing: dict[str, str]):
+    """Download a filing PDF."""
+    url = f"{BASE_URL}/filings/{filing['id']}/document"
+    async with httpx.AsyncClient() as client:
+        async with tracked_call("ca", url) as log:
+            r = await client.get(url)
+            log(r)
+        r.raise_for_status()
+        return r.content
+
+
+async def parse(raw: bytes):
+    """Return placeholder parsed output for Canadian filings."""
+    return [{"raw_bytes": len(raw)}]

--- a/adapters/uk.py
+++ b/adapters/uk.py
@@ -1,0 +1,47 @@
+"""Companies House UK adapter."""
+
+from __future__ import annotations
+
+import httpx
+
+from .base import tracked_call
+
+BASE_URL = "https://api.company-information.service.gov.uk"
+
+
+async def list_new_filings(company_number: str, since: str):
+    """List filing history items since a date (YYYY-MM-DD)."""
+    url = f"{BASE_URL}/company/{company_number}/filing-history"
+    params = {"category": "annual-return", "since": since}
+    async with httpx.AsyncClient() as client:
+        async with tracked_call("uk", url) as log:
+            r = await client.get(url, params=params)
+            log(r)
+        r.raise_for_status()
+        data = r.json()
+    items = data.get("items", [])
+    return [
+        {
+            "transaction_id": i.get("transaction_id"),
+            "company_number": company_number,
+            "date": i.get("date")[:10],
+        }
+        for i in items
+        if i.get("date") and i.get("date")[:10] > since
+    ]
+
+
+async def download(filing: dict[str, str]):
+    """Download the filing document."""
+    url = f"{BASE_URL}/filing-history/{filing['transaction_id']}/document" "?format=pdf"
+    async with httpx.AsyncClient() as client:
+        async with tracked_call("uk", url) as log:
+            r = await client.get(url)
+            log(r)
+        r.raise_for_status()
+        return r.content
+
+
+async def parse(raw: bytes):
+    """Return placeholder parsed result for UK filings."""
+    return [{"raw_bytes": len(raw)}]

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -1,0 +1,13 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from adapters.base import get_adapter
+
+
+def test_get_adapter_returns_module():
+    adapter = get_adapter("edgar")
+    assert isinstance(adapter, types.ModuleType)
+    assert hasattr(adapter, "list_new_filings")


### PR DESCRIPTION
## Summary
- implement registry for adapters in `adapters.base`
- add Companies House and SEDAR+ adapter stubs
- allow `etl/edgar_flow` to pick adapter based on `JURISDICTION`
- export helper functions via package `__init__`
- test adapter registry
- ignore local `dev.db`

## Testing
- `pre-commit run --files adapters/uk.py adapters/canada.py adapters/base.py adapters/__init__.py etl/edgar_flow.py tests/test_adapter_registry.py .gitignore`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868229a430c8331bae4b1c813c00ea7