### PR TITLE
chore: add .project_modules.txt for repo-specific modules

### DIFF
--- a/.project_modules.txt
+++ b/.project_modules.txt
@@ -1,0 +1,6 @@
+# Repo-specific first-party modules for Manager-Database
+# These standalone .py files in root are used by tests but excluded from
+# auto-detection (which skips root-level .py files).
+# See: https://github.com/stranske/Workflows/pull/441
+diff_holdings
+embeddings


### PR DESCRIPTION
## Summary

Adds `.project_modules.txt` to specify repo-specific first-party modules that should not be flagged as undeclared dependencies.

## Problem

`diff_holdings.py` and `embeddings.py` are standalone Python files in the repo root. The `sync_test_dependencies.py` script excludes root-level .py files from auto-detection, so they get flagged as undeclared dependencies.

This has caused **recurring CI failures** after workflow syncs.

## Solution

Create `.project_modules.txt` with:
```
diff_holdings
embeddings
```

**Requires**: stranske/Workflows#441 (adds support for reading this file)

Once Workflows#441 is merged and synced, this file will prevent future breakage.