### PR TITLE
fix(schema): order mv_daily_report index after matview + add Postgres bootstrap smoke

### DIFF
--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -96,19 +96,35 @@ Validation failures return HTTP 400 with field-level error messages:
 `schema.sql` is mounted into Postgres at compose-up via
 `/docker-entrypoint-initdb.d/schema.sql`. To verify it bootstraps a clean
 database end-to-end (catching object-ordering bugs that the SQLite-side
-Alembic tests cannot see), run:
+Alembic tests cannot see), run these commands from a fresh checkout:
 
 ```bash
+# 1. Create your local environment file (only needed once)
+cp .env.example .env
+
+# 2. Start the Postgres container (schema.sql is applied automatically on first start)
 docker compose up -d db
-export MGRDB_PG_TEST_URL=postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432/postgres
+
+# 3. Point the smoke test at the local container.
+#    The default password from .env.example is "postgres"; adjust if you changed it.
+export MGRDB_PG_TEST_URL=postgresql://postgres:postgres@localhost:5432/postgres
+
+# 4. Run the bootstrap smoke
 pytest tests/test_schema_postgres_bootstrap.py
 ```
 
+If you customised `POSTGRES_PASSWORD` in your `.env`, substitute it in the URL:
+
+```bash
+export MGRDB_PG_TEST_URL=postgresql://postgres:<your-password>@localhost:5432/postgres
+```
+
 The smoke drops and recreates the `public` schema before each test, applies
-`schema.sql`, and asserts that the API/ETL-critical tables, materialized
-views, and indexes (notably `mv_daily_report` and `mv_daily_report_idx`) are
-all present. Tests skip cleanly when `MGRDB_PG_TEST_URL` is unset, so the
-SQLite-only CI path is unaffected.
+`schema.sql` statement-by-statement, and asserts that the API/ETL-critical
+tables, materialized views, and indexes (notably `mv_daily_report` and
+`mv_daily_report_idx`) are all present. If any statement fails the test
+reports the exact statement and error. Tests skip cleanly when
+`MGRDB_PG_TEST_URL` is unset, so the SQLite-only CI path is unaffected.
 
 ## Further reading
 

--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -91,6 +91,25 @@ Validation failures return HTTP 400 with field-level error messages:
 }
 ```
 
+## Schema bootstrap smoke
+
+`schema.sql` is mounted into Postgres at compose-up via
+`/docker-entrypoint-initdb.d/schema.sql`. To verify it bootstraps a clean
+database end-to-end (catching object-ordering bugs that the SQLite-side
+Alembic tests cannot see), run:
+
+```bash
+docker compose up -d db
+export MGRDB_PG_TEST_URL=postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432/postgres
+pytest tests/test_schema_postgres_bootstrap.py
+```
+
+The smoke drops and recreates the `public` schema before each test, applies
+`schema.sql`, and asserts that the API/ETL-critical tables, materialized
+views, and indexes (notably `mv_daily_report` and `mv_daily_report_idx`) are
+all present. Tests skip cleanly when `MGRDB_PG_TEST_URL` is unset, so the
+SQLite-only CI path is unaffected.
+
 ## Further reading
 
 - SEC EDGAR API docs[^1]

--- a/schema.sql
+++ b/schema.sql
@@ -340,9 +340,6 @@ CREATE TABLE IF NOT EXISTS contrarian_signals (
 CREATE INDEX IF NOT EXISTS idx_contrarian_manager ON contrarian_signals(manager_id);
 CREATE INDEX IF NOT EXISTS idx_contrarian_date ON contrarian_signals(report_date DESC);
 
-CREATE UNIQUE INDEX IF NOT EXISTS mv_daily_report_idx
-    ON mv_daily_report (report_date, manager_id, cusip, delta_type);
-
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -371,3 +368,6 @@ BEGIN
   END IF;
 END
 $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_daily_report_idx
+    ON mv_daily_report (report_date, manager_id, cusip, delta_type);

--- a/tests/test_schema_postgres_bootstrap.py
+++ b/tests/test_schema_postgres_bootstrap.py
@@ -54,6 +54,31 @@ EXPECTED_MATVIEWS = {"monthly_usage", "mv_daily_report"}
 EXPECTED_INDEXES = {"mv_daily_report_idx"}
 
 
+def test_mv_daily_report_idx_defined_after_matview_in_sql():
+    """Text-level ordering guard: mv_daily_report_idx must appear after the matview DDL.
+
+    Runs without a live Postgres instance so it catches regressions in every CI path,
+    not just when MGRDB_PG_TEST_URL is set.
+    """
+    sql = SCHEMA_SQL.read_text()
+    matview_pos = sql.find("CREATE MATERIALIZED VIEW mv_daily_report")
+    index_pos = sql.find("CREATE UNIQUE INDEX IF NOT EXISTS mv_daily_report_idx")
+
+    assert matview_pos != -1, (
+        "schema.sql does not contain 'CREATE MATERIALIZED VIEW mv_daily_report' — "
+        "matview definition is missing or was renamed"
+    )
+    assert index_pos != -1, (
+        "schema.sql does not contain 'CREATE UNIQUE INDEX IF NOT EXISTS mv_daily_report_idx' — "
+        "index definition is missing or was renamed"
+    )
+    assert matview_pos < index_pos, (
+        f"schema.sql ordering error: mv_daily_report_idx (offset {index_pos}) appears before "
+        f"CREATE MATERIALIZED VIEW mv_daily_report (offset {matview_pos}). "
+        "Move the index creation to after the matview DDL."
+    )
+
+
 @pytest.fixture(scope="module")
 def pg_url() -> str:
     url = os.environ.get("MGRDB_PG_TEST_URL")

--- a/tests/test_schema_postgres_bootstrap.py
+++ b/tests/test_schema_postgres_bootstrap.py
@@ -1,0 +1,128 @@
+"""Smoke gate: a fresh Postgres database can apply ``schema.sql`` end-to-end.
+
+The existing ``test_schema.py`` exercises Alembic migrations against SQLite. That
+covers the ORM-side schema but not the canonical ``schema.sql`` that
+``docker-compose`` mounts into ``/docker-entrypoint-initdb.d/`` for a real
+Postgres bring-up. A bootstrap-order bug in ``schema.sql`` (e.g. creating an
+index on a materialized view before the view exists) would fail at compose-up
+time but pass every existing test. This module fills that gap.
+
+The smoke is gated on ``MGRDB_PG_TEST_URL``: when unset, the test skips so that
+local and SQLite-only CI paths stay green. To run it:
+
+    docker compose up -d db
+    export MGRDB_PG_TEST_URL=postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432/postgres
+    pytest tests/test_schema_postgres_bootstrap.py
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_SQL = ROOT / "schema.sql"
+
+# API/ETL-critical tables that downstream services (api/, etl/, alerts/, dashboard/,
+# chains/) all assume exist after bootstrap. This list is intentionally narrow —
+# the SQLite-side test_schema.py owns the broad "every canonical table" check.
+EXPECTED_TABLES = {
+    "managers",
+    "filings",
+    "holdings",
+    "daily_diffs",
+    "api_usage",
+    "documents",
+    "alert_rules",
+    "alert_history",
+    "conviction_scores",
+}
+EXPECTED_MATVIEWS = {"monthly_usage", "mv_daily_report"}
+EXPECTED_INDEXES = {"mv_daily_report_idx"}
+
+
+@pytest.fixture(scope="module")
+def pg_url() -> str:
+    url = os.environ.get("MGRDB_PG_TEST_URL")
+    if not url:
+        pytest.skip("MGRDB_PG_TEST_URL not set; skipping Postgres bootstrap smoke")
+    return url
+
+
+@pytest.fixture(scope="module")
+def psycopg_module():
+    psycopg = pytest.importorskip("psycopg")
+    return psycopg
+
+
+def _reset_public_schema(conn) -> None:
+    """Drop and recreate the public schema so schema.sql runs against a clean slate."""
+    with conn.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS public CASCADE")
+        cur.execute("CREATE SCHEMA public")
+        cur.execute("GRANT ALL ON SCHEMA public TO public")
+    conn.commit()
+
+
+def _apply_schema_sql(conn) -> None:
+    """Apply the canonical schema.sql, surfacing the exact failing statement on error."""
+    sql = SCHEMA_SQL.read_text()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+        conn.commit()
+    except Exception as exc:
+        conn.rollback()
+        pytest.fail(
+            f"schema.sql bootstrap failed: {type(exc).__name__}: {exc}\n"
+            f"(this almost always indicates an object-ordering problem in schema.sql)"
+        )
+
+
+def test_schema_sql_bootstraps_clean_postgres(pg_url, psycopg_module):
+    """schema.sql must apply end-to-end to a freshly created public schema."""
+    with psycopg_module.connect(pg_url, autocommit=False) as conn:
+        _reset_public_schema(conn)
+        _apply_schema_sql(conn)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT tablename FROM pg_tables WHERE schemaname = current_schema()"
+            )
+            tables = {row[0] for row in cur.fetchall()}
+        missing_tables = EXPECTED_TABLES - tables
+        assert not missing_tables, f"schema.sql did not create expected tables: {missing_tables}"
+
+
+def test_schema_sql_creates_matviews_before_their_indexes(pg_url, psycopg_module):
+    """Regression guard for the mv_daily_report ordering bug (issue #906).
+
+    The matview must exist (and the unique index on it must also exist) after
+    bootstrap. If the index were created before the matview, schema.sql would
+    have failed in the previous test — but we also assert the index exists here
+    so a future re-introduction of the bug surfaces with a clear message.
+    """
+    with psycopg_module.connect(pg_url, autocommit=False) as conn:
+        _reset_public_schema(conn)
+        _apply_schema_sql(conn)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT matviewname FROM pg_matviews WHERE schemaname = current_schema()"
+            )
+            matviews = {row[0] for row in cur.fetchall()}
+            cur.execute(
+                "SELECT indexname FROM pg_indexes WHERE schemaname = current_schema()"
+            )
+            indexes = {row[0] for row in cur.fetchall()}
+
+        missing_matviews = EXPECTED_MATVIEWS - matviews
+        assert not missing_matviews, f"missing matviews after bootstrap: {missing_matviews}"
+
+        missing_indexes = EXPECTED_INDEXES - indexes
+        assert not missing_indexes, (
+            f"missing indexes after bootstrap: {missing_indexes} "
+            f"(check schema.sql ordering: matview creation must precede its index)"
+        )

--- a/tests/test_schema_postgres_bootstrap.py
+++ b/tests/test_schema_postgres_bootstrap.py
@@ -88,9 +88,7 @@ def test_schema_sql_bootstraps_clean_postgres(pg_url, psycopg_module):
         _apply_schema_sql(conn)
 
         with conn.cursor() as cur:
-            cur.execute(
-                "SELECT tablename FROM pg_tables WHERE schemaname = current_schema()"
-            )
+            cur.execute("SELECT tablename FROM pg_tables WHERE schemaname = current_schema()")
             tables = {row[0] for row in cur.fetchall()}
         missing_tables = EXPECTED_TABLES - tables
         assert not missing_tables, f"schema.sql did not create expected tables: {missing_tables}"
@@ -109,13 +107,9 @@ def test_schema_sql_creates_matviews_before_their_indexes(pg_url, psycopg_module
         _apply_schema_sql(conn)
 
         with conn.cursor() as cur:
-            cur.execute(
-                "SELECT matviewname FROM pg_matviews WHERE schemaname = current_schema()"
-            )
+            cur.execute("SELECT matviewname FROM pg_matviews WHERE schemaname = current_schema()")
             matviews = {row[0] for row in cur.fetchall()}
-            cur.execute(
-                "SELECT indexname FROM pg_indexes WHERE schemaname = current_schema()"
-            )
+            cur.execute("SELECT indexname FROM pg_indexes WHERE schemaname = current_schema()")
             indexes = {row[0] for row in cur.fetchall()}
 
         missing_matviews = EXPECTED_MATVIEWS - matviews

--- a/tests/test_schema_postgres_bootstrap.py
+++ b/tests/test_schema_postgres_bootstrap.py
@@ -54,6 +54,37 @@ EXPECTED_MATVIEWS = {"monthly_usage", "mv_daily_report"}
 EXPECTED_INDEXES = {"mv_daily_report_idx"}
 
 
+def test_split_sql_statements_handles_dollar_quotes():
+    """_split_sql_statements must keep a DO $$...$$; block as a single statement."""
+    sql = (
+        "CREATE TABLE t (id int);\n"
+        "DO $$\n"
+        "BEGIN\n"
+        "  EXECUTE $mv$CREATE VIEW v AS SELECT 1$mv$;\n"
+        "END\n"
+        "$$;\n"
+        "CREATE INDEX i ON t (id);\n"
+    )
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 3, f"expected 3 statements, got {len(stmts)}: {stmts}"
+    assert any("DO" in s for s in stmts), "DO block missing from split result"
+    assert any("CREATE TABLE" in s for s in stmts)
+    assert any("CREATE INDEX" in s for s in stmts)
+
+
+def test_split_sql_statements_parses_schema_sql():
+    """schema.sql should split into non-empty statements; the DO blocks must stay whole."""
+    sql = SCHEMA_SQL.read_text()
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) >= 30, f"expected ≥30 statements in schema.sql, got {len(stmts)}"
+    for i, stmt in enumerate(stmts, 1):
+        assert stmt.strip(), f"statement {i} is empty after split"
+    do_stmts = [s for s in stmts if s.lstrip().upper().startswith("DO")]
+    assert (
+        len(do_stmts) == 2
+    ), f"expected exactly 2 DO blocks (monthly_usage + mv_daily_report), got {len(do_stmts)}"
+
+
 def test_mv_daily_report_idx_defined_after_matview_in_sql():
     """Text-level ordering guard: mv_daily_report_idx must appear after the matview DDL.
 
@@ -93,6 +124,67 @@ def psycopg_module():
     return psycopg
 
 
+def _split_sql_statements(sql: str) -> list[str]:
+    """Split SQL text into individual statements, correctly handling dollar-quoted blocks.
+
+    PostgreSQL dollar-quoting ($$...$$, $tag$...$tag$) can contain semicolons that must
+    not be treated as statement terminators.  This parser tracks the outermost dollar-quote
+    tag so DO-blocks and EXECUTE strings are kept as a single statement.
+    """
+    stmts: list[str] = []
+    buf: list[str] = []
+    in_dollar_quote = False
+    dollar_tag = ""
+    i = 0
+    n = len(sql)
+
+    while i < n:
+        ch = sql[i]
+        if not in_dollar_quote:
+            if ch == "-" and i + 1 < n and sql[i + 1] == "-":
+                # Line comment — skip to end of line (not added to buf)
+                while i < n and sql[i] != "\n":
+                    i += 1
+                continue
+            if ch == "$":
+                # Scan forward to find the closing $, forming a tag like $$ or $mv$
+                j = i + 1
+                while j < n and sql[j] != "$":
+                    j += 1
+                if j < n:
+                    tag = sql[i : j + 1]
+                    in_dollar_quote = True
+                    dollar_tag = tag
+                    buf.append(tag)
+                    i = j + 1
+                    continue
+            if ch == ";":
+                buf.append(";")
+                stmt = "".join(buf).strip()
+                if stmt:
+                    stmts.append(stmt)
+                buf = []
+                i += 1
+                continue
+        else:
+            # Inside dollar-quote: only the matching closing tag ends it
+            if sql[i : i + len(dollar_tag)] == dollar_tag:
+                buf.append(dollar_tag)
+                i += len(dollar_tag)
+                in_dollar_quote = False
+                dollar_tag = ""
+                continue
+
+        buf.append(ch)
+        i += 1
+
+    remaining = "".join(buf).strip()
+    if remaining:
+        stmts.append(remaining)
+
+    return stmts
+
+
 def _reset_public_schema(conn) -> None:
     """Drop and recreate the public schema so schema.sql runs against a clean slate."""
     with conn.cursor() as cur:
@@ -103,22 +195,26 @@ def _reset_public_schema(conn) -> None:
 
 
 def _apply_schema_sql(conn) -> None:
-    """Apply the canonical schema.sql, surfacing the exact failing statement on error."""
+    """Apply schema.sql one statement at a time; report the exact failing statement."""
     sql = SCHEMA_SQL.read_text()
-    try:
-        with conn.cursor() as cur:
-            cur.execute(sql)
-        conn.commit()
-    except Exception as exc:
-        conn.rollback()
-        pytest.fail(
-            f"schema.sql bootstrap failed: {type(exc).__name__}: {exc}\n"
-            f"(this almost always indicates an object-ordering problem in schema.sql)"
-        )
+    stmts = _split_sql_statements(sql)
+    for idx, stmt in enumerate(stmts, 1):
+        try:
+            with conn.cursor() as cur:
+                cur.execute(stmt)
+        except Exception as exc:
+            conn.rollback()
+            preview = stmt if len(stmt) <= 400 else stmt[:400] + "..."
+            pytest.fail(
+                f"schema.sql failed at statement {idx}/{len(stmts)}:\n"
+                f"  {type(exc).__name__}: {exc}\n"
+                f"Statement:\n{preview}"
+            )
+    conn.commit()
 
 
 def test_schema_sql_bootstraps_clean_postgres(pg_url, psycopg_module):
-    """schema.sql must apply end-to-end to a freshly created public schema."""
+    """schema.sql must apply end-to-end and create all API/ETL-critical tables and matviews."""
     with psycopg_module.connect(pg_url, autocommit=False) as conn:
         _reset_public_schema(conn)
         _apply_schema_sql(conn)
@@ -126,8 +222,19 @@ def test_schema_sql_bootstraps_clean_postgres(pg_url, psycopg_module):
         with conn.cursor() as cur:
             cur.execute("SELECT tablename FROM pg_tables WHERE schemaname = current_schema()")
             tables = {row[0] for row in cur.fetchall()}
+            cur.execute("SELECT matviewname FROM pg_matviews WHERE schemaname = current_schema()")
+            matviews = {row[0] for row in cur.fetchall()}
+
         missing_tables = EXPECTED_TABLES - tables
-        assert not missing_tables, f"schema.sql did not create expected tables: {missing_tables}"
+        assert not missing_tables, (
+            f"schema.sql did not create expected tables: {missing_tables!r}\n"
+            f"tables present: {sorted(tables)}"
+        )
+        missing_matviews = EXPECTED_MATVIEWS - matviews
+        assert not missing_matviews, (
+            f"schema.sql did not create expected matviews: {missing_matviews!r}\n"
+            f"matviews present: {sorted(matviews)}"
+        )
 
 
 def test_schema_sql_creates_matviews_before_their_indexes(pg_url, psycopg_module):

--- a/tests/test_schema_postgres_bootstrap.py
+++ b/tests/test_schema_postgres_bootstrap.py
@@ -26,18 +26,29 @@ ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_SQL = ROOT / "schema.sql"
 
 # API/ETL-critical tables that downstream services (api/, etl/, alerts/, dashboard/,
-# chains/) all assume exist after bootstrap. This list is intentionally narrow —
-# the SQLite-side test_schema.py owns the broad "every canonical table" check.
+# chains/) all assume exist after bootstrap. Grouped by category:
+#   core:     managers, filings, holdings, daily_diffs, api_usage, documents
+#   alerts:   alert_rules, alert_history
+#   signals:  conviction_scores, crowded_trades, contrarian_signals
+#   activism: activism_filings, activism_events
 EXPECTED_TABLES = {
+    # core
     "managers",
     "filings",
     "holdings",
     "daily_diffs",
     "api_usage",
     "documents",
+    # alerts
     "alert_rules",
     "alert_history",
+    # signals / computed
     "conviction_scores",
+    "crowded_trades",
+    "contrarian_signals",
+    # activism
+    "activism_filings",
+    "activism_events",
 }
 EXPECTED_MATVIEWS = {"monthly_usage", "mv_daily_report"}
 EXPECTED_INDEXES = {"mv_daily_report_idx"}


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:906 -->
> **Source:** Issue #906

Closes #906

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The project design depends on a one-command local stack with Postgres as the relational core. The current `schema.sql` creates the unique index `mv_daily_report_idx` before the `mv_daily_report` materialized view is created. A fresh Postgres initialization can fail before the local stack is usable, and the current tests do not prove that `schema.sql` can bootstrap a clean Postgres database end to end.

#### Tasks
- [x] Move `mv_daily_report_idx` creation until after `mv_daily_report` exists, and keep the operation idempotent.
- [x] Review `schema.sql` for any other object-ordering problems that would fail on a clean Postgres database.
- [x] Add or update a test/smoke that validates a fresh Postgres schema bootstrap, including `monthly_usage`, `mv_daily_report`, alert tables, filing/holding tables, and signal tables.
- [x] Ensure the smoke reports the exact missing object or failed statement when bootstrap fails.
- [x] Document the command in `README_bootstrap.md` or a schema runbook.

#### Acceptance criteria
- [x] A clean Postgres database can apply `schema.sql` without relation-order errors.
- [x] The schema smoke verifies that `mv_daily_report` exists before its unique index is created.
- [x] The schema smoke verifies that the API/ETL-critical tables and views exist after bootstrap.
- [x] Existing schema tests continue to pass.
- [x] The documented bootstrap command is runnable from a fresh checkout with the local compose stack.

<!-- auto-status-summary:end -->