### PR TITLE
Add unit test for dashboard loader

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,32 @@
+import sqlite3
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ui.dashboard import load_delta
+
+
+def setup_db(tmp_path: Path) -> str:
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE holdings (cik TEXT, accession TEXT, filed DATE, nameOfIssuer TEXT, cusip TEXT, value INTEGER, sshPrnamt INTEGER)"
+    )
+    rows = [
+        ("0", "a", "2024-01-01", "CorpA", "AAA", 1, 1),
+        ("0", "b", "2024-01-02", "CorpB", "BBB", 1, 1),
+        ("0", "c", "2024-01-02", "CorpC", "CCC", 1, 1),
+    ]
+    conn.executemany("INSERT INTO holdings VALUES (?,?,?,?,?,?,?)", rows)
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+def test_load_delta_counts(tmp_path: Path, monkeypatch):
+    db_path = setup_db(tmp_path)
+    monkeypatch.setenv("DB_PATH", db_path)
+    df = load_delta()
+    assert list(df["date"]) == ["2024-01-01", "2024-01-02"]
+    assert list(df["filings"]) == [1, 2]


### PR DESCRIPTION
## Summary
- test `ui.dashboard.load_delta` to ensure filings counts per date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694ce5f310833189526584514cd495