### PR TITLE
Codex bootstrap for #708

### DIFF
--- a/agents/codex-708.md
+++ b/agents/codex-708.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #708 -->

--- a/schema.sql
+++ b/schema.sql
@@ -23,3 +23,22 @@ CREATE TABLE IF NOT EXISTS documents (
     content text,
     embedding double precision[]
 );
+
+CREATE TABLE IF NOT EXISTS alert_rules (
+    rule_id         bigserial PRIMARY KEY,
+    name            text NOT NULL,
+    description     text,
+    event_type      text NOT NULL CHECK (event_type IN (
+        'new_filing', 'large_delta', 'news_spike', 'crowded_trade_change',
+        'contrarian_signal', 'missing_filing', 'etl_failure', 'activism_event'
+    )),
+    condition_json  jsonb NOT NULL DEFAULT '{}',
+    channels        text[] NOT NULL DEFAULT ARRAY['streamlit'],
+    enabled         boolean NOT NULL DEFAULT true,
+    manager_id      bigint REFERENCES managers(manager_id),
+    created_by      text,
+    created_at      timestamptz DEFAULT now(),
+    updated_at      timestamptz DEFAULT now()
+);
+
+CREATE INDEX idx_alert_rules_event ON alert_rules(event_type) WHERE enabled = true;


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Build the database schema for configurable alert rules and alert history, plus the core evaluation engine that matches database events against user-defined rules. This is the foundation for the entire alerting pipeline.

**Depends on**: S1-01 (#672 — canonical schema), S3-01 (#680 — ETL Postgres migration)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#672](https://github.com/stranske/Manager-Database/issues/672)
- [#680](https://github.com/stranske/Manager-Database/issues/680)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add `alert_rules` table to `schema.sql`:
  ```sql
  CREATE TABLE IF NOT EXISTS alert_rules (
      rule_id         bigserial PRIMARY KEY,
      name            text NOT NULL,
      description     text,
      event_type      text NOT NULL CHECK (event_type IN (
          'new_filing', 'large_delta', 'news_spike', 'crowded_trade_change',
          'contrarian_signal', 'missing_filing', 'etl_failure', 'activism_event'
      )),
      condition_json  jsonb NOT NULL DEFAULT '{}',
      -- condition_json examples:
      --   {"delta_type": "EXIT", "value_usd_gt": 1000000}
      --   {"manager_id": 42, "any_new_filing": true}
      --   {"news_count_gt": 5, "time_window_hours": 4}
      --   {"manager_count_gte": 8}
      channels        text[] NOT NULL DEFAULT ARRAY['streamlit'],
      -- valid channels: 'email', 'slack', 'streamlit'
      enabled         boolean NOT NULL DEFAULT true,
      manager_id      bigint REFERENCES managers(manager_id),  -- NULL = all managers
      created_by      text,
      created_at      timestamptz DEFAULT now(),
      updated_at      timestamptz DEFAULT now()
  );
  CREATE INDEX idx_alert_rules_event ON alert_rules(event_type) WHERE enabled = true;
  ```
- [x] Add `alert_history` table to `schema.sql`:
  ```sql
  CREATE TABLE IF NOT EXISTS alert_history (
      alert_id            bigserial PRIMARY KEY,
      rule_id             bigint NOT NULL REFERENCES alert_rules(rule_id),
      fired_at            timestamptz DEFAULT now(),
      event_type          text NOT NULL,
      payload_json        jsonb NOT NULL,
      -- payload contains event-specific data:
      --   {"filing_id": 123, "manager_name": "Elliott", "type": "13F-HR"}
      --   {"cusip": "037833100", "delta_type": "EXIT", "value_usd": 5000000}
      delivered_channels  text[] DEFAULT ARRAY[]::text[],
      delivery_errors     jsonb,  -- {"slack": "webhook_timeout", ...}
      acknowledged        boolean NOT NULL DEFAULT false,
      acknowledged_by     text,
      acknowledged_at     timestamptz
  );
  CREATE INDEX idx_alert_history_unack ON alert_history(fired_at DESC)
      WHERE acknowledged = false;
  CREATE INDEX idx_alert_history_rule ON alert_history(rule_id);
  ```
- [ ] Add Alembic migrations for both tables
- [ ] Create `alerts/__init__.py` and `alerts/models.py`:
  - [ ] Pydantic models: `AlertRule`, `AlertRuleCreate`, `AlertRuleUpdate`
  - [ ] Pydantic models: `AlertEvent`, `FiredAlert`
  - [ ] `AlertEvent(event_type, manager_id?, payload)` — input to the engine
  - [ ] `FiredAlert(rule, event, channels)` — output from evaluation
- [ ] Create `alerts/engine.py` — Rule evaluation engine:
  ```python
  class AlertEngine:
      def __init__(self, db_conn):
          """Load enabled rules from database."""

      def evaluate(self, event: AlertEvent) -> list[FiredAlert]:
          """Match event against all enabled rules of matching event_type.
          
          For each matching rule:
          1. Filter by event_type match
          2. Filter by manager_id match (if rule has manager_id set)
          3. Evaluate condition_json against event payload:
             - 'value_usd_gt': payload.value_usd > threshold
             - 'delta_type': payload.delta_type == value
             - 'news_count_gt': count recent news > threshold
             - 'manager_count_gte': payload.manager_count >= threshold
             - 'any_new_filing': always matches for new_filing events
             - 'time_window_hours': restrict to events within window
          4. Return list of FiredAlert for all matching rules
          """

      def _evaluate_condition(self, condition: dict, payload: dict) -> bool:
          """Evaluate a single condition_json against event payload."""
  ```
- [ ] Add engine integration points (called from ETL flows):
  ```python
  # At end of edgar_flow.py:
  engine = AlertEngine(conn)
  for filing in new_filings:
      event = AlertEvent(event_type="new_filing", manager_id=filing.manager_id,
                         payload={"filing_id": filing.id, "type": filing.type})
      fired = engine.evaluate(event)
      for alert in fired:
          record_and_deliver(alert)
  ```
  - [ ] Document the integration points but don't modify ETL flows yet (S8-02 handles delivery)
- [ ] Write comprehensive tests in `tests/test_alert_engine.py`:
  - [ ] Test rule matching by event_type
  - [ ] Test condition evaluation: `value_usd_gt`, `delta_type`, `news_count_gt`
  - [ ] Test manager_id filtering (rule for specific manager vs all managers)
  - [ ] Test disabled rules are skipped
  - [ ] Test multiple rules matching same event → multiple FiredAlerts
  - [ ] Test no rules match → empty list

#### Acceptance criteria
- [ ] Both tables exist in Postgres with correct schema, constraints, and indexes
- [ ] Alembic migration runs cleanly (upgrade + downgrade)
- [ ] AlertEngine correctly evaluates all supported condition types
- [ ] Engine handles edge cases: no rules, disabled rules, null manager_id
- [ ] All tests pass: `pytest tests/test_alert_engine.py -v`
- [ ] Pydantic models validate correctly and reject invalid event_types/channels

**Head SHA:** 19c988781f47ec34beedc1d5c7490ac8f05e5f8b
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Manager-Database/actions/runs/22535146906) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Manager-Database/actions/runs/22535146910) |
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Scope

Build the database schema for configurable alert rules and alert history, plus the core evaluation engine that matches database events against user-defined rules. This is the foundation for the entire alerting pipeline.

**Depends on**: S1-01 (#672 — canonical schema), S3-01 (#680 — ETL Postgres migration)

## Tasks

- [ ] Add `alert_rules` table to `schema.sql`:
  ```sql
  CREATE TABLE IF NOT EXISTS alert_rules (
      rule_id         bigserial PRIMARY KEY,
      name            text NOT NULL,
      description     text,
      event_type      text NOT NULL CHECK (event_type IN (
          'new_filing', 'large_delta', 'news_spike', 'crowded_trade_change',
          'contrarian_signal', 'missing_filing', 'etl_failure', 'activism_event'
      )),
      condition_json  jsonb NOT NULL DEFAULT '{}',
      -- condition_json examples:
      --   {"delta_type": "EXIT", "value_usd_gt": 1000000}
      --   {"manager_id": 42, "any_new_filing": true}
      --   {"news_count_gt": 5, "time_window_hours": 4}
      --   {"manager_count_gte": 8}
      channels        text[] NOT NULL DEFAULT ARRAY['streamlit'],
      -- valid channels: 'email', 'slack', 'streamlit'
      enabled         boolean NOT NULL DEFAULT true,
      manager_id      bigint REFERENCES managers(manager_id),  -- NULL = all managers
      created_by      text,
      created_at      timestamptz DEFAULT now(),
      updated_at      timestamptz DEFAULT now()
  );
  CREATE INDEX idx_alert_rules_event ON alert_rules(event_type) WHERE enabled = true;
  ```
- [ ] Add `alert_history` table to `schema.sql`:
  ```sql
  CREATE TABLE IF NOT EXISTS alert_history (
      alert_id            bigserial PRIMARY KEY,
      rule_id             bigint NOT NULL REFERENCES alert_rules(rule_id),
      fired_at            timestamptz DEFAULT now(),
      event_type          text NOT NULL,
      payload_json        jsonb NOT NULL,
      -- payload contains event-specific data:
      --   {"filing_id": 123, "manager_name": "Elliott", "type": "13F-HR"}
      --   {"cusip": "037833100", "delta_type": "EXIT", "value_usd": 5000000}
      delivered_channels  text[] DEFAULT ARRAY[]::text[],
      delivery_errors     jsonb,  -- {"slack": "webhook_timeout", ...}
      acknowledged        boolean NOT NULL DEFAULT false,
      acknowledged_by     text,
      acknowledged_at     timestamptz
  );
  CREATE INDEX idx_alert_history_unack ON alert_history(fired_at DESC)
      WHERE acknowledged = false;
  CREATE INDEX idx_alert_history_rule ON alert_history(rule_id);
  ```
- [ ] Add Alembic migrations for both tables
- [ ] Create `alerts/__init__.py` and `alerts/models.py`:
  - Pydantic models: `AlertRule`, `AlertRuleCreate`, `AlertRuleUpdate`
  - Pydantic models: `AlertEvent`, `FiredAlert`
  - `AlertEvent(event_type, manager_id?, payload)` — input to the engine
  - `FiredAlert(rule, event, channels)` — output from evaluation
- [ ] Create `alerts/engine.py` — Rule evaluation engine:
  ```python
  class AlertEngine:
      def __init__(self, db_conn):
          """Load enabled rules from database."""

      def evaluate(self, event: AlertEvent) -> list[FiredAlert]:
          """Match event against all enabled rules of matching event_type.
          
          For each matching rule:
          1. Filter by event_type match
          2. Filter by manager_id match (if rule has manager_id set)
          3. Evaluate condition_json against event payload:
             - 'value_usd_gt': payload.value_usd > threshold
             - 'delta_type': payload.delta_type == value
             - 'news_count_gt': count recent news > threshold
             - 'manager_count_gte': payload.manager_count >= threshold
             - 'any_new_filing': always matches for new_filing events
             - 'time_window_hours': restrict to events within window
          4. Return list of FiredAlert for all matching rules
          """

      def _evaluate_condition(self, condition: dict, payload: dict) -> bool:
          """Evaluate a single condition_json against event payload."""
  ```
- [ ] Add engine integration points (called from ETL flows):
  ```python
  # At end of edgar_flow.py:
  engine = AlertEngine(conn)
  for filing in new_filings:
      event = AlertEvent(event_type="new_filing", manager_id=filing.manager_id,
                         payload={"filing_id": filing.id, "type": filing.type})
      fired = engine.evaluate(event)
      for alert in fired:
          record_and_deliver(alert)
  ```
  - Document the integration points but don't modify ETL flows yet (S8-02 handles delivery)
- [ ] Write comprehensive tests in `tests/test_alert_engine.py`:
  - Test rule matching by event_type
  - Test condition evaluation: `value_usd_gt`, `delta_type`, `news_count_gt`
  - Test manager_id filtering (rule for specific manager vs all managers)
  - Test disabled rules are skipped
  - Test multiple rules matching same event → multiple FiredAlerts
  - Test no rules match → empty list

## Acceptance Criteria

- [ ] Both tables exist in Postgres with correct schema, constraints, and indexes
- [ ] Alembic migration runs cleanly (upgrade + downgrade)
- [ ] AlertEngine correctly evaluates all supported condition types
- [ ] Engine handles edge cases: no rules, disabled rules, null manager_id
- [ ] All tests pass: `pytest tests/test_alert_engine.py -v`
- [ ] Pydantic models validate correctly and reject invalid event_types/channels

## Additional Context

- The `condition_json` is intentionally flexible (JSONB) to support future condition types without schema changes
- The engine should be stateless per evaluation call (load rules fresh or accept them as parameter)
- Future enhancement: compound conditions (AND/OR) — for now, all conditions in a rule are AND'd
- The `missing_filing` event type is special: it's generated by a scheduled check ("manager X hasn't filed in >45 days") rather than by an ETL flow inserting data



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #708

<!-- pr-preamble:end -->