### PR TITLE
Enable FTS-backed news search

### DIFF
--- a/tests/test_edgar_additional.py
+++ b/tests/test_edgar_additional.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-import types
 
 import httpx
 import pytest
@@ -38,7 +37,9 @@ async def test_download_success(monkeypatch):
             return False
 
         async def get(self, *args, **kwargs):
-            return httpx.Response(200, text="<xml>ok</xml>", request=httpx.Request("GET", "x"))
+            return httpx.Response(
+                200, text="<xml>ok</xml>", request=httpx.Request("GET", "x")
+            )
 
     monkeypatch.setattr(edgar.httpx, "AsyncClient", DummyClient)
     text = await edgar.download({"accession": "1", "cik": "0"})

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,29 @@
+import sqlite3
+from pathlib import Path
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ui.search import search_news
+
+
+def setup_db(tmp_path: Path) -> str:
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE news (headline TEXT, source TEXT, published TEXT)")
+    data = [
+        ("Alpha Beta", "src", "2024-01-01"),
+        ("Gamma Delta", "src", "2024-01-02"),
+    ]
+    conn.executemany("INSERT INTO news VALUES (?,?,?)", data)
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+def test_search_fts(tmp_path: Path, monkeypatch):
+    db_path = setup_db(tmp_path)
+    monkeypatch.setenv("DB_PATH", db_path)
+    df = search_news("Gamma")
+    assert list(df["headline"]) == ["Gamma Delta"]


### PR DESCRIPTION
## Summary
- switch search page to use SQLite FTS and Postgres full-text search
- add regression test for FTS query
- clean up unused imports in tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c866d1788331a3f2b0f3b49e86e3