### PR TITLE
chore: sync agents-guard.js to allow Wave 0 deprecated removals

### DIFF
--- a/.github/scripts/agents-guard.js
+++ b/.github/scripts/agents-guard.js
@@ -32,6 +32,12 @@ const ALLOW_REMOVED_PATHS = new Set(
     // v1 verify-to-issue workflow deprecated; v2 is the active version.
     // Archived to archives/deprecated-workflows/
     '.github/workflows/agents-verify-to-issue.yml',
+    // Wave 0 cleanup removes deprecated consumer-template workflows past the
+    // 2026-02-15 deprecation deadline so sync PRs can delete stale copies.
+    '.github/workflows/agents-autofix-loop.yml',
+    '.github/workflows/agents-bot-comment-handler.yml',
+    '.github/workflows/agents-keepalive-loop.yml',
+    '.github/workflows/agents-verify-to-issue-v2.yml',
     // The verify-to-new-pr autopilot bridge was collapsed into the main workflow.
     '.github/workflows/agents-verify-to-new-pr-autopilot.yml',
   ].map((entry) => entry.toLowerCase()),


### PR DESCRIPTION
## Summary
- Syncs `.github/scripts/agents-guard.js` from Workflows PR #2007: https://github.com/stranske/Workflows/pull/2007
- Prerequisite for the upcoming bigger workflow sync PR in this repo: https://github.com/stranske/Manager-Database/pull/958
- Allows the Wave 0 deprecated workflow removals to pass Health 45 Agents Guard before the broader sync lands.

## Test plan
Manual: confirm the agents-guard check passes by re-running the guard on this PR