### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -2967,6 +2967,9 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
     // tasks off.  Re-derive the counter here with the authoritative counts.
     // When force_retry is active, honour the evaluate-step's reset to 0 and
     // do not overwrite it — the human explicitly wants a fresh start.
+    // After a review action, reset to 0 so the next evaluate triggers a run
+    // instead of another review (the review already provided course-correction
+    // feedback — the agent needs a chance to act on it).
     if (isForceRetry) {
       if (roundsWithoutTaskCompletion !== 0) {
         core?.info?.(
@@ -2975,6 +2978,12 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
         );
         roundsWithoutTaskCompletion = 0;
       }
+    } else if (action === 'review') {
+      core?.info?.(
+        `[summary] review action completed — resetting rounds_without_task_completion ` +
+        `from ${roundsWithoutTaskCompletion} to 0 so next iteration runs the agent`,
+      );
+      roundsWithoutTaskCompletion = 0;
     } else {
       const prevTasks = previousState?.tasks || {};
       const prevUncheckedForCounter = toNumber(prevTasks.unchecked, tasksUnchecked);

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -1886,23 +1886,96 @@ jobs:
               return;
             }
 
-            // Force-dispatch Codex belt dispatcher to create the branch
-            try {
-              await withRetry((client) => client.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'agents-71-codex-belt-dispatcher.yml',
-                ref: baseBranch,
-                inputs: {
-                  agent_key: agentKey,
-                  force_issue: issueNumber.toString(),
-                  dry_run: 'false'
+            // Force-dispatch Codex belt dispatcher to create the branch.
+            // Retry up to 3 times because GitHub Actions can silently cancel
+            // queued runs before they receive a runner (observed on issue #34).
+            const maxDispatchAttempts = 3;
+            let dispatchSucceeded = false;
+            for (let attempt = 1; attempt <= maxDispatchAttempts; attempt++) {
+              // Truncate to second precision — GitHub created_at has no
+              // milliseconds, so sub-second remainder would filter out the
+              // run we just dispatched.
+              const dispatchedAt = new Date(Math.floor(Date.now() / 1000) * 1000);
+              try {
+                await withRetry((client) => client.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'agents-71-codex-belt-dispatcher.yml',
+                  ref: baseBranch,
+                  inputs: {
+                    agent_key: agentKey,
+                    force_issue: issueNumber.toString(),
+                    dry_run: 'false'
+                  }
+                }));
+                core.info(
+                  `Dispatched belt dispatcher (agent: ${agentKey}) ` +
+                  `for issue #${issueNumber} (attempt ${attempt}/${maxDispatchAttempts})`
+                );
+              } catch (dispatchError) {
+                core.warning(
+                  `Belt dispatch attempt ${attempt} failed: ${dispatchError?.message}`
+                );
+                if (attempt < maxDispatchAttempts) {
+                  await new Promise(r => setTimeout(r, attempt * 5000));
                 }
-              }));
-              const prefix = `Dispatched belt dispatcher (agent: ${agentKey}) for issue`;
-              core.info(`${prefix} #${issueNumber}`);
-            } catch (dispatchError) {
-              core.warning(`Could not dispatch belt dispatcher: ${dispatchError?.message}`);
+                continue;
+              }
+
+              // Wait briefly then verify the dispatched run is queued/in_progress
+              // (not cancelled before receiving a runner).  Only consider runs
+              // created after the dispatch timestamp to avoid matching stale runs.
+              // Note: listWorkflowRuns doesn't expose dispatch inputs, so we
+              // can't filter by force_issue here.  The tight timestamp window
+              // makes cross-issue false matches unlikely in practice.
+              await new Promise(r => setTimeout(r, 15000));
+              try {
+                const { data: runs } = await withRetry((client) =>
+                  client.rest.actions.listWorkflowRuns({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: 'agents-71-codex-belt-dispatcher.yml',
+                    per_page: 5,
+                  })
+                );
+                const recentRuns = runs.workflow_runs.filter(
+                  r => new Date(r.created_at) >= dispatchedAt &&
+                    r.event === 'workflow_dispatch'
+                );
+                const alive = recentRuns.find(
+                  r => r.status === 'queued' || r.status === 'in_progress'
+                );
+                if (alive) {
+                  core.info(`Belt dispatcher run ${alive.id} is ${alive.status}`);
+                  dispatchSucceeded = true;
+                  break;
+                }
+                const succeeded = recentRuns.find(
+                  r => r.conclusion === 'success'
+                );
+                if (succeeded) {
+                  core.info(`Belt dispatcher run ${succeeded.id} already succeeded`);
+                  dispatchSucceeded = true;
+                  break;
+                }
+                const latest = recentRuns[0] || runs.workflow_runs[0];
+                core.warning(
+                  `Belt dispatcher run not alive after attempt ${attempt}` +
+                  ` (latest: ${latest?.id} ${latest?.conclusion}); ` +
+                  (attempt < maxDispatchAttempts ? 'retrying…' : 'no more attempts.')
+                );
+              } catch (checkError) {
+                core.warning(
+                  `Could not verify dispatcher run after attempt ${attempt}: ` +
+                  `${checkError?.message}; status unknown, will retry.`
+                );
+              }
+            }
+            if (!dispatchSucceeded) {
+              core.warning(
+                `Belt dispatcher could not be confirmed after ${maxDispatchAttempts} attempts ` +
+                `for issue #${issueNumber}. The branch-check loop will re-dispatch if needed.`
+              );
             }
 
       - name: Metrics - End capability check timer
@@ -2304,6 +2377,69 @@ jobs:
                 const actualBackoffMs = Math.min(backoffMs, maxBackoffMs);
                 const actualMinutes = Math.round(actualBackoffMs / 60000);
 
+                // Re-dispatch the belt if no recent dispatcher run is active.
+                // Only consider runs in the last 30 minutes.  Note: the API
+                // doesn't expose dispatch inputs, so we can't scope this to
+                // the current issue; an unrelated active run may suppress
+                // re-dispatch.  This is acceptable — a false skip only delays
+                // re-dispatch by one backoff iteration.
+                let redispatched = false;
+                try {
+                  const { data: runs } = await withRetry((client) =>
+                    client.rest.actions.listWorkflowRuns({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      workflow_id: 'agents-71-codex-belt-dispatcher.yml',
+                      per_page: 10,
+                    })
+                  );
+                  const cutoff = new Date(Date.now() - 30 * 60 * 1000);
+                  const recentRuns = runs.workflow_runs.filter(
+                    r => new Date(r.created_at) >= cutoff &&
+                      r.event === 'workflow_dispatch'
+                  );
+                  const alive = recentRuns.find(
+                    r => r.status === 'queued' || r.status === 'in_progress'
+                  );
+                  if (!alive) {
+                    core.info(
+                      `No active belt dispatcher run in last 30m ` +
+                      `(${recentRuns.length} recent runs checked); re-dispatching`
+                    );
+                    const { data: repoInfo } = await withRetry((client) =>
+                      client.rest.repos.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                      })
+                    );
+                    const dispatchRef = repoInfo.default_branch || 'main';
+                    await withRetry((client) =>
+                      client.rest.actions.createWorkflowDispatch({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        workflow_id: 'agents-71-codex-belt-dispatcher.yml',
+                        ref: dispatchRef,
+                        inputs: {
+                          agent_key: agentKey,
+                          force_issue: String(issueNumber),
+                          dry_run: 'false',
+                        },
+                      })
+                    );
+                    redispatched = true;
+                    core.info(`Re-dispatched belt for issue #${issueNumber}`);
+                  } else {
+                    core.info(
+                      `Belt dispatcher run ${alive.id} still ${alive.status}; skipping re-dispatch`
+                    );
+                  }
+                } catch (redispatchErr) {
+                  core.warning(`Belt re-dispatch check failed: ${redispatchErr?.message}`);
+                }
+
+                const redispatchNote = redispatched
+                  ? ' Re-dispatched belt dispatcher.'
+                  : '';
                 core.info(`Applying branch-creation backoff: waiting ${actualMinutes} minutes`);
                 await withRetry((client) => client.rest.issues.createComment({
                   owner: context.repo.owner,
@@ -2311,7 +2447,7 @@ jobs:
                   issue_number: issueNumber,
                     body: `🤖 **Auto-pilot**: Backoff delay (${actualMinutes}m)
 
-                    Branch not created yet. Attempt ${stallCount + 1}/${maxStallRetries}.
+                    Branch not created yet. Attempt ${stallCount + 1}/${maxStallRetries}.${redispatchNote}
                     Waiting before retry...`
                 }));
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-auto-pilot.yml: Auto-pilot - end-to-end automation orchestrator (format → optimize → agent → verify)
- keepalive_loop.js: Core keepalive loop logic

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`