### PR TITLE
Add Streamlit daily report GUI and diff flow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,15 @@ services:
       - db
       - minio
 
+  ui:
+    build: ./ui
+    volumes:
+      - ./ui:/app
+    ports:
+      - "8501:8501"
+    depends_on:
+      - db
+
 volumes:
   pgdata:
   miniodata:

--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+
+from prefect import flow, task
+
+from adapters.base import connect_db
+from diff_holdings import diff_holdings
+
+
+@task
+def compute(cik: str, date: str, db_path: str) -> None:
+    additions, exits = diff_holdings(cik, db_path)
+    conn = connect_db(db_path)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS daily_diff (
+            date TEXT,
+            cik TEXT,
+            cusip TEXT,
+            change TEXT
+        )"""
+    )
+    for cusip in additions:
+        conn.execute(
+            "INSERT INTO daily_diff VALUES (?,?,?,?)",
+            (date, cik, cusip, "ADD"),
+        )
+    for cusip in exits:
+        conn.execute(
+            "INSERT INTO daily_diff VALUES (?,?,?,?)",
+            (date, cik, cusip, "EXIT"),
+        )
+    conn.commit()
+    conn.close()
+
+
+@flow
+def daily_diff_flow(cik_list: list[str] | None = None, date: str | None = None):
+    if cik_list is None:
+        env = os.getenv("CIK_LIST", "0001791786,0001434997")
+        cik_list = [c.strip() for c in env.split(",")]
+    db_path = os.getenv("DB_PATH", "dev.db")
+    date = date or str(dt.date.today() - dt.timedelta(days=1))
+    for cik in cik_list:
+        compute(cik, date, db_path)
+
+
+if __name__ == "__main__":
+    daily_diff_flow()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ black
 ruff
 pre-commit
 psycopg[binary]
+streamlit
+pandas

--- a/tests/test_daily_diff.py
+++ b/tests/test_daily_diff.py
@@ -1,0 +1,39 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from etl.daily_diff_flow import daily_diff_flow
+
+
+def setup_db(tmp_path: Path) -> str:
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE holdings (cik TEXT, accession TEXT, filed DATE, nameOfIssuer TEXT, cusip TEXT, value INTEGER, sshPrnamt INTEGER)"
+    )
+    data = [
+        ("0000000000", "a", "2024-01-01", "CorpA", "AAA", 1, 1),
+        ("0000000000", "a", "2024-01-01", "CorpB", "BBB", 1, 1),
+        ("0000000000", "b", "2024-04-01", "CorpA", "AAA", 1, 1),
+        ("0000000000", "b", "2024-04-01", "CorpC", "CCC", 1, 1),
+    ]
+    conn.executemany("INSERT INTO holdings VALUES (?,?,?,?,?,?,?)", data)
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+def test_daily_diff_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    db_path = setup_db(tmp_path)
+    monkeypatch.setenv("DB_PATH", db_path)
+    daily_diff_flow(["0000000000"], date="2024-05-01")
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT cik, cusip, change FROM daily_diff ORDER BY cusip"
+    ).fetchall()
+    conn.close()
+    assert rows == [
+        ("0000000000", "BBB", "EXIT"),
+        ("0000000000", "CCC", "ADD"),
+    ]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY ../requirements.txt /tmp/req.txt
+RUN pip install --no-cache-dir -r /tmp/req.txt
+CMD ["streamlit", "run", "daily_report.py", "--server.port=8501", "--server.headless=true"]

--- a/ui/daily_report.py
+++ b/ui/daily_report.py
@@ -1,0 +1,45 @@
+import datetime as dt
+
+import pandas as pd
+import streamlit as st
+
+from adapters.base import connect_db
+
+
+def load_diffs(date: str) -> pd.DataFrame:
+    conn = connect_db()
+    query = "SELECT cik, cusip, change FROM daily_diff WHERE date = ?"
+    df = pd.read_sql_query(query, conn, params=(date,))
+    conn.close()
+    return df
+
+
+def load_news(date: str) -> pd.DataFrame:
+    conn = connect_db()
+    query = "SELECT headline, source FROM news WHERE substr(published, 1, 10) = ? ORDER BY published DESC LIMIT 20"
+    try:
+        df = pd.read_sql_query(query, conn, params=(date,))
+    except Exception:
+        df = pd.DataFrame(columns=["headline", "source"])
+    conn.close()
+    return df
+
+
+def main():
+    date = st.date_input("Date", dt.date.today() - dt.timedelta(days=1))
+    date_str = str(date)
+    tab1, tab2 = st.tabs(["Filings & Diffs", "News Pulse"])
+    with tab1:
+        df = load_diffs(date_str)
+        st.dataframe(df)
+        csv = df.to_csv(index=False).encode("utf-8")
+        st.download_button(
+            "Download CSV", csv, file_name=f"diff_{date_str}.csv", mime="text/csv"
+        )
+    with tab2:
+        news = load_news(date_str)
+        st.dataframe(news)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Prefect `daily_diff_flow` to compute daily holdings changes
- create Streamlit `daily_report.py` GUI with CSV export
- include UI container and port 8501 in docker compose
- add Streamlit and pandas requirements
- test diff flow writes expected rows

## Testing
- `ruff check tests/test_daily_diff.py etl/daily_diff_flow.py ui/daily_report.py`
- `PREFECT_LOGGING_LEVEL=CRITICAL pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686828e51da48331898f174012db2ffb