### PR TITLE
Issue #977: Make EDGAR ingest Postgres-safe

### DIFF
--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -146,6 +146,19 @@ tables, materialized views, and indexes (notably `mv_daily_report` and
 reports the exact statement and error. Tests skip cleanly when
 `MGRDB_PG_TEST_URL` is unset, so the SQLite-only CI path is unaffected.
 
+### EDGAR Postgres persistence smoke
+
+The EDGAR ingest path has a strict Postgres-style persistence smoke that
+rejects SQLite-only SQL while verifying raw upload, document metadata,
+canonical filing and holding writes, and `new_filing` alert dispatch:
+
+```bash
+pytest tests/test_edgar_flow.py::test_fetch_and_store_uses_postgres_safe_persistence -q
+```
+
+Run it with the schema bootstrap smoke above when changing compose `DB_URL`,
+MinIO, or canonical filing/holding columns.
+
 The Schema Idempotence workflow also runs
 `scripts/verify_schema_idempotence.sh` against a `pgvector/pgvector:pg16`
 service on schema-related pull requests, pushes to `main`, nightly schedule,

--- a/etl/edgar_flow.py
+++ b/etl/edgar_flow.py
@@ -113,11 +113,18 @@ def _ensure_legacy_tables(conn: Any) -> None:
         conn.execute("""CREATE TABLE IF NOT EXISTS holdings (
                 holding_id INTEGER PRIMARY KEY,
                 filing_id INTEGER NOT NULL,
+                manager_id INTEGER,
+                cik TEXT,
+                accession TEXT,
                 cusip TEXT,
                 isin TEXT,
                 name_of_issuer TEXT,
+                nameOfIssuer TEXT,
                 shares INTEGER,
+                sshPrnamt INTEGER,
                 value_usd NUMERIC,
+                value NUMERIC,
+                filed TEXT,
                 delta_type TEXT,
                 FOREIGN KEY(filing_id) REFERENCES filings(filing_id)
             )""")

--- a/etl/edgar_flow.py
+++ b/etl/edgar_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import sqlite3
@@ -60,10 +61,21 @@ class _EdgarLogProxy:
 
 def _columns(conn: Any, table: str) -> set[str]:
     try:
-        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
-    except sqlite3.OperationalError:
+        if isinstance(conn, sqlite3.Connection):
+            rows = conn.execute(f"PRAGMA table_xinfo({table})").fetchall()
+            return {str(row[1]) for row in rows}
+        rows = conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = %s",
+            (table,),
+        ).fetchall()
+        return {str(row[0]) for row in rows}
+    except Exception:
         return set()
-    return {str(row[1]) for row in rows}
+
+
+def _placeholder(conn: Any) -> str:
+    return "?" if isinstance(conn, sqlite3.Connection) else "%s"
 
 
 def _manager_id_for_cik(conn: Any, cik: str) -> int | None:
@@ -75,38 +87,68 @@ def _manager_id_for_cik(conn: Any, cik: str) -> int | None:
     )
     if not id_col or "cik" not in manager_cols:
         return None
-    row = conn.execute(f"SELECT {id_col} FROM managers WHERE cik = ? LIMIT 1", (cik,)).fetchone()
+    marker = _placeholder(conn)
+    row = conn.execute(
+        f"SELECT {id_col} FROM managers WHERE cik = {marker} LIMIT 1", (cik,)
+    ).fetchone()
     if not row or row[0] is None:
         return None
     return int(row[0])
 
 
 def _ensure_legacy_tables(conn: Any) -> None:
+    if isinstance(conn, sqlite3.Connection):
+        conn.execute("""CREATE TABLE IF NOT EXISTS filings (
+                filing_id INTEGER PRIMARY KEY,
+                manager_id INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                period_end TEXT,
+                filed_date TEXT,
+                source TEXT NOT NULL,
+                url TEXT,
+                raw_key TEXT UNIQUE,
+                parsed_payload TEXT,
+                schema_version INTEGER
+            )""")
+        conn.execute("""CREATE TABLE IF NOT EXISTS holdings (
+                holding_id INTEGER PRIMARY KEY,
+                filing_id INTEGER NOT NULL,
+                cusip TEXT,
+                isin TEXT,
+                name_of_issuer TEXT,
+                shares INTEGER,
+                value_usd NUMERIC,
+                delta_type TEXT,
+                FOREIGN KEY(filing_id) REFERENCES filings(filing_id)
+            )""")
+        return
     conn.execute("""CREATE TABLE IF NOT EXISTS filings (
-            filing_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            manager_id INTEGER NOT NULL,
-            type TEXT NOT NULL,
-            filed_date TEXT,
-            source TEXT,
-            url TEXT,
-            raw_key TEXT UNIQUE,
-            schema_version INTEGER
+            filing_id bigserial PRIMARY KEY,
+            manager_id bigint NOT NULL REFERENCES managers(manager_id),
+            type text NOT NULL,
+            period_end date,
+            filed_date date,
+            source text NOT NULL,
+            url text,
+            raw_key text,
+            parsed_payload jsonb,
+            schema_version int DEFAULT 1,
+            created_at timestamptz DEFAULT now()
         )""")
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_filings_raw_key_unique "
+        "ON filings (raw_key) WHERE raw_key IS NOT NULL"
+    )
     conn.execute("""CREATE TABLE IF NOT EXISTS holdings (
-            holding_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            filing_id INTEGER,
-            manager_id INTEGER,
-            cik TEXT,
-            accession TEXT,
-            filed DATE,
-            nameOfIssuer TEXT,
-            cusip TEXT,
-            value INTEGER,
-            sshPrnamt INTEGER,
-            name_of_issuer TEXT,
-            shares INTEGER,
-            value_usd INTEGER,
-            FOREIGN KEY(filing_id) REFERENCES filings(filing_id)
+            holding_id bigserial PRIMARY KEY,
+            filing_id bigint NOT NULL REFERENCES filings(filing_id),
+            cusip text,
+            isin text,
+            name_of_issuer text,
+            shares bigint,
+            value_usd numeric(18,2),
+            delta_type text,
+            created_at timestamptz DEFAULT now()
         )""")
 
 
@@ -115,12 +157,53 @@ def _upsert_filing_legacy(
 ) -> int:
     if manager_id is None:
         return 0
-    conn.execute(
-        "INSERT OR IGNORE INTO filings(manager_id, type, filed_date, source, raw_key) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (manager_id, filing_type, filed_date, "edgar", raw_key),
-    )
-    row = conn.execute("SELECT filing_id FROM filings WHERE raw_key = ?", (raw_key,)).fetchone()
+    payload = json.dumps({"raw_key": raw_key})
+    if isinstance(conn, sqlite3.Connection):
+        columns = _columns(conn, "filings")
+        values: dict[str, Any] = {
+            "manager_id": manager_id,
+            "type": filing_type,
+            "filed_date": filed_date,
+            "source": "edgar",
+            "raw_key": raw_key,
+            "parsed_payload": payload,
+        }
+        insert_columns = [column for column in values if column in columns]
+        if not insert_columns or "raw_key" not in insert_columns:
+            return 0
+        update_columns = [column for column in insert_columns if column != "raw_key"]
+        conflict_action = (
+            "DO UPDATE SET "
+            + ", ".join(f"{column} = excluded.{column}" for column in update_columns)
+            if update_columns
+            else "DO NOTHING"
+        )
+        returning = " RETURNING filing_id" if "filing_id" in columns else ""
+        row = conn.execute(
+            f"INSERT INTO filings({', '.join(insert_columns)}) "
+            f"VALUES ({', '.join('?' for _ in insert_columns)}) "
+            f"ON CONFLICT(raw_key) {conflict_action}{returning}",
+            [values[column] for column in insert_columns],
+        ).fetchone()
+        if row and row[0] is not None:
+            return int(row[0])
+        if "filing_id" not in columns:
+            return 0
+        existing = conn.execute(
+            "SELECT filing_id FROM filings WHERE raw_key = ?", (raw_key,)
+        ).fetchone()
+        return int(existing[0]) if existing and existing[0] is not None else 0
+    row = conn.execute(
+        "INSERT INTO filings(manager_id, type, filed_date, source, raw_key, parsed_payload) "
+        "VALUES (%s, %s, %s, %s, %s, %s::jsonb) "
+        "ON CONFLICT (raw_key) WHERE raw_key IS NOT NULL DO UPDATE SET "
+        "manager_id = EXCLUDED.manager_id, "
+        "type = EXCLUDED.type, "
+        "filed_date = EXCLUDED.filed_date, "
+        "parsed_payload = EXCLUDED.parsed_payload "
+        "RETURNING filing_id",
+        (manager_id, filing_type, filed_date, "edgar", raw_key, payload),
+    ).fetchone()
     return int(row[0]) if row and row[0] is not None else 0
 
 
@@ -135,26 +218,32 @@ def _insert_holding_legacy(
     filed_date: str | None,
 ) -> None:
     columns = _columns(conn, "holdings")
+    marker = _placeholder(conn)
     values: dict[str, Any] = {
         "filing_id": filing_id,
-        "manager_id": manager_id,
-        "cik": cik,
-        "accession": accession,
-        "filed": filed_date,
-        "nameOfIssuer": row.get("nameOfIssuer"),
         "cusip": row.get("cusip"),
-        "value": int(row.get("value") or 0),
-        "sshPrnamt": int(row.get("sshPrnamt") or 0),
         "name_of_issuer": row.get("nameOfIssuer"),
         "shares": int(row.get("sshPrnamt") or 0),
         "value_usd": int(row.get("value") or 0),
     }
+    if isinstance(conn, sqlite3.Connection):
+        values.update(
+            {
+                "manager_id": manager_id,
+                "cik": cik,
+                "accession": accession,
+                "filed": filed_date,
+                "nameOfIssuer": row.get("nameOfIssuer"),
+                "value": int(row.get("value") or 0),
+                "sshPrnamt": int(row.get("sshPrnamt") or 0),
+            }
+        )
     insert_columns = [column for column in values if column in columns]
     if not insert_columns:
         return
     conn.execute(
         f"INSERT INTO holdings({', '.join(insert_columns)}) "
-        f"VALUES ({', '.join('?' for _ in insert_columns)})",
+        f"VALUES ({', '.join(marker for _ in insert_columns)})",
         [values[column] for column in insert_columns],
     )
 

--- a/tests/test_edgar_flow.py
+++ b/tests/test_edgar_flow.py
@@ -61,6 +61,69 @@ class MultiRowAdapter:
         ]
 
 
+class StrictPostgresCursor:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    def fetchall(self):
+        return self._rows
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+
+class StrictPostgresConnection:
+    columns = {
+        "managers": {"manager_id", "cik"},
+        "filings": {
+            "filing_id",
+            "manager_id",
+            "type",
+            "filed_date",
+            "source",
+            "raw_key",
+            "parsed_payload",
+        },
+        "holdings": {"holding_id", "filing_id", "cusip", "name_of_issuer", "shares", "value_usd"},
+    }
+
+    def __init__(self):
+        self.sql = []
+        self.params = []
+        self.filings = []
+        self.holdings = []
+        self.commits = 0
+        self.closed = False
+
+    def execute(self, sql, params=()):
+        forbidden = ["PRAGMA", "AUTOINCREMENT", "INSERT OR IGNORE"]
+        upper_sql = sql.upper()
+        assert not any(token in upper_sql for token in forbidden), sql
+        assert "?" not in sql, sql
+        self.sql.append(sql)
+        self.params.append(tuple(params))
+
+        if "information_schema.columns" in sql:
+            assert "table_schema = current_schema()" in sql
+            table = params[0]
+            return StrictPostgresCursor([(column,) for column in self.columns.get(table, set())])
+        if "FROM managers" in sql:
+            return StrictPostgresCursor([(321,)])
+        if "INSERT INTO filings" in sql:
+            self.filings.append(tuple(params))
+            return StrictPostgresCursor([(9001,)])
+        if "INSERT INTO holdings" in sql:
+            self.holdings.append(tuple(params))
+            return StrictPostgresCursor([])
+        return StrictPostgresCursor([])
+
+    def commit(self):
+        self.commits += 1
+
+    def close(self):
+        self.closed = True
+
+
 def _setup_relational_schema(db_path: Path, cik: str = "0", manager_id: int = 100) -> None:
     conn = sqlite3.connect(db_path)
     conn.execute("""CREATE TABLE IF NOT EXISTS managers (
@@ -268,6 +331,80 @@ async def test_fetch_and_store_inserts_multiple_rows(monkeypatch, tmp_path):
     ).fetchall()
     conn.close()
     assert rows == [(filing_id, "AAA", 1, 1), (filing_id, "BBB", 2, 2)]
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_uses_postgres_safe_persistence(monkeypatch):
+    conn = StrictPostgresConnection()
+    monkeypatch.setattr(flow, "connect_db", lambda db_path: conn)
+    monkeypatch.setattr(flow, "DB_PATH", "postgres://manager-db")
+    monkeypatch.setattr(flow, "ADAPTER", MultiRowAdapter())
+
+    put_calls = []
+    stored = []
+    events = []
+
+    monkeypatch.setattr(flow.S3, "put_object", lambda **kwargs: put_calls.append(kwargs))
+    monkeypatch.setattr(flow, "store_document", lambda raw, **kwargs: stored.append((raw, kwargs)))
+
+    async def fake_fire_alerts_for_event(db_conn, event):
+        assert db_conn is conn
+        events.append(event)
+        return [1]
+
+    monkeypatch.setattr(flow, "fire_alerts_for_event", fake_fire_alerts_for_event)
+
+    rows = await flow.fetch_and_store.fn("0", "2024-01-01")
+
+    assert len(rows) == 2
+    assert len(put_calls) == 1
+    assert put_calls[0]["ServerSideEncryption"] == "AES256"
+    assert stored == [
+        (
+            "<xml></xml>",
+            {
+                "db_path": "postgres://manager-db",
+                "manager_id": 321,
+                "kind": "filing_text",
+                "filename": "1.xml",
+            },
+        )
+    ]
+    assert conn.filings == [
+        (
+            321,
+            "13F-HR",
+            "2024-05-01",
+            "edgar",
+            put_calls[0]["Key"],
+            '{"raw_key": "' + put_calls[0]["Key"] + '"}',
+        )
+    ]
+    assert conn.holdings == [
+        (9001, "AAA", "CorpA", 1, 1),
+        (9001, "BBB", "CorpB", 2, 2),
+    ]
+    assert conn.commits == 1
+    assert conn.closed is True
+    assert len(events) == 1
+    assert events[0].event_type == "new_filing"
+    assert events[0].manager_id == 321
+    assert events[0].payload["filing_id"] == 9001
+
+
+def test_upsert_filing_legacy_handles_minimal_raw_key_schema(tmp_path):
+    db_path = tmp_path / "minimal.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE filings (raw_key TEXT UNIQUE)")
+
+    filing_id = flow._upsert_filing_legacy(conn, 100, "13F-HR", "2024-05-01", "raw.xml")
+    duplicate_id = flow._upsert_filing_legacy(conn, 100, "13F-HR", "2024-05-01", "raw.xml")
+    rows = conn.execute("SELECT raw_key FROM filings").fetchall()
+    conn.close()
+
+    assert filing_id == 0
+    assert duplicate_id == 0
+    assert rows == [("raw.xml",)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #977

## Summary
- split EDGAR persistence into SQLite-safe local setup and Postgres-safe canonical filings/holdings writes
- use information_schema, %s placeholders, raw_key idempotency, and canonical holding columns for non-SQLite connections
- add a strict Postgres-style fake test plus README smoke command for EDGAR persistence

## Validation
- pytest tests/test_edgar_flow.py tests/test_etl_flows_additional.py -q
- ruff check etl/edgar_flow.py tests/test_edgar_flow.py
- rg -n "AUTOINCREMENT|INSERT OR IGNORE|PRAGMA table_info" etl/edgar_flow.py