### PR TITLE
Add notes upload page

### DIFF
--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -41,3 +41,7 @@ Feel free to open issues or pull requests as you iterate.
    ```bash
    streamlit run ui/search.py
    ```
+5. Upload your own notes:
+   ```bash
+   streamlit run ui/upload.py
+   ```

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,27 @@
+import sqlite3
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ui.upload import save_note
+from ui.search import search_notes
+
+
+def setup_db(tmp_path: Path) -> str:
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE notes (id INTEGER PRIMARY KEY AUTOINCREMENT, filename TEXT, content TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+def test_save_and_search(tmp_path: Path, monkeypatch):
+    db_path = setup_db(tmp_path)
+    monkeypatch.setenv("DB_PATH", db_path)
+    save_note("hello world", "note.txt")
+    df = search_notes("hello")
+    assert list(df["filename"]) == ["note.txt"]

--- a/ui/upload.py
+++ b/ui/upload.py
@@ -1,0 +1,31 @@
+import streamlit as st
+from adapters.base import connect_db
+from . import require_login
+
+
+def save_note(content: str, filename: str) -> None:
+    conn = connect_db()
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY AUTOINCREMENT, filename TEXT, content TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO notes (filename, content) VALUES (?, ?)",
+        (filename, content),
+    )
+    conn.commit()
+    conn.close()
+
+
+def main() -> None:
+    if not require_login():
+        st.stop()
+    st.header("Upload Memo")
+    uploaded = st.file_uploader("Upload text/markdown file", type=["txt", "md"])
+    if uploaded and st.button("Save"):
+        content = uploaded.getvalue().decode("utf-8")
+        save_note(content, uploaded.name)
+        st.success("Uploaded")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- enable uploading analyst notes in Streamlit
- extend search page to query uploaded notes
- document upload page
- test save/search utilities

## Testing
- `pre-commit run --files ui/upload.py ui/search.py tests/test_upload.py README_bootstrap.md`
- `pytest -q`
- `coverage run -m pytest -q && coverage report --fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_6869771a498c8331a3b860f539242689