### PR TITLE
fix: add models:read permission to keepalive workflow

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -38,6 +38,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  models: read
 
 concurrency:
   group: keepalive-${{ github.event.workflow_run.pull_requests[0].number || github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
## Summary

Adds `models: read` permission to the keepalive workflow.

## Problem

The `workflow_run` triggered keepalive loops fail with `startup_failure` because the workflow file on `main` (which is used for workflow_run events) doesn't have the `models: read` permission required by the reusable-codex-run workflow.

## Solution

Add `models: read` to the permissions block.

## Testing

After merging, the keepalive loop should work for PR #136.

<!-- pr-preamble:start -->
> **Source:** Issue #136

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] Create a simple README.md file in a docs/ folder explaining what LLM providers are supported
- [ ] Add a CHANGELOG.md entry for this feature
- [ ] This PR tests the LLM analysis feature from the Workflows repo.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** a5b2af1d69d92e76ee4ab99257ad1af5f8ed3bbd
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Manager-Database/actions/runs/20669052694) |
| Autofix | ❔ in progress | [View run](https://github.com/stranske/Manager-Database/actions/runs/20669052691) |
| CI | ⏳ queued | [View run](https://github.com/stranske/Manager-Database/actions/runs/20669052712) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Manager-Database/actions/runs/20669052996) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Manager-Database/actions/runs/20669052692) |
| Health 45 Agents Guard | ❔ in progress | [View run](https://github.com/stranske/Manager-Database/actions/runs/20669052671) |
<!-- auto-status-summary:end -->