### PR TITLE
Implement Stage 4 AI endpoints

### DIFF
--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -45,3 +45,8 @@ Feel free to open issues or pull requests as you iterate.
    ```bash
    streamlit run ui/upload.py
    ```
+
+6. Start the chat API:
+   ```bash
+   uvicorn api.chat:app --reload
+   ```

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""API package for Stage 4 chat endpoint."""

--- a/api/chat.py
+++ b/api/chat.py
@@ -1,0 +1,20 @@
+"""Minimal FastAPI app providing a /chat endpoint."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Query
+
+from embeddings import search_documents
+
+app = FastAPI()
+
+
+@app.get("/chat")
+def chat(q: str = Query(..., description="User question")):
+    """Return a naive answer built from stored documents."""
+    hits = search_documents(q)
+    if not hits:
+        answer = "No documents found."
+    else:
+        answer = "Context: " + " ".join(h["content"] for h in hits)
+    return {"answer": answer}

--- a/embeddings.py
+++ b/embeddings.py
@@ -1,0 +1,59 @@
+"""Simple text embedding utilities for Stage 4."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import Counter
+from typing import Any, Dict, List
+
+from adapters.base import connect_db
+
+
+def embed_text(text: str) -> List[float]:
+    """Return a simple letter-frequency vector for ``text``."""
+    letters = Counter(c.lower() for c in text if c.isalpha())
+    vec = [letters.get(chr(i + 97), 0) for i in range(26)]
+    norm = sum(vec) or 1
+    return [v / norm for v in vec]
+
+
+def store_document(text: str, db_path: str | None = None) -> None:
+    """Store ``text`` and its embedding in the ``documents`` table."""
+    conn = connect_db(db_path)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            content TEXT,
+            embedding TEXT
+        )"""
+    )
+    emb = json.dumps(embed_text(text))
+    placeholder = (
+        "%s"
+        if conn.__class__.__name__ == "Connection" and hasattr(conn, "info")
+        else "?"
+    )
+    conn.execute(
+        f"INSERT INTO documents(content, embedding) VALUES ({placeholder},{placeholder})",
+        (text, emb),
+    )
+    conn.commit()
+    conn.close()
+
+
+def search_documents(
+    query: str, db_path: str | None = None, k: int = 3
+) -> List[Dict[str, Any]]:
+    """Return top ``k`` docs similar to ``query``."""
+    conn = connect_db(db_path)
+    rows = conn.execute("SELECT content, embedding FROM documents").fetchall()
+    conn.close()
+    qvec = embed_text(query)
+    results = []
+    for content, emb_json in rows:
+        emb = json.loads(emb_json)
+        dist = math.sqrt(sum((a - b) ** 2 for a, b in zip(qvec, emb)))
+        results.append({"content": content, "distance": dist})
+    results.sort(key=lambda r: r["distance"])
+    return results[:k]

--- a/etl/summariser_flow.py
+++ b/etl/summariser_flow.py
@@ -1,0 +1,40 @@
+"""Prefect flow that posts a daily summary to Slack."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Optional
+
+import pandas as pd
+import requests  # type: ignore
+from prefect import flow, task
+
+from adapters.base import connect_db
+
+
+@task
+def summarise(date: str) -> str:
+    conn = connect_db()
+    df = pd.read_sql_query(
+        "SELECT cik, cusip, change FROM daily_diff WHERE date = ?",
+        conn,
+        params=(date,),
+    )
+    conn.close()
+    summary = f"{len(df)} changes on {date}"
+    webhook = os.getenv("SLACK_WEBHOOK_URL")
+    if webhook:
+        requests.post(webhook, json={"text": summary})
+    return summary
+
+
+@flow
+def summariser_flow(date: Optional[str] = None) -> str:
+    if date is None:
+        date = str(dt.date.today() - dt.timedelta(days=1))
+    return summarise(date)
+
+
+if __name__ == "__main__":
+    print(summariser_flow())

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ streamlit-authenticator
 altair
 mypy
 coverage
+fastapi
+uvicorn

--- a/schema.sql
+++ b/schema.sql
@@ -17,3 +17,9 @@ SELECT date_trunc('month', ts) AS month,
        sum(cost_usd) AS cost
 FROM api_usage
 GROUP BY 1,2;
+
+CREATE TABLE IF NOT EXISTS documents (
+    id bigserial PRIMARY KEY,
+    content text,
+    embedding double precision[]
+);

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from api.chat import app
+from embeddings import store_document
+
+
+def test_chat_endpoint(tmp_path, monkeypatch):
+    db_path = tmp_path / "dev.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    store_document("hello world", str(db_path))
+    client = TestClient(app)
+    resp = client.get("/chat", params={"q": "hello"})
+    assert resp.status_code == 200
+    assert "hello world" in resp.json()["answer"]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,18 @@
+import sqlite3
+from pathlib import Path
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from embeddings import store_document, search_documents
+
+
+def test_store_and_search(tmp_path):
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.close()
+    store_document("hello world", str(db_path))
+    store_document("goodbye", str(db_path))
+    results = search_documents("hello", str(db_path))
+    assert results[0]["content"] == "hello world"

--- a/tests/test_summariser.py
+++ b/tests/test_summariser.py
@@ -1,0 +1,33 @@
+import sqlite3
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from etl.summariser_flow import summarise
+
+
+def setup_db(path: Path) -> str:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE daily_diff (date TEXT, cik TEXT, cusip TEXT, change TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO daily_diff VALUES (?,?,?,?)",
+        ("2024-01-02", "1", "AAA", "ADD"),
+    )
+    conn.execute(
+        "INSERT INTO daily_diff VALUES (?,?,?,?)",
+        ("2024-01-02", "1", "BBB", "EXIT"),
+    )
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+def test_summarise(tmp_path, monkeypatch):
+    db_file = tmp_path / "dev.db"
+    setup_db(db_file)
+    monkeypatch.setenv("DB_PATH", str(db_file))
+    result = summarise.fn("2024-01-02")
+    assert result == "2 changes on 2024-01-02"


### PR DESCRIPTION
## Summary
- add simple letter-frequency embedding utilities
- create FastAPI `/chat` endpoint for retrieved answers
- implement Prefect summariser flow to post daily diffs
- document chat API usage
- add new tests

## Testing
- `pre-commit run --files embeddings.py api/chat.py etl/summariser_flow.py tests/test_embeddings.py tests/test_chat_api.py tests/test_summariser.py README_bootstrap.md schema.sql requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697fd83b7c8331bfcefe7fa3f3dda4