### PR TITLE
style: reformat 3 files with black --line-length 100

### DIFF
--- a/scripts/langchain/capability_check.py
+++ b/scripts/langchain/capability_check.py
@@ -139,9 +139,7 @@ def _build_llm_config(
     issue_or_pr = (
         str(issue_number)
         if issue_number is not None
-        else env_issue
-        if env_issue.isdigit()
-        else "unknown"
+        else env_issue if env_issue.isdigit() else "unknown"
     )
     metadata = {
         "repo": repo,

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -319,9 +319,7 @@ def _build_llm_config(
     issue_or_pr = (
         str(issue_number)
         if issue_number is not None
-        else env_issue
-        if env_issue.isdigit()
-        else "unknown"
+        else env_issue if env_issue.isdigit() else "unknown"
     )
     metadata = {
         "repo": repo,

--- a/tests/test_github_rate_limited_wrapper_sync.py
+++ b/tests/test_github_rate_limited_wrapper_sync.py
@@ -16,9 +16,9 @@ def test_github_rate_limited_wrapper_has_expected_exports() -> None:
     assert "module.exports" in wrapper_contents
     assert "createRateLimitedGithub" in wrapper_contents
     assert "wrapWithRateLimitedGithub" in wrapper_contents
-    assert wrapper_contents == fixture_contents, (
-        "Wrapper file should stay in sync with the approved fixture"
-    )
+    assert (
+        wrapper_contents == fixture_contents
+    ), "Wrapper file should stay in sync with the approved fixture"
 
 
 def test_github_rate_limited_wrapper_is_single_source_of_truth() -> None:
@@ -33,9 +33,9 @@ def test_github_rate_limited_wrapper_is_single_source_of_truth() -> None:
         if ".git" not in path.parts and ".workflows-lib" not in path.parts
     }
 
-    assert found_paths == expected_paths, (
-        "Only the wrapper and approved fixture should exist in the repo"
-    )
+    assert (
+        found_paths == expected_paths
+    ), "Only the wrapper and approved fixture should exist in the repo"
 
 
 # Commit-message checklist:


### PR DESCRIPTION
## Summary
- Fix pre-existing CI `lint-format` failures on `main`
- CI uses `black --check --line-length 100`; these 3 files had minor formatting differences that black resolves
- Files reformatted: `scripts/langchain/capability_check.py`, `scripts/langchain/issue_optimizer.py`, `tests/test_github_rate_limited_wrapper_sync.py`

## Test plan
- [ ] CI `Python CI / lint-format` check passes (no code logic changes, formatting only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)