### PR TITLE
Add colored arrows to daily report table

### DIFF
--- a/adapters/base.py
+++ b/adapters/base.py
@@ -29,7 +29,7 @@ def connect_db(db_path: str | None = None):
     if url and psycopg and url.startswith("postgres"):
         return psycopg.connect(url)
     path = db_path or os.getenv("DB_PATH", "dev.db")
-    return sqlite3.connect(path)
+    return sqlite3.connect(str(path))
 
 
 @asynccontextmanager

--- a/ui/daily_report.py
+++ b/ui/daily_report.py
@@ -34,8 +34,15 @@ def main():
     tab1, tab2 = st.tabs(["Filings & Diffs", "News Pulse"])
     with tab1:
         df = load_diffs(date_str)
-        st.dataframe(df)
-        csv = df.to_csv(index=False).encode("utf-8")
+        # map change to coloured arrows for on-screen table
+        arrow = {
+            "ADD": "<span style='color:green'>&uarr;</span>",
+            "EXIT": "<span style='color:red'>&darr;</span>",
+        }
+        df["Δ"] = df["change"].map(arrow)
+        html = df[["cik", "cusip", "Δ"]].to_html(escape=False, index=False)
+        st.markdown(html, unsafe_allow_html=True)
+        csv = df[["cik", "cusip", "change"]].to_csv(index=False).encode("utf-8")
         st.download_button(
             "Download CSV", csv, file_name=f"diff_{date_str}.csv", mime="text/csv"
         )


### PR DESCRIPTION
## Summary
- show coloured arrows for daily filing diffs in Streamlit
- fix mypy path warning in `connect_db`

## Testing
- `pre-commit run --files ui/daily_report.py adapters/base.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686896343a8c83319bf2d5458939d26b