### PR TITLE
Add cron deployment for daily diff flow

### DIFF
--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -4,6 +4,7 @@ import datetime as dt
 import os
 
 from prefect import flow, task
+from prefect.schedules import Cron
 
 from adapters.base import connect_db
 from diff_holdings import diff_holdings
@@ -48,3 +49,10 @@ def daily_diff_flow(cik_list: list[str] | None = None, date: str | None = None):
 
 if __name__ == "__main__":
     daily_diff_flow()
+
+# Prefect deployment with daily schedule at 08:00 local time
+LOCAL_TZ = os.getenv("TZ") or dt.datetime.now().astimezone().tzinfo.tzname(None)
+daily_diff_deployment = daily_diff_flow.to_deployment(
+    "daily-diff",
+    schedule=Cron("0 8 * * *", timezone=LOCAL_TZ),
+)


### PR DESCRIPTION
## Summary
- schedule `daily_diff_flow` via Prefect cron to run each morning

## Testing
- `pre-commit run --files etl/daily_diff_flow.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688687e31883319beb45af6312e261