### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=25.12.0
-RUFF_VERSION=0.14.11
+RUFF_VERSION=0.14.12
 ISORT_VERSION=7.0.0
 DOCFORMATTER_VERSION=1.7.7
 MYPY_VERSION=1.19.1
@@ -13,4 +13,3 @@ PYTEST_VERSION=9.0.2
 PYTEST_COV_VERSION=7.0.0
 PYTEST_XDIST_VERSION=3.8.0
 COVERAGE_VERSION=7.13.1
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov>=7.0.0",
     "black>=25.12.0",
-    "ruff>=0.14.11",
+    "ruff>=0.14.12",
     "pre-commit",
     "mypy>=1.19.1",
     "coverage>=7.13.1",

--- a/requirements.lock
+++ b/requirements.lock
@@ -383,7 +383,7 @@ ruamel-yaml==0.19.1
     # via prefect
 ruamel-yaml-clib==0.2.15 ; platform_python_implementation == 'CPython'
     # via prefect
-ruff==0.14.11
+ruff==0.14.12
     # via manager-database (pyproject.toml)
 s3transfer==0.16.0
     # via boto3


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 2 version updates:
  - ruff: >=0.14.11 -> >=0.14.12
  - requirements.lock:ruff: 0.14.11 -> ==0.14.12

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** [`.github/workflows/autofix-versions.env`](https://github.com/stranske/Workflows/blob/main/.github/workflows/autofix-versions.env)