### PR TITLE
Fix mypy and add type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,4 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
+        args: ["--explicit-package-bases"]

--- a/adapters/edgar.py
+++ b/adapters/edgar.py
@@ -60,10 +60,10 @@ async def download(filing: Dict[str, str]) -> str:
         return r.text
 
 
-async def parse(raw: str) -> List[Dict[str, str]]:
+async def parse(raw: str) -> List[Dict[str, int | str]]:
     """Parse an XML 13F document into row dicts."""
     root = ET.fromstring(raw)
-    rows = []
+    rows: List[Dict[str, int | str]] = []
     for info in root.findall(".//infoTable"):
         rows.append(
             {

--- a/diff_holdings.py
+++ b/diff_holdings.py
@@ -16,7 +16,7 @@ def _fetch_latest_sets(cik: str, db_path: str):
     conn.close()
     if not rows:
         raise SystemExit("CIK not found")
-    grouped = {}
+    grouped: dict[str, set[str]] = {}
     for filed, cusip in rows:
         grouped.setdefault(filed, set()).add(cusip)
     dates = sorted(grouped.keys(), reverse=True)[:2]

--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -51,7 +51,10 @@ if __name__ == "__main__":
     daily_diff_flow()
 
 # Prefect deployment with daily schedule at 08:00 local time
-LOCAL_TZ = os.getenv("TZ") or dt.datetime.now().astimezone().tzinfo.tzname(None)
+LOCAL_TZ = os.getenv("TZ")
+if not LOCAL_TZ:
+    tzinfo = dt.datetime.now().astimezone().tzinfo
+    LOCAL_TZ = tzinfo.tzname(None) if tzinfo else "UTC"
 daily_diff_deployment = daily_diff_flow.to_deployment(
     "daily-diff",
     schedule=Cron("0 8 * * *", timezone=LOCAL_TZ),

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = true
+explicit_package_bases = true


### PR DESCRIPTION
## Summary
- tweak mypy pre-commit hook and add config
- annotate holdings diff helper and EDGAR parser
- guard timezone logic in diff flow

## Testing
- `pre-commit run --files ui/daily_report.py etl/daily_diff_flow.py adapters/edgar.py diff_holdings.py tests/test_edgar.py tests/test_daily_diff.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a88dc9b48331aaa680080878bad5