### PR TITLE
fix: restore keepalive/watchdog defaults for scheduled runs

### DIFF
--- a/.github/workflows/agents-orchestrator.yml
+++ b/.github/workflows/agents-orchestrator.yml
@@ -60,12 +60,16 @@ jobs:
     name: Agent Orchestration
     uses: stranske/Workflows/.github/workflows/reusable-16-agents.yml@main
     with:
+      # Readiness/bootstrap default to false (opt-in)
       enable_readiness: ${{ inputs.enable_readiness && 'true' || 'false' }}
       readiness_agents: "copilot,codex"
       enable_preflight: "false"
       enable_verify_issue: "false"
-      enable_watchdog: ${{ inputs.enable_watchdog && 'true' || 'false' }}
-      enable_keepalive: ${{ inputs.enable_keepalive && 'true' || 'false' }}
+      # Watchdog/keepalive default to true for schedule, respect input for dispatch
+      # When triggered by schedule, inputs.* is null, so we default to 'true'
+      # When triggered by workflow_dispatch, we use the actual input value
+      enable_watchdog: ${{ github.event_name == 'schedule' && 'true' || (inputs.enable_watchdog && 'true' || 'false') }}
+      enable_keepalive: ${{ github.event_name == 'schedule' && 'true' || (inputs.enable_keepalive && 'true' || 'false') }}
       enable_bootstrap: ${{ inputs.enable_bootstrap && 'true' || 'false' }}
       bootstrap_issues_label: "agent:codex"
       draft_pr: "false"


### PR DESCRIPTION
## Critical Bug Fix

The previous workflow setup PR introduced a bug where scheduled orchestrator runs would NOT run keepalive or watchdog sweeps.

### Root Cause

The expression `${{ inputs.enable_watchdog && 'true' || 'false' }}` evaluates to `'false'` when there are no inputs (schedule trigger), because:
- `inputs.enable_watchdog` is `null` on schedule
- `null && 'true'` = `null`
- `null || 'false'` = `'false'`

### Fix

Use `github.event_name == 'schedule'` to detect schedule trigger and default to `'true'`:
```yaml
enable_watchdog: ${{ github.event_name == 'schedule' && 'true' || (inputs.enable_watchdog && 'true' || 'false') }}
```

This ensures:
- Scheduled runs: watchdog/keepalive enabled by default
- Manual dispatch: respects input values

### Impact

Without this fix, **all automated keepalive sweeps are disabled**, meaning stalled agent PRs would not receive reminder comments.