### PR TITLE
Add Streamlit dashboard skeleton

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pre-commit
 psycopg[binary]
 streamlit
 pandas
+streamlit-authenticator

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,36 @@
+"""Shared UI utilities."""
+
+from __future__ import annotations
+
+import streamlit as st
+import streamlit_authenticator as stauth
+
+
+def require_login() -> bool:
+    """Render a simple login form and return authentication status."""
+    if st.session_state.get("auth"):
+        return True
+
+    names = ["analyst"]
+    usernames = ["analyst"]
+    passwords = stauth.Hasher(["pass"]).generate()
+
+    authenticator = stauth.Authenticate(
+        {
+            "usernames": usernames,
+            "names": names,
+            "passwords": passwords,
+        },
+        "mi_cookie",
+        "auth",
+        cookie_expiry_days=1,
+    )
+    name, auth_status, _ = authenticator.login("Login", "main")
+    if auth_status:
+        authenticator.logout("Logout", "sidebar")
+        st.session_state["auth"] = True
+        st.success(f"Welcome {name}!")
+        return True
+    elif auth_status is False:
+        st.error("Invalid credentials")
+    return False

--- a/ui/daily_report.py
+++ b/ui/daily_report.py
@@ -4,6 +4,7 @@ import pandas as pd
 import streamlit as st
 
 from adapters.base import connect_db
+from . import require_login
 
 
 def load_diffs(date: str) -> pd.DataFrame:
@@ -26,6 +27,8 @@ def load_news(date: str) -> pd.DataFrame:
 
 
 def main():
+    if not require_login():
+        st.stop()
     date = st.date_input("Date", dt.date.today() - dt.timedelta(days=1))
     date_str = str(date)
     tab1, tab2 = st.tabs(["Filings & Diffs", "News Pulse"])

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -1,0 +1,37 @@
+"""Holdings delta dashboard with sparkline."""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+import altair as alt
+
+from adapters.base import connect_db
+from . import require_login
+
+
+def load_delta() -> pd.DataFrame:
+    conn = connect_db()
+    df = pd.read_sql_query(
+        "SELECT filed as date, COUNT(*) AS filings FROM holdings GROUP BY filed ORDER BY filed",
+        conn,
+    )
+    conn.close()
+    return df
+
+
+def main() -> None:
+    if not require_login():
+        st.stop()
+    st.header("Holdings Delta")
+    df = load_delta()
+    if df.empty:
+        st.info("No data available")
+        return
+    chart = alt.Chart(df).mark_line().encode(x="date:T", y="filings:Q")
+    st.altair_chart(chart, use_container_width=True)
+    st.dataframe(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/search.py
+++ b/ui/search.py
@@ -1,0 +1,34 @@
+"""Simple news search page."""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from adapters.base import connect_db
+from . import require_login
+
+
+def search_news(term: str) -> pd.DataFrame:
+    conn = connect_db()
+    df = pd.read_sql_query(
+        "SELECT headline, source FROM news WHERE headline LIKE ? ORDER BY published DESC LIMIT 20",
+        conn,
+        params=(f"%{term}%",),
+    )
+    conn.close()
+    return df
+
+
+def main() -> None:
+    if not require_login():
+        st.stop()
+    st.header("News Search")
+    q = st.text_input("Keyword")
+    if q:
+        df = search_news(q)
+        st.dataframe(df)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create shared `require_login` util with `streamlit-authenticator`
- extend `requirements.txt`
- guard `daily_report.py` with login check
- add new `dashboard.py` and `search.py` pages

## Testing
- `pre-commit run --files ui/__init__.py ui/dashboard.py ui/search.py ui/daily_report.py requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686889adc3248331b1c9da1da1cdb183