### PR TITLE
fix: Use remote reference for reusable-agents-issue-bridge.yml

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -1168,7 +1168,7 @@ jobs:
           github.run_id
         }}
       cancel-in-progress: true
-    uses: ./.github/workflows/reusable-agents-issue-bridge.yml
+    uses: stranske/Workflows/.github/workflows/reusable-agents-issue-bridge.yml@main
     with:
       agent: ${{ needs.normalize_inputs.outputs.bridge_agent || needs.bridge_preflight.outputs.agent_key }}
       issue_number: ${{ needs.normalize_inputs.outputs.issue_number || needs.bridge_preflight.outputs.issue_number || '' }}


### PR DESCRIPTION
Closes #49

## Problem

The `agents-63-issue-intake.yml` workflow was incorrectly referencing a local reusable workflow:
```yaml
uses: ./.github/workflows/reusable-agents-issue-bridge.yml
```

Consumer repos do not have this file locally - it only exists in the Workflows repo.

## Solution

Changed to reference the workflow from the Workflows repo:
```yaml
uses: stranske/Workflows/.github/workflows/reusable-agents-issue-bridge.yml@main
```

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] The application currently has no way to verify database connectivity is working. This makes it difficult to diagnose connection issues and implement proper health monitoring.

#### Tasks
- [ ] Create a `/health/db` endpoint in the API
- [ ] Implement a simple database ping/query to verify connectivity
- [ ] Return appropriate HTTP status codes (200 for healthy, 503 for unhealthy)
- [ ] Add timeout handling for slow database responses

#### Acceptance criteria
- [ ] GET `/health/db` returns 200 when database is connected
- [ ] GET `/health/db` returns 503 when database is unreachable
- [ ] Response includes connection latency in milliseconds
- [ ] Endpoint responds within 5 seconds even if database is slow

**Head SHA:** 19ba498693049d44499d148c6f18bc5c3d267d2e
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Manager-Database/actions/runs/20544673837) |
| Autofix | ❔ in progress | [View run](https://github.com/stranske/Manager-Database/actions/runs/20544673841) |
| Copilot code review | ⏳ queued | [View run](https://github.com/stranske/Manager-Database/actions/runs/20544674133) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Manager-Database/actions/runs/20544673816) |
<!-- auto-status-summary:end -->