### PR TITLE
Issue #910: Add automated filings and news digest

### DIFF
--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -48,12 +48,22 @@ Feel free to open issues or pull requests as you iterate.
    ```
    Parsed rows will be stored in `dev.db` and raw filings uploaded to the `filings` bucket in MinIO.
 
-3. Start the Streamlit app shell:
+3. Generate the local analyst digest without sending email:
+   ```bash
+   DIGEST_DRY_RUN=true DIGEST_OUTPUT_PATH=/tmp/manager-digest.txt python etl/digest_flow.py
+   ```
+   The digest reads recent `filings`, manager-linked `news_items`, and unacknowledged
+   important `alert_history` rows from `DB_PATH`/`DB_URL`. Configure
+   `DIGEST_LOOKBACK_HOURS`, `DIGEST_EMAIL_TO`, and `DIGEST_EMAIL_FROM` for scheduled
+   delivery; it reuses the existing SMTP/SendGrid environment variables from alert email
+   delivery.
+
+4. Start the Streamlit app shell:
    ```bash
    streamlit run ui/app.py
    ```
 
-4. You can still run individual pages directly if needed:
+5. You can still run individual pages directly if needed:
    ```bash
    streamlit run ui/daily_report.py
    ```
@@ -61,12 +71,12 @@ Feel free to open issues or pull requests as you iterate.
    streamlit run ui/search.py
    ```
    The multipage shell exposes routes like `/daily-report`, `/search`, `/upload`, and `/research`.
-5. Upload your own notes:
+6. Upload your own notes:
    ```bash
    streamlit run ui/upload.py
    ```
 
-6. The chat API runs as the `api` compose service started in step 2 of the
+7. The chat API runs as the `api` compose service started in step 2 of the
    Quick start. To run it directly against an out-of-compose environment
    (for example with `--reload` for fast iteration), you can still launch
    it manually:

--- a/alerts/channels.py
+++ b/alerts/channels.py
@@ -80,6 +80,27 @@ def _send_via_smtp(
         smtp.send_message(message)
 
 
+def send_email_message_via_smtp(
+    message: EmailMessage,
+    *,
+    host: str,
+    port: int,
+    username: str | None,
+    password: str | None,
+    use_tls: bool,
+    timeout_seconds: float,
+) -> None:
+    _send_via_smtp(
+        message,
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        use_tls=use_tls,
+        timeout_seconds=timeout_seconds,
+    )
+
+
 class EmailChannel(NotificationChannel):
     """Send HTML email alerts using SMTP or SendGrid."""
 

--- a/etl/digest_flow.py
+++ b/etl/digest_flow.py
@@ -17,7 +17,7 @@ import httpx
 from prefect import flow, task
 
 from adapters.base import connect_db
-from alerts.channels import DeliveryResult, _send_via_smtp
+from alerts.channels import DeliveryResult, send_email_message_via_smtp
 from alerts.db import deserialize_json_object
 from etl.logging_setup import configure_logging, log_outcome
 
@@ -118,7 +118,9 @@ def _payload_summary(payload: dict[str, Any]) -> str:
 
 
 @task
-def build_digest(conn: Any, lookback_hours: int = 24, now: datetime | None = None) -> DigestDocument:
+def build_digest(
+    conn: Any, lookback_hours: int = 24, now: datetime | None = None
+) -> DigestDocument:
     """Query recent filings, news, and unacknowledged alerts into one digest."""
     generated_at = _coerce_utc(now)
     window_start = generated_at - timedelta(hours=lookback_hours)
@@ -127,15 +129,25 @@ def build_digest(conn: Any, lookback_hours: int = 24, now: datetime | None = Non
 
     filing_cols = _columns(conn, "filings")
     if {"manager_id", "type", "source"} <= filing_cols and _table_exists(conn, "managers"):
-        date_expr = "COALESCE(f.filed_date, f.created_at)" if "created_at" in filing_cols else "f.filed_date"
+        filter_expr = "f.created_at" if "created_at" in filing_cols else "f.filed_date"
+        filter_value = (
+            window_start.isoformat()
+            if "created_at" in filing_cols
+            else window_start.date().isoformat()
+        )
+        display_date_expr = (
+            "COALESCE(f.filed_date, f.created_at)"
+            if "created_at" in filing_cols
+            else "f.filed_date"
+        )
         rows = conn.execute(
-            f"""SELECT COALESCE(m.name, 'Manager ' || f.manager_id), f.type, {date_expr},
+            f"""SELECT COALESCE(m.name, 'Manager ' || CAST(f.manager_id AS TEXT)), f.type, {display_date_expr},
                        f.source, f.url
                   FROM filings AS f
                   LEFT JOIN managers AS m ON m.manager_id = f.manager_id
-                 WHERE {date_expr} >= {ph}
-                 ORDER BY {date_expr} DESC, f.filing_id DESC""",
-            (window_start.date().isoformat(),),
+                 WHERE {filter_expr} >= {ph}
+                 ORDER BY {filter_expr} DESC, f.filing_id DESC""",
+            (filter_value,),
         ).fetchall()
         digest.filings = [
             DigestFiling(
@@ -151,7 +163,14 @@ def build_digest(conn: Any, lookback_hours: int = 24, now: datetime | None = Non
     news_cols = _columns(conn, "news_items")
     if {"manager_id", "published_at", "source", "headline"} <= news_cols:
         rows = conn.execute(
-            f"""SELECT COALESCE(m.name, 'Manager ' || n.manager_id, 'Unlinked manager'),
+            f"""SELECT COALESCE(
+                       m.name,
+                       CASE
+                           WHEN n.manager_id IS NOT NULL
+                           THEN 'Manager ' || CAST(n.manager_id AS TEXT)
+                       END,
+                       'Unlinked manager'
+                   ),
                        n.headline, n.source, n.published_at, n.url
                   FROM news_items AS n
                   LEFT JOIN managers AS m ON m.manager_id = n.manager_id
@@ -214,9 +233,7 @@ def render_digest_plain_text(digest: DigestDocument) -> str:
         )
     lines.extend(["", f"News ({len(digest.news)})"])
     for item in digest.news:
-        lines.append(
-            f"- {item.manager_name}: {item.headline} ({item.source}, {item.published_at})"
-        )
+        lines.append(f"- {item.manager_name}: {item.headline} ({item.source}, {item.published_at})")
     lines.extend(["", f"Important alerts ({len(digest.alerts)})"])
     for item in digest.alerts:
         manager = f" [{item.manager_name}]" if item.manager_name else ""
@@ -290,19 +307,30 @@ async def deliver_digest_email(digest: DigestDocument, *, dry_run: bool = False)
     recipients = _split_csv(os.getenv("DIGEST_EMAIL_TO") or os.getenv("ALERT_EMAIL_TO"))
     if not sender:
         return DeliveryResult(
-            channel="email", success=True, skipped=True, error_message="DIGEST_EMAIL_FROM is not configured"
+            channel="email",
+            success=True,
+            skipped=True,
+            error_message="DIGEST_EMAIL_FROM is not configured",
         )
     if not recipients:
         return DeliveryResult(
-            channel="email", success=True, skipped=True, error_message="DIGEST_EMAIL_TO is not configured"
+            channel="email",
+            success=True,
+            skipped=True,
+            error_message="DIGEST_EMAIL_TO is not configured",
         )
 
-    provider = (os.getenv("DIGEST_EMAIL_PROVIDER") or os.getenv("ALERT_EMAIL_PROVIDER") or "smtp").lower()
+    provider = (
+        os.getenv("DIGEST_EMAIL_PROVIDER") or os.getenv("ALERT_EMAIL_PROVIDER") or "smtp"
+    ).lower()
     if provider == "sendgrid":
         api_key = os.getenv("SENDGRID_API_KEY")
         if not api_key:
             return DeliveryResult(
-                channel="email", success=True, skipped=True, error_message="SENDGRID_API_KEY is not configured"
+                channel="email",
+                success=True,
+                skipped=True,
+                error_message="SENDGRID_API_KEY is not configured",
             )
         payload = {
             "personalizations": [{"to": [{"email": recipient} for recipient in recipients]}],
@@ -313,11 +341,18 @@ async def deliver_digest_email(digest: DigestDocument, *, dry_run: bool = False)
                 {"type": "text/html", "value": render_digest_html(digest)},
             ],
         }
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.post(
-                "https://api.sendgrid.com/v3/mail/send",
-                headers={"Authorization": f"Bearer {api_key}"},
-                json=payload,
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    "https://api.sendgrid.com/v3/mail/send",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    json=payload,
+                )
+        except httpx.HTTPError as exc:
+            return DeliveryResult(
+                channel="email",
+                success=False,
+                error_message=f"SendGrid digest delivery failed: {exc}",
             )
         if response.status_code not in (200, 202):
             return DeliveryResult(
@@ -333,16 +368,23 @@ async def deliver_digest_email(digest: DigestDocument, *, dry_run: bool = False)
             channel="email", success=True, skipped=True, error_message="SMTP_HOST is not configured"
         )
     message = build_digest_email_message(digest, sender=sender, recipients=recipients)
-    await asyncio.to_thread(
-        _send_via_smtp,
-        message,
-        host=smtp_host,
-        port=int(os.getenv("SMTP_PORT", "587")),
-        username=os.getenv("SMTP_USER"),
-        password=os.getenv("SMTP_PASSWORD"),
-        use_tls=os.getenv("ALERT_EMAIL_USE_TLS", "true").strip().lower() != "false",
-        timeout_seconds=10.0,
-    )
+    try:
+        await asyncio.to_thread(
+            send_email_message_via_smtp,
+            message,
+            host=smtp_host,
+            port=int(os.getenv("SMTP_PORT", "587")),
+            username=os.getenv("SMTP_USER"),
+            password=os.getenv("SMTP_PASSWORD"),
+            use_tls=os.getenv("ALERT_EMAIL_USE_TLS", "true").strip().lower() != "false",
+            timeout_seconds=10.0,
+        )
+    except Exception as exc:  # pragma: no cover - defensive against network stack specifics
+        return DeliveryResult(
+            channel="email",
+            success=False,
+            error_message=f"SMTP digest delivery failed: {exc}",
+        )
     return DeliveryResult(channel="email", success=True)
 
 
@@ -355,7 +397,11 @@ async def digest_flow(
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Build and optionally deliver the automated analyst digest."""
-    resolved_lookback = lookback_hours or int(os.getenv("DIGEST_LOOKBACK_HOURS", "24"))
+    resolved_lookback = (
+        int(os.getenv("DIGEST_LOOKBACK_HOURS", "24")) if lookback_hours is None else lookback_hours
+    )
+    if resolved_lookback <= 0:
+        raise ValueError("lookback_hours must be greater than 0")
     resolved_dry_run = (
         os.getenv("DIGEST_DRY_RUN", "true").strip().lower() != "false"
         if dry_run is None

--- a/etl/digest_flow.py
+++ b/etl/digest_flow.py
@@ -1,0 +1,410 @@
+"""Automated filings, news, and alert digest generation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from email.message import EmailMessage
+from html import escape
+from pathlib import Path
+from typing import Any
+
+import httpx
+from prefect import flow, task
+
+from adapters.base import connect_db
+from alerts.channels import DeliveryResult, _send_via_smtp
+from alerts.db import deserialize_json_object
+from etl.logging_setup import configure_logging, log_outcome
+
+configure_logging("digest_flow")
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class DigestFiling:
+    manager_name: str
+    filing_type: str
+    filed_date: str
+    source: str
+    url: str | None = None
+
+
+@dataclass(slots=True)
+class DigestNewsItem:
+    manager_name: str
+    headline: str
+    source: str
+    published_at: str
+    url: str | None = None
+
+
+@dataclass(slots=True)
+class DigestAlert:
+    rule_name: str
+    event_type: str
+    fired_at: str
+    summary: str
+    manager_name: str | None = None
+
+
+@dataclass(slots=True)
+class DigestDocument:
+    generated_at: datetime
+    lookback_hours: int
+    filings: list[DigestFiling] = field(default_factory=list)
+    news: list[DigestNewsItem] = field(default_factory=list)
+    alerts: list[DigestAlert] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.filings or self.news or self.alerts)
+
+
+def _placeholder(conn: Any) -> str:
+    return "?" if isinstance(conn, sqlite3.Connection) else "%s"
+
+
+def _table_exists(conn: Any, table: str) -> bool:
+    if isinstance(conn, sqlite3.Connection):
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+    else:
+        row = conn.execute("SELECT to_regclass(%s)", (table,)).fetchone()
+    return bool(row and row[0])
+
+
+def _columns(conn: Any, table: str) -> set[str]:
+    if not _table_exists(conn, table):
+        return set()
+    if isinstance(conn, sqlite3.Connection):
+        rows = conn.execute(f"PRAGMA table_xinfo({table})").fetchall()
+        return {str(row[1]) for row in rows}
+    rows = conn.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = current_schema() AND table_name = %s",
+        (table,),
+    ).fetchall()
+    return {str(row[0]) for row in rows}
+
+
+def _coerce_utc(value: datetime | None) -> datetime:
+    current = value or datetime.now(UTC)
+    if current.tzinfo is None:
+        return current.replace(tzinfo=UTC)
+    return current.astimezone(UTC)
+
+
+def _row_value(row: Any, index: int) -> Any:
+    return row[index] if not isinstance(row, sqlite3.Row) else row[index]
+
+
+def _payload_summary(payload: dict[str, Any]) -> str:
+    for key in ("summary", "headline", "type", "filing_type", "delta_type"):
+        value = payload.get(key)
+        if value not in (None, "", []):
+            return str(value)
+    if payload.get("news_count"):
+        return f"{payload['news_count']} manager-linked news items"
+    if payload.get("threshold_crossed"):
+        return f"Threshold crossed: {payload['threshold_crossed']}"
+    return "Important alert event"
+
+
+@task
+def build_digest(conn: Any, lookback_hours: int = 24, now: datetime | None = None) -> DigestDocument:
+    """Query recent filings, news, and unacknowledged alerts into one digest."""
+    generated_at = _coerce_utc(now)
+    window_start = generated_at - timedelta(hours=lookback_hours)
+    ph = _placeholder(conn)
+    digest = DigestDocument(generated_at=generated_at, lookback_hours=lookback_hours)
+
+    filing_cols = _columns(conn, "filings")
+    if {"manager_id", "type", "source"} <= filing_cols and _table_exists(conn, "managers"):
+        date_expr = "COALESCE(f.filed_date, f.created_at)" if "created_at" in filing_cols else "f.filed_date"
+        rows = conn.execute(
+            f"""SELECT COALESCE(m.name, 'Manager ' || f.manager_id), f.type, {date_expr},
+                       f.source, f.url
+                  FROM filings AS f
+                  LEFT JOIN managers AS m ON m.manager_id = f.manager_id
+                 WHERE {date_expr} >= {ph}
+                 ORDER BY {date_expr} DESC, f.filing_id DESC""",
+            (window_start.date().isoformat(),),
+        ).fetchall()
+        digest.filings = [
+            DigestFiling(
+                manager_name=str(_row_value(row, 0)),
+                filing_type=str(_row_value(row, 1)),
+                filed_date=str(_row_value(row, 2)),
+                source=str(_row_value(row, 3)),
+                url=str(_row_value(row, 4)) if _row_value(row, 4) else None,
+            )
+            for row in rows
+        ]
+
+    news_cols = _columns(conn, "news_items")
+    if {"manager_id", "published_at", "source", "headline"} <= news_cols:
+        rows = conn.execute(
+            f"""SELECT COALESCE(m.name, 'Manager ' || n.manager_id, 'Unlinked manager'),
+                       n.headline, n.source, n.published_at, n.url
+                  FROM news_items AS n
+                  LEFT JOIN managers AS m ON m.manager_id = n.manager_id
+                 WHERE n.published_at >= {ph}
+                 ORDER BY n.published_at DESC, n.news_id DESC""",
+            (window_start.isoformat(),),
+        ).fetchall()
+        digest.news = [
+            DigestNewsItem(
+                manager_name=str(_row_value(row, 0)),
+                headline=str(_row_value(row, 1)),
+                source=str(_row_value(row, 2)),
+                published_at=str(_row_value(row, 3)),
+                url=str(_row_value(row, 4)) if _row_value(row, 4) else None,
+            )
+            for row in rows
+        ]
+
+    alert_cols = _columns(conn, "alert_history")
+    if {"rule_id", "fired_at", "event_type", "payload_json", "acknowledged"} <= alert_cols:
+        rows = conn.execute(
+            f"""SELECT COALESCE(ar.name, ah.event_type), ah.event_type, ah.fired_at,
+                       ah.payload_json, m.name
+                  FROM alert_history AS ah
+                  LEFT JOIN alert_rules AS ar ON ar.rule_id = ah.rule_id
+                  LEFT JOIN managers AS m ON m.manager_id = ar.manager_id
+                 WHERE ah.acknowledged = {ph} AND ah.fired_at >= {ph}
+                 ORDER BY ah.fired_at DESC, ah.alert_id DESC""",
+            (False if not isinstance(conn, sqlite3.Connection) else 0, window_start.isoformat()),
+        ).fetchall()
+        digest.alerts = [
+            DigestAlert(
+                rule_name=str(_row_value(row, 0)),
+                event_type=str(_row_value(row, 1)),
+                fired_at=str(_row_value(row, 2)),
+                summary=_payload_summary(deserialize_json_object(_row_value(row, 3))),
+                manager_name=str(_row_value(row, 4)) if _row_value(row, 4) else None,
+            )
+            for row in rows
+        ]
+
+    return digest
+
+
+def render_digest_plain_text(digest: DigestDocument) -> str:
+    """Render a deterministic plaintext digest."""
+    lines = [
+        f"Manager activity digest ({digest.lookback_hours}h)",
+        f"Generated at: {digest.generated_at.isoformat()}",
+        "",
+    ]
+    if digest.is_empty:
+        lines.append("No filings, manager-linked news, or unacknowledged alerts were found.")
+        return "\n".join(lines)
+
+    lines.append(f"Filings ({len(digest.filings)})")
+    for item in digest.filings:
+        lines.append(
+            f"- {item.manager_name}: {item.filing_type} filed {item.filed_date} via {item.source}"
+        )
+    lines.extend(["", f"News ({len(digest.news)})"])
+    for item in digest.news:
+        lines.append(
+            f"- {item.manager_name}: {item.headline} ({item.source}, {item.published_at})"
+        )
+    lines.extend(["", f"Important alerts ({len(digest.alerts)})"])
+    for item in digest.alerts:
+        manager = f" [{item.manager_name}]" if item.manager_name else ""
+        lines.append(f"- {item.rule_name}{manager}: {item.summary} ({item.fired_at})")
+    return "\n".join(lines)
+
+
+def render_digest_html(digest: DigestDocument) -> str:
+    """Render a lightweight HTML digest body."""
+    if digest.is_empty:
+        body = "<p>No filings, manager-linked news, or unacknowledged alerts were found.</p>"
+    else:
+        filing_rows = "".join(
+            "<li>"
+            f"{escape(item.manager_name)}: {escape(item.filing_type)} filed "
+            f"{escape(item.filed_date)} via {escape(item.source)}"
+            "</li>"
+            for item in digest.filings
+        )
+        news_rows = "".join(
+            "<li>"
+            f"{escape(item.manager_name)}: {escape(item.headline)} "
+            f"({escape(item.source)}, {escape(item.published_at)})"
+            "</li>"
+            for item in digest.news
+        )
+        alert_rows = "".join(
+            "<li>"
+            f"{escape(item.rule_name)}: {escape(item.summary)} "
+            f"({escape(item.fired_at)})"
+            "</li>"
+            for item in digest.alerts
+        )
+        body = (
+            f"<h3>Filings ({len(digest.filings)})</h3><ul>{filing_rows}</ul>"
+            f"<h3>News ({len(digest.news)})</h3><ul>{news_rows}</ul>"
+            f"<h3>Important alerts ({len(digest.alerts)})</h3><ul>{alert_rows}</ul>"
+        )
+    return (
+        "<html><body style='font-family:Arial,sans-serif'>"
+        f"<h2>Manager activity digest ({digest.lookback_hours}h)</h2>"
+        f"<p><strong>Generated at:</strong> {escape(digest.generated_at.isoformat())}</p>"
+        f"{body}</body></html>"
+    )
+
+
+def build_digest_email_message(
+    digest: DigestDocument, *, sender: str, recipients: list[str]
+) -> EmailMessage:
+    message = EmailMessage()
+    message["Subject"] = f"Manager activity digest ({digest.lookback_hours}h)"
+    message["From"] = sender
+    message["To"] = ", ".join(recipients)
+    message.set_content(render_digest_plain_text(digest))
+    message.add_alternative(render_digest_html(digest), subtype="html")
+    return message
+
+
+def _split_csv(raw: str | None) -> list[str]:
+    if raw is None:
+        return []
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+async def deliver_digest_email(digest: DigestDocument, *, dry_run: bool = False) -> DeliveryResult:
+    """Send the digest through the configured email provider, or skip safely."""
+    if dry_run:
+        return DeliveryResult(channel="email", success=True, skipped=True, error_message="dry-run")
+
+    sender = (os.getenv("DIGEST_EMAIL_FROM") or os.getenv("ALERT_EMAIL_FROM") or "").strip()
+    recipients = _split_csv(os.getenv("DIGEST_EMAIL_TO") or os.getenv("ALERT_EMAIL_TO"))
+    if not sender:
+        return DeliveryResult(
+            channel="email", success=True, skipped=True, error_message="DIGEST_EMAIL_FROM is not configured"
+        )
+    if not recipients:
+        return DeliveryResult(
+            channel="email", success=True, skipped=True, error_message="DIGEST_EMAIL_TO is not configured"
+        )
+
+    provider = (os.getenv("DIGEST_EMAIL_PROVIDER") or os.getenv("ALERT_EMAIL_PROVIDER") or "smtp").lower()
+    if provider == "sendgrid":
+        api_key = os.getenv("SENDGRID_API_KEY")
+        if not api_key:
+            return DeliveryResult(
+                channel="email", success=True, skipped=True, error_message="SENDGRID_API_KEY is not configured"
+            )
+        payload = {
+            "personalizations": [{"to": [{"email": recipient} for recipient in recipients]}],
+            "from": {"email": sender},
+            "subject": f"Manager activity digest ({digest.lookback_hours}h)",
+            "content": [
+                {"type": "text/plain", "value": render_digest_plain_text(digest)},
+                {"type": "text/html", "value": render_digest_html(digest)},
+            ],
+        }
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                "https://api.sendgrid.com/v3/mail/send",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json=payload,
+            )
+        if response.status_code not in (200, 202):
+            return DeliveryResult(
+                channel="email",
+                success=False,
+                error_message=f"SendGrid digest delivery failed: HTTP {response.status_code}",
+            )
+        return DeliveryResult(channel="email", success=True)
+
+    smtp_host = (os.getenv("SMTP_HOST") or "").strip()
+    if not smtp_host:
+        return DeliveryResult(
+            channel="email", success=True, skipped=True, error_message="SMTP_HOST is not configured"
+        )
+    message = build_digest_email_message(digest, sender=sender, recipients=recipients)
+    await asyncio.to_thread(
+        _send_via_smtp,
+        message,
+        host=smtp_host,
+        port=int(os.getenv("SMTP_PORT", "587")),
+        username=os.getenv("SMTP_USER"),
+        password=os.getenv("SMTP_PASSWORD"),
+        use_tls=os.getenv("ALERT_EMAIL_USE_TLS", "true").strip().lower() != "false",
+        timeout_seconds=10.0,
+    )
+    return DeliveryResult(channel="email", success=True)
+
+
+@flow
+async def digest_flow(
+    db_path: str | None = None,
+    lookback_hours: int | None = None,
+    dry_run: bool | None = None,
+    output_path: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build and optionally deliver the automated analyst digest."""
+    resolved_lookback = lookback_hours or int(os.getenv("DIGEST_LOOKBACK_HOURS", "24"))
+    resolved_dry_run = (
+        os.getenv("DIGEST_DRY_RUN", "true").strip().lower() != "false"
+        if dry_run is None
+        else dry_run
+    )
+    conn = connect_db(db_path)
+    try:
+        digest = build_digest.fn(conn, resolved_lookback, now)
+    finally:
+        conn.close()
+
+    rendered = render_digest_plain_text(digest)
+    resolved_output = output_path or os.getenv("DIGEST_OUTPUT_PATH")
+    if resolved_output:
+        Path(resolved_output).write_text(rendered, encoding="utf-8")
+
+    delivery = await deliver_digest_email(digest, dry_run=resolved_dry_run)
+    log_outcome(
+        logger,
+        "Digest flow completed",
+        has_data=not digest.is_empty,
+        extra={
+            "lookback_hours": resolved_lookback,
+            "filings": len(digest.filings),
+            "news": len(digest.news),
+            "alerts": len(digest.alerts),
+            "dry_run": resolved_dry_run,
+            "delivery_skipped": delivery.skipped,
+        },
+    )
+    return {
+        "lookback_hours": resolved_lookback,
+        "filings": len(digest.filings),
+        "news": len(digest.news),
+        "alerts": len(digest.alerts),
+        "empty": digest.is_empty,
+        "dry_run": resolved_dry_run,
+        "delivery": {
+            "channel": delivery.channel,
+            "success": delivery.success,
+            "skipped": delivery.skipped,
+            "error_message": delivery.error_message,
+        },
+        "rendered": rendered,
+    }
+
+
+digest_deployment = digest_flow.to_deployment(name="manager-digest-daily", cron="0 13 * * *")
+
+
+if __name__ == "__main__":
+    asyncio.run(digest_flow())

--- a/tests/test_digest_flow.py
+++ b/tests/test_digest_flow.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+
+import pytest
+
+from alerts.db import ensure_alert_tables, serialize_json
+from etl import digest_flow
+
+
+def _seed_digest_db(conn: sqlite3.Connection) -> None:
+    conn.execute("CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+    conn.execute(
+        """CREATE TABLE filings (
+            filing_id INTEGER PRIMARY KEY,
+            manager_id INTEGER NOT NULL,
+            type TEXT NOT NULL,
+            filed_date TEXT,
+            source TEXT NOT NULL,
+            url TEXT,
+            created_at TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE news_items (
+            news_id INTEGER PRIMARY KEY,
+            manager_id INTEGER,
+            published_at TEXT NOT NULL,
+            source TEXT NOT NULL,
+            headline TEXT NOT NULL,
+            url TEXT,
+            body_snippet TEXT,
+            topics TEXT DEFAULT '[]',
+            confidence REAL
+        )"""
+    )
+    conn.execute("INSERT INTO managers(manager_id, name) VALUES (1, 'Alpha Capital')")
+    conn.execute(
+        """INSERT INTO filings(filing_id, manager_id, type, filed_date, source, url, created_at)
+           VALUES (10, 1, '13F-HR', '2026-05-08', 'edgar', 'https://filing.test/10',
+                   '2026-05-08T20:00:00+00:00')"""
+    )
+    conn.execute(
+        """INSERT INTO news_items(news_id, manager_id, published_at, source, headline, url)
+           VALUES (20, 1, '2026-05-08T21:00:00+00:00', 'rss',
+                   'Alpha Capital opens new office', 'https://news.test/20')"""
+    )
+    ensure_alert_tables(conn)
+    conn.execute(
+        """INSERT INTO alert_rules(rule_id, name, event_type, condition_json, channels,
+                                   enabled, manager_id, created_by)
+           VALUES (30, 'Large filing alert', 'new_filing', '{}', '["streamlit"]', 1, 1, 'test')"""
+    )
+    conn.execute(
+        """INSERT INTO alert_history(alert_id, rule_id, fired_at, event_type, payload_json,
+                                     delivered_channels, acknowledged)
+           VALUES (40, 30, '2026-05-08T22:00:00+00:00', 'new_filing', ?, '[]', 0)""",
+        (serialize_json({"summary": "New 13F received", "type": "13F-HR"}),),
+    )
+    conn.commit()
+
+
+def test_build_digest_collects_recent_filings_news_and_alerts():
+    conn = sqlite3.connect(":memory:")
+    try:
+        _seed_digest_db(conn)
+        digest = digest_flow.build_digest.fn(
+            conn,
+            lookback_hours=24,
+            now=datetime(2026, 5, 9, 0, 0, tzinfo=UTC),
+        )
+    finally:
+        conn.close()
+
+    assert digest.is_empty is False
+    assert digest.filings[0].manager_name == "Alpha Capital"
+    assert digest.filings[0].filing_type == "13F-HR"
+    assert digest.news[0].headline == "Alpha Capital opens new office"
+    assert digest.news[0].source == "rss"
+    assert digest.alerts[0].rule_name == "Large filing alert"
+    assert digest.alerts[0].summary == "New 13F received"
+
+    text = digest_flow.render_digest_plain_text(digest)
+    assert "Alpha Capital: 13F-HR filed 2026-05-08 via edgar" in text
+    assert "Alpha Capital opens new office" in text
+    assert "New 13F received" in text
+
+
+def test_build_digest_empty_when_window_has_no_activity():
+    conn = sqlite3.connect(":memory:")
+    try:
+        _seed_digest_db(conn)
+        digest = digest_flow.build_digest.fn(
+            conn,
+            lookback_hours=24,
+            now=datetime(2026, 5, 12, 0, 0, tzinfo=UTC),
+        )
+    finally:
+        conn.close()
+
+    assert digest.is_empty is True
+    assert "No filings" in digest_flow.render_digest_plain_text(digest)
+    assert "No filings" in digest_flow.render_digest_html(digest)
+
+
+@pytest.mark.asyncio
+async def test_digest_flow_dry_run_skips_delivery_without_credentials(monkeypatch, tmp_path):
+    db_path = tmp_path / "digest.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        _seed_digest_db(conn)
+    finally:
+        conn.close()
+
+    monkeypatch.delenv("ALERT_EMAIL_FROM", raising=False)
+    monkeypatch.delenv("ALERT_EMAIL_TO", raising=False)
+    output_path = tmp_path / "digest.txt"
+
+    result = await digest_flow.digest_flow.fn(
+        db_path=str(db_path),
+        lookback_hours=24,
+        dry_run=True,
+        output_path=str(output_path),
+        now=datetime(2026, 5, 9, 0, 0, tzinfo=UTC),
+    )
+
+    assert result["filings"] == 1
+    assert result["news"] == 1
+    assert result["alerts"] == 1
+    assert result["delivery"] == {
+        "channel": "email",
+        "success": True,
+        "skipped": True,
+        "error_message": "dry-run",
+    }
+    assert "Alpha Capital" in output_path.read_text(encoding="utf-8")

--- a/tests/test_digest_flow.py
+++ b/tests/test_digest_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import UTC, datetime
 
+import httpx
 import pytest
 
 from alerts.db import ensure_alert_tables, serialize_json
@@ -11,8 +12,7 @@ from etl import digest_flow
 
 def _seed_digest_db(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
-    conn.execute(
-        """CREATE TABLE filings (
+    conn.execute("""CREATE TABLE filings (
             filing_id INTEGER PRIMARY KEY,
             manager_id INTEGER NOT NULL,
             type TEXT NOT NULL,
@@ -20,10 +20,8 @@ def _seed_digest_db(conn: sqlite3.Connection) -> None:
             source TEXT NOT NULL,
             url TEXT,
             created_at TEXT
-        )"""
-    )
-    conn.execute(
-        """CREATE TABLE news_items (
+        )""")
+    conn.execute("""CREATE TABLE news_items (
             news_id INTEGER PRIMARY KEY,
             manager_id INTEGER,
             published_at TEXT NOT NULL,
@@ -33,25 +31,20 @@ def _seed_digest_db(conn: sqlite3.Connection) -> None:
             body_snippet TEXT,
             topics TEXT DEFAULT '[]',
             confidence REAL
-        )"""
-    )
+        )""")
     conn.execute("INSERT INTO managers(manager_id, name) VALUES (1, 'Alpha Capital')")
     conn.execute(
         """INSERT INTO filings(filing_id, manager_id, type, filed_date, source, url, created_at)
            VALUES (10, 1, '13F-HR', '2026-05-08', 'edgar', 'https://filing.test/10',
                    '2026-05-08T20:00:00+00:00')"""
     )
-    conn.execute(
-        """INSERT INTO news_items(news_id, manager_id, published_at, source, headline, url)
+    conn.execute("""INSERT INTO news_items(news_id, manager_id, published_at, source, headline, url)
            VALUES (20, 1, '2026-05-08T21:00:00+00:00', 'rss',
-                   'Alpha Capital opens new office', 'https://news.test/20')"""
-    )
+                   'Alpha Capital opens new office', 'https://news.test/20')""")
     ensure_alert_tables(conn)
-    conn.execute(
-        """INSERT INTO alert_rules(rule_id, name, event_type, condition_json, channels,
+    conn.execute("""INSERT INTO alert_rules(rule_id, name, event_type, condition_json, channels,
                                    enabled, manager_id, created_by)
-           VALUES (30, 'Large filing alert', 'new_filing', '{}', '["streamlit"]', 1, 1, 'test')"""
-    )
+           VALUES (30, 'Large filing alert', 'new_filing', '{}', '["streamlit"]', 1, 1, 'test')""")
     conn.execute(
         """INSERT INTO alert_history(alert_id, rule_id, fired_at, event_type, payload_json,
                                      delivered_channels, acknowledged)
@@ -68,7 +61,7 @@ def test_build_digest_collects_recent_filings_news_and_alerts():
         digest = digest_flow.build_digest.fn(
             conn,
             lookback_hours=24,
-            now=datetime(2026, 5, 9, 0, 0, tzinfo=UTC),
+            now=datetime(2026, 5, 9, 12, 0, tzinfo=UTC),
         )
     finally:
         conn.close()
@@ -104,6 +97,26 @@ def test_build_digest_empty_when_window_has_no_activity():
     assert "No filings" in digest_flow.render_digest_html(digest)
 
 
+def test_build_digest_filters_created_at_without_date_truncation():
+    conn = sqlite3.connect(":memory:")
+    try:
+        _seed_digest_db(conn)
+        conn.execute(
+            """INSERT INTO filings(filing_id, manager_id, type, filed_date, source, url, created_at)
+               VALUES (11, 99, '13D', '2026-05-08', 'edgar', NULL,
+                       '2026-05-08T00:30:00+00:00')"""
+        )
+        digest = digest_flow.build_digest.fn(
+            conn,
+            lookback_hours=24,
+            now=datetime(2026, 5, 9, 12, 0, tzinfo=UTC),
+        )
+    finally:
+        conn.close()
+
+    assert [filing.filing_type for filing in digest.filings] == ["13F-HR"]
+
+
 @pytest.mark.asyncio
 async def test_digest_flow_dry_run_skips_delivery_without_credentials(monkeypatch, tmp_path):
     db_path = tmp_path / "digest.db"
@@ -135,3 +148,35 @@ async def test_digest_flow_dry_run_skips_delivery_without_credentials(monkeypatc
         "error_message": "dry-run",
     }
     assert "Alpha Capital" in output_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_sendgrid_http_errors_return_failed_delivery(monkeypatch):
+    digest = digest_flow.DigestDocument(
+        generated_at=datetime(2026, 5, 9, 0, 0, tzinfo=UTC),
+        lookback_hours=24,
+    )
+
+    class FailingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, *args, **kwargs):
+            raise httpx.ConnectError("offline")
+
+    monkeypatch.setenv("DIGEST_EMAIL_FROM", "alerts@example.test")
+    monkeypatch.setenv("DIGEST_EMAIL_TO", "user@example.test")
+    monkeypatch.setenv("DIGEST_EMAIL_PROVIDER", "sendgrid")
+    monkeypatch.setenv("SENDGRID_API_KEY", "token")
+    monkeypatch.setattr(digest_flow.httpx, "AsyncClient", FailingClient)
+
+    result = await digest_flow.deliver_digest_email(digest)
+
+    assert result.success is False
+    assert result.error_message == "SendGrid digest delivery failed: offline"


### PR DESCRIPTION
Implements #910.\n\n## Summary\n- Add a Prefect digest flow that queries recent filings, manager-linked news, and unacknowledged important alerts.\n- Render deterministic plain-text and HTML digests with dry-run output and SMTP/SendGrid email delivery using existing alert email configuration.\n- Document the local dry-run command and digest email/window configuration.\n\n## Validation\n- python -m pytest tests/test_digest_flow.py tests/test_alert_channels.py tests/test_news_flow.py --no-cov\n- python -m ruff check etl/digest_flow.py tests/test_digest_flow.py\n- python -m compileall -q etl/digest_flow.py tests/test_digest_flow.py\n- git diff --check