### PR TITLE
Issue #978: Add schema idempotence gate

### DIFF
--- a/.github/workflows/schema-idempotence.yml
+++ b/.github/workflows/schema-idempotence.yml
@@ -36,7 +36,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Postgres client
         run: |
           sudo apt-get update

--- a/.github/workflows/schema-idempotence.yml
+++ b/.github/workflows/schema-idempotence.yml
@@ -1,0 +1,49 @@
+name: Schema Idempotence
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - schema.sql
+      - scripts/verify_schema_idempotence.sh
+      - .github/workflows/schema-idempotence.yml
+  pull_request:
+    paths:
+      - schema.sql
+      - scripts/verify_schema_idempotence.sh
+      - .github/workflows/schema-idempotence.yml
+  schedule:
+    - cron: '30 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  schema-verifier:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -h localhost -p 5432 -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Postgres client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+      - name: Run scripts/verify_schema_idempotence.sh
+        env:
+          PGHOST: localhost
+          PGPORT: '5432'
+          PGUSER: postgres
+        run: bash scripts/verify_schema_idempotence.sh

--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -146,6 +146,12 @@ tables, materialized views, and indexes (notably `mv_daily_report` and
 reports the exact statement and error. Tests skip cleanly when
 `MGRDB_PG_TEST_URL` is unset, so the SQLite-only CI path is unaffected.
 
+The Schema Idempotence workflow also runs
+`scripts/verify_schema_idempotence.sh` against a `pgvector/pgvector:pg16`
+service on schema-related pull requests, pushes to `main`, nightly schedule,
+and manual dispatch. That gate applies `schema.sql` twice to a fresh Postgres
+database, so non-idempotent schema changes fail in CI before merge.
+
 ## Further reading
 
 - SEC EDGAR API docs[^1]

--- a/tests/test_schema_idempotence_workflow.py
+++ b/tests/test_schema_idempotence_workflow.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "schema-idempotence.yml"
+
+
+def test_schema_idempotence_workflow_runs_verifier_against_pg16_service():
+    workflow = WORKFLOW.read_text()
+
+    assert "schema-verifier:" in workflow
+    assert "image: pgvector/pgvector:pg16" in workflow
+    assert "PGHOST: localhost" in workflow
+    assert "PGPORT: '5432'" in workflow
+    assert "PGUSER: postgres" in workflow
+    assert "bash scripts/verify_schema_idempotence.sh" in workflow
+
+
+def test_schema_idempotence_workflow_runs_on_schema_changes_and_schedule():
+    workflow = WORKFLOW.read_text()
+
+    assert "push:" in workflow
+    assert "pull_request:" in workflow
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "schema.sql" in workflow
+    assert "scripts/verify_schema_idempotence.sh" in workflow

--- a/tests/test_schema_idempotence_workflow.py
+++ b/tests/test_schema_idempotence_workflow.py
@@ -1,26 +1,41 @@
 from pathlib import Path
 
+import yaml  # type: ignore[import-untyped]
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "schema-idempotence.yml"
+SCHEMA_PATHS = [
+    "schema.sql",
+    "scripts/verify_schema_idempotence.sh",
+    ".github/workflows/schema-idempotence.yml",
+]
+
+
+def load_workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
 
 
 def test_schema_idempotence_workflow_runs_verifier_against_pg16_service():
-    workflow = WORKFLOW.read_text()
+    workflow = load_workflow()
+    job = workflow["jobs"]["schema-verifier"]
+    service = job["services"]["postgres"]
+    run_step = job["steps"][-1]
 
-    assert "schema-verifier:" in workflow
-    assert "image: pgvector/pgvector:pg16" in workflow
-    assert "PGHOST: localhost" in workflow
-    assert "PGPORT: '5432'" in workflow
-    assert "PGUSER: postgres" in workflow
-    assert "bash scripts/verify_schema_idempotence.sh" in workflow
+    assert service["image"] == "pgvector/pgvector:pg16"
+    assert run_step["env"] == {
+        "PGHOST": "localhost",
+        "PGPORT": "5432",
+        "PGUSER": "postgres",
+    }
+    assert run_step["run"] == "bash scripts/verify_schema_idempotence.sh"
 
 
 def test_schema_idempotence_workflow_runs_on_schema_changes_and_schedule():
-    workflow = WORKFLOW.read_text()
+    workflow = load_workflow()
+    triggers = workflow[True]
 
-    assert "push:" in workflow
-    assert "pull_request:" in workflow
-    assert "schedule:" in workflow
-    assert "workflow_dispatch:" in workflow
-    assert "schema.sql" in workflow
-    assert "scripts/verify_schema_idempotence.sh" in workflow
+    assert triggers["push"]["branches"] == ["main"]
+    assert triggers["push"]["paths"] == SCHEMA_PATHS
+    assert triggers["pull_request"]["paths"] == SCHEMA_PATHS
+    assert triggers["schedule"] == [{"cron": "30 4 * * *"}]
+    assert triggers["workflow_dispatch"] is None


### PR DESCRIPTION
Closes #978

## Summary
- add a dedicated Schema Idempotence workflow that runs scripts/verify_schema_idempotence.sh against pgvector/pgvector:pg16
- trigger the gate for schema-related PRs, pushes to main, nightly schedule, and manual dispatch
- add a focused workflow contract test and document the gate in README_bootstrap.md

## Validation
- pytest tests/test_schema_idempotence_workflow.py tests/test_schema_postgres_bootstrap.py -q
- ruff check tests/test_schema_idempotence_workflow.py
- python - <<'PY' ... yaml.safe_load('.github/workflows/schema-idempotence.yml')
PY

## Automated Status Summary
- [x] Schema idempotence workflow is present and invokes scripts/verify_schema_idempotence.sh against Postgres/pgvector.
- [x] Workflow triggers cover schema-related pull requests, schema-related pushes to main, nightly schedule, and manual dispatch.
- [x] Bootstrap documentation describes the new gate.
- [x] Workflow contract tests parse the YAML structurally and validate the gate wiring.
- [x] Copilot review threads were resolved before merge.
- [x] Provider comparison verifier reported PASS from OpenAI and Anthropic.
