### PR TITLE
Add script to open issues from Agents.md

### DIFF
--- a/scripts/open_issues.py
+++ b/scripts/open_issues.py
@@ -1,0 +1,56 @@
+import argparse
+import re
+import subprocess
+from pathlib import Path
+from typing import List, Tuple
+
+
+TASK_RE = re.compile(r"^\s*(?:\d+\.|\*)\s+(.*)")
+# Match headings like "### 4.2 Stage 1 — Proof" and capture the Stage number.
+STAGE_RE = re.compile(r"^###\s+4\.\d+\s+Stage\s+(\d+)")
+
+
+def parse_tasks(path: str) -> List[Tuple[str, str]]:
+    """Return (stage, task) tuples parsed from Agents.md."""
+    tasks: List[Tuple[str, str]] = []
+    stage = None
+    for line in Path(path).read_text().splitlines():
+        m = STAGE_RE.match(line)
+        if m:
+            stage = f"Stage{m.group(1)}"
+            continue
+        m = TASK_RE.match(line)
+        if stage and m:
+            task = m.group(1).strip()
+            task = re.sub(r"`([^`]+)`", r"\1", task)
+            tasks.append((stage, task))
+    return tasks
+
+
+def create_issue(stage: str, task: str) -> None:
+    """Open a GitHub issue via ``gh`` CLI."""
+    title = f"{stage}: {task}"
+    subprocess.run(
+        [
+            "gh",
+            "issue",
+            "create",
+            "--title",
+            title,
+            "--body",
+            f"Auto-generated from Agents.md for {stage}",
+        ],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create Issues from Agents.md")
+    parser.add_argument("file", help="Path to Agents.md")
+    parser.add_argument("--dry-run", action="store_true", help="Print tasks only")
+    args = parser.parse_args()
+    for stage, task in parse_tasks(args.file):
+        if args.dry_run:
+            print(f"{stage}: {task}")
+        else:
+            create_issue(stage, task)

--- a/tests/test_open_issues.py
+++ b/tests/test_open_issues.py
@@ -1,0 +1,22 @@
+import textwrap
+from scripts.open_issues import parse_tasks
+
+
+def test_parse_tasks(tmp_path):
+    md = textwrap.dedent(
+        """
+        ### 4.1 Stage 0 — Bootstrap
+        1. Create docker-compose
+        2. Create schema
+        ### 4.2 Stage 1 — Proof
+        * Implement adapter
+        """
+    )
+    file = tmp_path / "a.md"
+    file.write_text(md)
+    tasks = parse_tasks(str(file))
+    assert tasks == [
+        ("Stage0", "Create docker-compose"),
+        ("Stage0", "Create schema"),
+        ("Stage1", "Implement adapter"),
+    ]


### PR DESCRIPTION
## Summary
- provide `open_issues.py` utility to parse Agents.md and create GitHub Issues
- test issue parser

## Testing
- `pre-commit run --files scripts/open_issues.py tests/test_open_issues.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c83061888331b2f567ee8f7e2f94