### PR TITLE
Follow-up: include live source attribution metric

### DIFF
--- a/etl/evaluation_flow.py
+++ b/etl/evaluation_flow.py
@@ -22,6 +22,7 @@ QUALITY_THRESHOLDS: dict[str, float] = {
     "sql_correctness": 0.85,
     "sql_safety": 1.0,
     "rag_faithfulness": 0.7,
+    "source_attribution": 0.9,
     "hallucination": 0.95,
 }
 EVALUATION_FLOW_CRON = os.getenv("EVALUATION_FLOW_CRON", "0 6 * * 0")
@@ -286,6 +287,11 @@ def build_live_evaluation_datasets(db_conn: sqlite3.Connection) -> dict[str, lis
                 "retrieval_sources": [
                     {"document_id": "doc-live-1", "description": "elliott-apple-note.md"},
                     {"filing_id": 1, "description": "13F-HR filed 2026-03-01"},
+                    {
+                        "news_reference": "Elliott Investment Management increases Apple stake",
+                        "description": "Published 2026-03-02T08:00:00",
+                        "url": "https://example.com/news/1",
+                    },
                 ],
                 "allowed_values": [
                     "Apple Inc",
@@ -339,9 +345,13 @@ def run_evaluation_suite(
             )
         for entry in datasets.get("rag_search", []):
             faithfulness = evaluator.evaluate_rag_faithfulness(entry.get("run", {}), entry)
+            attribution = evaluator.evaluate_rag_source_attribution(entry.get("run", {}), entry)
             hallucination = evaluator.evaluate_hallucination(entry.get("run", {}), entry)
             summary.setdefault("datasets", {}).setdefault("rag_faithfulness", []).append(
                 float(faithfulness.score or 0.0)
+            )
+            summary.setdefault("datasets", {}).setdefault("source_attribution", []).append(
+                float(attribution.score or 0.0)
             )
             summary.setdefault("datasets", {}).setdefault("hallucination", []).append(
                 float(hallucination.score or 0.0)

--- a/llm/evaluation.py
+++ b/llm/evaluation.py
@@ -215,7 +215,7 @@ class ManagerDBEvaluator:
         }
         score = sum(1.0 for passed in checks.values() if passed) / len(checks)
         return EvaluationResult(
-            key="rag_source_attribution",
+            key="source_attribution",
             score=round(score, 3),
             comment=self._comment_from_checks(checks),
             extra={"checks": checks},

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -128,7 +128,9 @@ def test_evaluate_rag_source_attribution_rejects_phantom_sources(tmp_path):
     )
 
     assert good.score == 1.0
+    assert good.key == "source_attribution"
     assert bad.score < 1.0
+    assert bad.key == "source_attribution"
     conn.close()
 
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -199,6 +199,7 @@ def test_live_evaluation_suite_scores_live_chain_outputs(tmp_path):
     assert summary["metrics"]["sql_correctness"] == 1.0
     assert summary["metrics"]["sql_safety"] == 1.0
     assert summary["metrics"]["rag_faithfulness"] == 1.0
+    assert summary["metrics"]["source_attribution"] == 1.0
     assert summary["metrics"]["hallucination"] == 1.0
     assert summary["failures"] == {}
     conn.close()


### PR DESCRIPTION
## Summary
- Adds `source_attribution` to the live/weekly evaluation metric thresholds and summary output.
- Scores RAG source attribution for each `rag_search` evaluation entry.
- Extends the deterministic live evaluation corpus and regression test so the emitted live summary proves source attribution is present.

## Context
Follow-up for verifier CONCERNS on PR #1002 / issue #909. Refs #909.

## Validation
- `python -m pytest tests/test_evaluation.py --no-cov`
- `python -m ruff check etl/evaluation_flow.py tests/test_evaluation.py`
- `python -m black --target-version py312 --check etl/evaluation_flow.py tests/test_evaluation.py`