### PR TITLE
fix: rename CI job from 'python' to 'python-ci'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  python:
+  python-ci:
     name: Python CI
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:


### PR DESCRIPTION
The CI workflow has been failing with startup_failure. Renaming the job ID to 'python-ci' (matching Gate) to rule out a job naming issue.