### PR TITLE
fix: use Workflows main for verifier

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -186,7 +186,7 @@ jobs:
   verifier:
     needs: check
     if: needs.check.outputs.should_run == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-agents-verifier.yml@v1
+    uses: stranske/Workflows/.github/workflows/reusable-agents-verifier.yml@main
     with:
       # CI workflows to wait for before running verifier
       ci_workflows: '["ci.yml", "pr-00-gate.yml"]'


### PR DESCRIPTION
Use Workflows main for reusable verifier workflow to unblock verify:compare until v1 tag is updated.