### PR TITLE
Log Slack summaries

### DIFF
--- a/etl/summariser_flow.py
+++ b/etl/summariser_flow.py
@@ -10,11 +10,12 @@ import pandas as pd
 import requests  # type: ignore
 from prefect import flow, task
 
-from adapters.base import connect_db
+from adapters.base import connect_db, tracked_call
 
 
 @task
-def summarise(date: str) -> str:
+async def summarise(date: str) -> str:
+    """Return and optionally post the daily change summary."""
     conn = connect_db()
     df = pd.read_sql_query(
         "SELECT cik, cusip, change FROM daily_diff WHERE date = ?",
@@ -25,16 +26,22 @@ def summarise(date: str) -> str:
     summary = f"{len(df)} changes on {date}"
     webhook = os.getenv("SLACK_WEBHOOK_URL")
     if webhook:
-        requests.post(webhook, json={"text": summary})
+        # log Slack webhook usage to api_usage table
+        async with tracked_call("slack", webhook) as log:
+            resp = requests.post(webhook, json={"text": summary})
+            log(resp)
     return summary
 
 
 @flow
-def summariser_flow(date: Optional[str] = None) -> str:
+async def summariser_flow(date: Optional[str] = None) -> str:
+    """Run the summary task for the given date."""
     if date is None:
         date = str(dt.date.today() - dt.timedelta(days=1))
-    return summarise(date)
+    return await summarise(date)
 
 
 if __name__ == "__main__":
-    print(summariser_flow())
+    import asyncio
+
+    print(asyncio.run(summariser_flow()))

--- a/tests/test_summariser.py
+++ b/tests/test_summariser.py
@@ -4,6 +4,8 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import pytest
+
 from etl.summariser_flow import summarise
 
 
@@ -25,9 +27,10 @@ def setup_db(path: Path) -> str:
     return str(path)
 
 
-def test_summarise(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_summarise(tmp_path, monkeypatch):
     db_file = tmp_path / "dev.db"
     setup_db(db_file)
     monkeypatch.setenv("DB_PATH", str(db_file))
-    result = summarise.fn("2024-01-02")
+    result = await summarise.fn("2024-01-02")
     assert result == "2 changes on 2024-01-02"


### PR DESCRIPTION
## Summary
- wrap Slack webhook requests in `tracked_call`
- make summariser flow async
- adjust test for async call

## Testing
- `pre-commit run --files etl/summariser_flow.py tests/test_summariser.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686987c6a07883318be43206b71e45a7