### PR TITLE
feat: cache daily report queries

### DIFF
--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -2,6 +2,7 @@ import sqlite3
 from pathlib import Path
 
 from ui.daily_report import load_diffs, load_news
+import streamlit as st
 
 
 def setup_db(tmp_path: Path) -> str:
@@ -29,6 +30,7 @@ def setup_db(tmp_path: Path) -> str:
 def test_load_diffs_and_news(tmp_path, monkeypatch):
     db_path = setup_db(tmp_path)
     monkeypatch.setenv("DB_PATH", db_path)
+    st.cache_data.clear()
     diffs = load_diffs("2024-05-01")
     news = load_news("2024-05-01")
     assert len(diffs) == 2

--- a/ui/daily_report.py
+++ b/ui/daily_report.py
@@ -7,6 +7,7 @@ from adapters.base import connect_db
 from . import require_login
 
 
+@st.cache_data(show_spinner=False)
 def load_diffs(date: str) -> pd.DataFrame:
     conn = connect_db()
     query = "SELECT cik, cusip, change FROM daily_diff WHERE date = ?"
@@ -15,6 +16,7 @@ def load_diffs(date: str) -> pd.DataFrame:
     return df
 
 
+@st.cache_data(show_spinner=False)
 def load_news(date: str) -> pd.DataFrame:
     conn = connect_db()
     query = "SELECT headline, source FROM news WHERE substr(published, 1, 10) = ? ORDER BY published DESC LIMIT 20"


### PR DESCRIPTION
## Summary
- speed up daily report by caching DB lookups
- clear cache in daily report unit test

## Testing
- `pre-commit run --files ui/daily_report.py tests/test_daily_report.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68696b6467dc8331bdddfc78658490b7