### PR TITLE
Issue #980: Add dialect portability audit gate

### DIFF
--- a/docs/reports/dialect_portability_audit.md
+++ b/docs/reports/dialect_portability_audit.md
@@ -1,0 +1,66 @@
+# Dialect Portability Audit
+
+Issue: #980
+
+Generated: 2026-05-09
+
+## Summary
+
+The Manager-Database runtime can use SQLite through `DB_PATH` or Postgres through
+`DB_URL`. This audit records production modules that still contain SQLite-only
+DDL or inspection tokens on paths that can share the same backend-flexible
+connection surface. The paired gate, `scripts/check_dialect_portability.py`,
+fails CI when a new non-test module combines `connect_db()` with an unaudited
+SQLite-only token.
+
+Already-covered dispositions:
+
+- `adapters/base.py` `tracked_call` telemetry was made dialect-aware by PR #976.
+- `etl/edgar_flow.py` EDGAR persistence was made dialect-aware by PR #977.
+- `etl/summariser_flow.py` now uses `daily_diffs` and backend-aware placeholders.
+- `schema.sql` bootstrap ordering is covered by PR #978 and the schema idempotence gate.
+
+## Audit Commands
+
+```bash
+rg -n "AUTOINCREMENT|INSERT OR IGNORE|PRAGMA table_info" adapters etl chains alerts api ui llm scripts embeddings.py diff_holdings.py
+rg -n "connect_db\(" adapters etl chains alerts api ui llm scripts embeddings.py diff_holdings.py
+python scripts/check_dialect_portability.py
+```
+
+## Disposition Table
+
+| Surface | Classification | Evidence | Failure Mode Or Justification | Disposition |
+| --- | --- | --- | --- | --- |
+| `embeddings.py` | postgres-incompatible | `AUTOINCREMENT`, `PRAGMA table_info`, `INSERT OR IGNORE`; `connect_db(db_path)` | Document table setup and introspection are SQLite-specific while the helper can receive a Postgres-capable connection path. | Follow-up #1005: `dialect_portability_audit embeddings`. |
+| `chains/holdings_analysis.py` | postgres-incompatible | `AUTOINCREMENT`; imports `connect_db` through chain DB paths | Cache table setup uses SQLite DDL in a chain module that participates in DB-backed analysis flows. | Follow-up #1006: `dialect_portability_audit chains`. |
+| `chains/filing_summary.py` | postgres-incompatible | `AUTOINCREMENT`; imports `connect_db` through chain DB paths | Filing summary cache/setup uses SQLite DDL without a Postgres branch. | Follow-up #1006: `dialect_portability_audit chains`. |
+| `etl/activism_detection.py` | postgres-incompatible | `AUTOINCREMENT`, `INSERT OR IGNORE` | Activism event persistence uses SQLite DDL/upsert syntax on an ETL path that should not assume SQLite. | Follow-up #1007: `dialect_portability_audit etl-activism`. |
+| `etl/activism_flow.py` | postgres-incompatible | `AUTOINCREMENT`; `connect_db(DB_PATH)` | Legacy filing setup is SQLite-only and separate from the EDGAR dialect-aware fix. | Follow-up #1007: `dialect_portability_audit etl-activism`. |
+| `etl/conviction_flow.py` | postgres-incompatible | multiple `AUTOINCREMENT`; `connect_db()` | Conviction score/crowding/signal setup uses SQLite DDL in a backend-flexible ETL flow. | Follow-up #1008: `dialect_portability_audit etl-conviction`. |
+| `etl/ingest_flow.py` | postgres-incompatible | `PRAGMA table_info`, `AUTOINCREMENT`; `connect_db(db_path or DB_PATH)` | Ingest setup still introspects and creates local tables with SQLite-only syntax. | Follow-up #1008: `dialect_portability_audit etl-ingest`. |
+| `etl/evaluation_flow.py` | postgres-incompatible | multiple `AUTOINCREMENT`; `connect_db()` | Evaluation dataset and holding/diff setup use SQLite DDL without a Postgres branch. | Follow-up #1008: `dialect_portability_audit etl-evaluation`. |
+| `etl/daily_diff_flow.py` | dialect-aware | `AUTOINCREMENT`; `connect_db()` | `_ensure_daily_diffs_table` branches on `sqlite3.Connection`; Postgres requires migrations and fails fast if missing. | Allowed by gate. |
+| `etl/digest_flow.py` | dialect-aware | `PRAGMA table_xinfo`; `connect_db(db_path)` | `_columns` first branches on `sqlite3.Connection`; Postgres uses `information_schema.columns`. | Allowed by gate. |
+| `etl/edgar_flow.py` | dialect-aware | `PRAGMA table_xinfo`; `connect_db(DB_PATH)` | `_columns`, placeholders, table setup, filing upsert, and holding inserts branch for SQLite vs Postgres after PR #977. | Fixed by PR #977; allowed by gate. |
+| `alerts/db.py` | postgres-incompatible | `PRAGMA table_info`, `AUTOINCREMENT` | Alert schema setup and introspection are SQLite-only while API alert routes use `connect_db()`. | Follow-up #1009: `dialect_portability_audit alerts`. |
+| `api/chat.py` | postgres-incompatible | `PRAGMA table_info`, `AUTOINCREMENT`; `connect_db()` | Manager introspection and feedback table setup use SQLite-only SQL in the FastAPI app. | Follow-up #1009: `dialect_portability_audit api`. |
+| `api/managers.py` | postgres-incompatible | `AUTOINCREMENT`, `PRAGMA table_info`; `connect_db()` | Manager bootstrap and column introspection use SQLite-only SQL in API routes. | Follow-up #1009: `dialect_portability_audit api`. |
+| `api/search.py` | postgres-incompatible | `PRAGMA table_info`; imports `connect_db` | Dynamic table introspection is SQLite-specific in an API search route. | Follow-up #1009: `dialect_portability_audit api`. |
+| `api/signals.py` | postgres-incompatible | `PRAGMA table_info`; `connect_db()` | Signals routes inspect manager columns through SQLite PRAGMA only. | Follow-up #1009: `dialect_portability_audit api`. |
+| `llm/cost_tracking.py` | postgres-incompatible | `AUTOINCREMENT`; `connect_db()` | Cost tracking table setup uses SQLite DDL despite arbitrary backend selection. | Follow-up #1010: `dialect_portability_audit llm-cost`. |
+| `scripts/seed_universe.py` | postgres-incompatible | `AUTOINCREMENT`, `PRAGMA table_info`; `connect_db()` | Seed helper setup and introspection are SQLite-only but can be run against configured DB. | Follow-up #1010: `dialect_portability_audit scripts`. |
+| `scripts/resolve_aliases.py` | postgres-incompatible | `PRAGMA table_info`; `connect_db(db_path)` | Alias resolution introspection is SQLite-specific and should branch before Postgres usage. | Follow-up #1010: `dialect_portability_audit scripts`. |
+
+## Gate Policy
+
+`scripts/check_dialect_portability.py` is intentionally conservative:
+
+- It scans production Python surfaces only.
+- It only flags modules that define or import `connect_db`.
+- It rejects unaudited `AUTOINCREMENT`, `INSERT OR IGNORE`, and `PRAGMA table_info` or `PRAGMA table_xinfo`.
+- Existing entries in this report are mirrored in the script allowlist so CI stays green while follow-up issues drain the debt.
+
+New code should either use dialect-aware helpers, branch on `sqlite3.Connection`,
+or update this report with a `sqlite-only-by-design` rationale before adding an
+allowlist entry.

--- a/docs/reports/dialect_portability_audit.md
+++ b/docs/reports/dialect_portability_audit.md
@@ -23,7 +23,7 @@ Already-covered dispositions:
 ## Audit Commands
 
 ```bash
-rg -n "AUTOINCREMENT|INSERT OR IGNORE|PRAGMA table_info" adapters etl chains alerts api ui llm scripts embeddings.py diff_holdings.py
+rg -n "AUTOINCREMENT|INSERT OR IGNORE|PRAGMA table_(?:info|xinfo)|execute(?:many)?\\([^#\\n]*(?:SELECT|INSERT|UPDATE|DELETE|VALUES|WHERE)[^#\\n]*\\?|\\bdaily_diff\\b|\\bd\\.change\\b" adapters etl chains alerts api ui llm scripts embeddings.py diff_holdings.py
 rg -n "connect_db\(" adapters etl chains alerts api ui llm scripts embeddings.py diff_holdings.py
 python scripts/check_dialect_portability.py
 ```
@@ -39,7 +39,7 @@ python scripts/check_dialect_portability.py
 | `etl/activism_flow.py` | postgres-incompatible | `AUTOINCREMENT`; `connect_db(DB_PATH)` | Legacy filing setup is SQLite-only and separate from the EDGAR dialect-aware fix. | Follow-up #1007: `dialect_portability_audit etl-activism`. |
 | `etl/conviction_flow.py` | postgres-incompatible | multiple `AUTOINCREMENT`; `connect_db()` | Conviction score/crowding/signal setup uses SQLite DDL in a backend-flexible ETL flow. | Follow-up #1008: `dialect_portability_audit etl-conviction`. |
 | `etl/ingest_flow.py` | postgres-incompatible | `PRAGMA table_info`, `AUTOINCREMENT`; `connect_db(db_path or DB_PATH)` | Ingest setup still introspects and creates local tables with SQLite-only syntax. | Follow-up #1008: `dialect_portability_audit etl-ingest`. |
-| `etl/evaluation_flow.py` | postgres-incompatible | multiple `AUTOINCREMENT`; `connect_db()` | Evaluation dataset and holding/diff setup use SQLite DDL without a Postgres branch. | Follow-up #1008: `dialect_portability_audit etl-evaluation`. |
+| `etl/evaluation_flow.py` | postgres-incompatible | multiple `AUTOINCREMENT`, unconditional `?` placeholders; `connect_db()` | Evaluation dataset and holding/diff setup use SQLite DDL and SQLite placeholders without a Postgres branch. | Follow-up #1008: `dialect_portability_audit etl-evaluation`. |
 | `etl/daily_diff_flow.py` | dialect-aware | `AUTOINCREMENT`; `connect_db()` | `_ensure_daily_diffs_table` branches on `sqlite3.Connection`; Postgres requires migrations and fails fast if missing. | Allowed by gate. |
 | `etl/digest_flow.py` | dialect-aware | `PRAGMA table_xinfo`; `connect_db(db_path)` | `_columns` first branches on `sqlite3.Connection`; Postgres uses `information_schema.columns`. | Allowed by gate. |
 | `etl/edgar_flow.py` | dialect-aware | `PRAGMA table_xinfo`; `connect_db(DB_PATH)` | `_columns`, placeholders, table setup, filing upsert, and holding inserts branch for SQLite vs Postgres after PR #977. | Fixed by PR #977; allowed by gate. |
@@ -58,7 +58,7 @@ python scripts/check_dialect_portability.py
 
 - It scans production Python surfaces only.
 - It only flags modules that define or import `connect_db`.
-- It rejects unaudited `AUTOINCREMENT`, `INSERT OR IGNORE`, and `PRAGMA table_info` or `PRAGMA table_xinfo`.
+- It rejects unaudited `AUTOINCREMENT`, `INSERT OR IGNORE`, `PRAGMA table_info`, `PRAGMA table_xinfo`, direct `execute` / `executemany` calls with unconditional SQLite `?` placeholders, and legacy `daily_diff` / `d.change` schema names.
 - Existing entries in this report are mirrored in the script allowlist so CI stays green while follow-up issues drain the debt.
 
 New code should either use dialect-aware helpers, branch on `sqlite3.Connection`,

--- a/scripts/check_dialect_portability.py
+++ b/scripts/check_dialect_portability.py
@@ -13,7 +13,18 @@ from pathlib import Path
 SQLITE_ONLY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("AUTOINCREMENT", re.compile(r"\bAUTOINCREMENT\b", re.IGNORECASE)),
     ("INSERT OR IGNORE", re.compile(r"\bINSERT\s+OR\s+IGNORE\b", re.IGNORECASE)),
-    ("PRAGMA table_info", re.compile(r"\bPRAGMA\s+table_(?:info|xinfo)\b", re.IGNORECASE)),
+    ("PRAGMA table_info", re.compile(r"\bPRAGMA\s+table_info\b", re.IGNORECASE)),
+    ("PRAGMA table_xinfo", re.compile(r"\bPRAGMA\s+table_xinfo\b", re.IGNORECASE)),
+    (
+        "SQLITE ? placeholder",
+        re.compile(
+            r"\b(?:execute|executemany)\s*\([^#\n]*"
+            r"(?:SELECT|INSERT|UPDATE|DELETE|VALUES|WHERE)[^#\n]*\?",
+            re.IGNORECASE,
+        ),
+    ),
+    ("legacy daily_diff table", re.compile(r"\bdaily_diff\b", re.IGNORECASE)),
+    ("legacy d.change column", re.compile(r"\bd\.change\b", re.IGNORECASE)),
 )
 
 DEFAULT_SCAN_ROOTS = (
@@ -42,9 +53,9 @@ AUDITED_SQLITE_ONLY_ALLOWLIST: dict[str, set[str]] = {
     "etl/activism_flow.py": {"AUTOINCREMENT"},
     "etl/conviction_flow.py": {"AUTOINCREMENT"},
     "etl/daily_diff_flow.py": {"AUTOINCREMENT"},
-    "etl/digest_flow.py": {"PRAGMA table_info"},
-    "etl/edgar_flow.py": {"PRAGMA table_info"},
-    "etl/evaluation_flow.py": {"AUTOINCREMENT"},
+    "etl/digest_flow.py": {"PRAGMA table_xinfo"},
+    "etl/edgar_flow.py": {"PRAGMA table_xinfo"},
+    "etl/evaluation_flow.py": {"AUTOINCREMENT", "SQLITE ? placeholder"},
     "etl/ingest_flow.py": {"AUTOINCREMENT", "PRAGMA table_info"},
     "llm/cost_tracking.py": {"AUTOINCREMENT"},
     "scripts/resolve_aliases.py": {"PRAGMA table_info"},
@@ -89,7 +100,9 @@ def _imports_connect_db(source: str) -> bool:
         return "connect_db(" in source
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
-            if node.module == "adapters.base" and any(alias.name == "connect_db" for alias in node.names):
+            if node.module == "adapters.base" and any(
+                alias.name == "connect_db" for alias in node.names
+            ):
                 return True
         elif isinstance(node, ast.FunctionDef) and node.name == "connect_db":
             return True

--- a/scripts/check_dialect_portability.py
+++ b/scripts/check_dialect_portability.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Reject unaudited SQLite-only SQL on Postgres-capable code paths."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SQLITE_ONLY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("AUTOINCREMENT", re.compile(r"\bAUTOINCREMENT\b", re.IGNORECASE)),
+    ("INSERT OR IGNORE", re.compile(r"\bINSERT\s+OR\s+IGNORE\b", re.IGNORECASE)),
+    ("PRAGMA table_info", re.compile(r"\bPRAGMA\s+table_(?:info|xinfo)\b", re.IGNORECASE)),
+)
+
+DEFAULT_SCAN_ROOTS = (
+    "adapters",
+    "etl",
+    "chains",
+    "alerts",
+    "api",
+    "ui",
+    "llm",
+    "scripts",
+    "embeddings.py",
+    "diff_holdings.py",
+)
+
+AUDITED_SQLITE_ONLY_ALLOWLIST: dict[str, set[str]] = {
+    "alerts/db.py": {"AUTOINCREMENT", "PRAGMA table_info"},
+    "api/chat.py": {"AUTOINCREMENT", "PRAGMA table_info"},
+    "api/managers.py": {"AUTOINCREMENT", "PRAGMA table_info"},
+    "api/search.py": {"PRAGMA table_info"},
+    "api/signals.py": {"PRAGMA table_info"},
+    "chains/filing_summary.py": {"AUTOINCREMENT"},
+    "chains/holdings_analysis.py": {"AUTOINCREMENT"},
+    "embeddings.py": {"AUTOINCREMENT", "INSERT OR IGNORE", "PRAGMA table_info"},
+    "etl/activism_detection.py": {"AUTOINCREMENT", "INSERT OR IGNORE"},
+    "etl/activism_flow.py": {"AUTOINCREMENT"},
+    "etl/conviction_flow.py": {"AUTOINCREMENT"},
+    "etl/daily_diff_flow.py": {"AUTOINCREMENT"},
+    "etl/digest_flow.py": {"PRAGMA table_info"},
+    "etl/edgar_flow.py": {"PRAGMA table_info"},
+    "etl/evaluation_flow.py": {"AUTOINCREMENT"},
+    "etl/ingest_flow.py": {"AUTOINCREMENT", "PRAGMA table_info"},
+    "llm/cost_tracking.py": {"AUTOINCREMENT"},
+    "scripts/resolve_aliases.py": {"PRAGMA table_info"},
+    "scripts/seed_universe.py": {"AUTOINCREMENT", "PRAGMA table_info"},
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    token: str
+    text: str
+
+
+def _relative_path(path: Path, repo_root: Path) -> str:
+    try:
+        return path.relative_to(repo_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _python_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(
+                child
+                for child in path.rglob("*.py")
+                if not any(part in {"tests", "__pycache__", ".venv"} for part in child.parts)
+                and child.name != "check_dialect_portability.py"
+            )
+        elif path.suffix == ".py":
+            files.append(path)
+    return sorted(set(files))
+
+
+def _imports_connect_db(source: str) -> bool:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return "connect_db(" in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "adapters.base" and any(alias.name == "connect_db" for alias in node.names):
+                return True
+        elif isinstance(node, ast.FunctionDef) and node.name == "connect_db":
+            return True
+    return "connect_db(" in source
+
+
+def scan(paths: list[Path], *, repo_root: Path, allowlist: dict[str, set[str]]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in _python_files(paths):
+        source = path.read_text(encoding="utf-8")
+        if not _imports_connect_db(source):
+            continue
+        rel_path = _relative_path(path, repo_root)
+        allowed_tokens = allowlist.get(rel_path, set())
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            for token, pattern in SQLITE_ONLY_PATTERNS:
+                if pattern.search(line) and token not in allowed_tokens:
+                    findings.append(Finding(rel_path, lineno, token, line.strip()))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files or directories to scan. Defaults to production DB-facing surfaces.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root used for allowlist-relative paths.",
+    )
+    parser.add_argument(
+        "--no-allowlist",
+        action="store_true",
+        help="Ignore the audited allowlist; useful for tests.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    raw_paths = args.paths or list(DEFAULT_SCAN_ROOTS)
+    paths = [(repo_root / raw_path).resolve() for raw_path in raw_paths]
+    allowlist = {} if args.no_allowlist else AUDITED_SQLITE_ONLY_ALLOWLIST
+    findings = scan(paths, repo_root=repo_root, allowlist=allowlist)
+    if findings:
+        for finding in findings:
+            print(
+                f"{finding.path}:{finding.line}: unaudited {finding.token}: {finding.text}",
+                file=sys.stderr,
+            )
+        print(
+            "Dialect portability gate failed; classify this path in "
+            "docs/reports/dialect_portability_audit.md before allowing it.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_dialect_portability.py
+++ b/scripts/check_dialect_portability.py
@@ -62,6 +62,8 @@ AUDITED_SQLITE_ONLY_ALLOWLIST: dict[str, set[str]] = {
     "scripts/seed_universe.py": {"AUTOINCREMENT", "PRAGMA table_info"},
 }
 
+AUDIT_REPORT_PATH = Path("docs/reports/dialect_portability_audit.md")
+
 
 @dataclass(frozen=True)
 class Finding:
@@ -124,6 +126,27 @@ def scan(paths: list[Path], *, repo_root: Path, allowlist: dict[str, set[str]]) 
     return findings
 
 
+def documented_audit_paths(audit_report: Path) -> set[str]:
+    """Return audited module paths listed in the disposition table."""
+    if not audit_report.exists():
+        return set()
+
+    paths: set[str] = set()
+    for line in audit_report.read_text(encoding="utf-8").splitlines():
+        match = re.search(r"\|\s*`([^`]+\.py)`\s*\|", line)
+        if match:
+            paths.add(match.group(1))
+    return paths
+
+
+def allowlist_paths_missing_from_audit(
+    *, repo_root: Path, allowlist: dict[str, set[str]]
+) -> list[str]:
+    audited_paths = documented_audit_paths(repo_root / AUDIT_REPORT_PATH)
+    missing = sorted(path for path in allowlist if path not in audited_paths)
+    return missing
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -147,6 +170,23 @@ def main(argv: list[str] | None = None) -> int:
     raw_paths = args.paths or list(DEFAULT_SCAN_ROOTS)
     paths = [(repo_root / raw_path).resolve() for raw_path in raw_paths]
     allowlist = {} if args.no_allowlist else AUDITED_SQLITE_ONLY_ALLOWLIST
+    if allowlist:
+        missing_audit_entries = allowlist_paths_missing_from_audit(
+            repo_root=repo_root,
+            allowlist=allowlist,
+        )
+        if missing_audit_entries:
+            for path in missing_audit_entries:
+                print(
+                    f"allowlist entry missing from audit report: {path}",
+                    file=sys.stderr,
+                )
+            print(
+                f"Update {AUDIT_REPORT_PATH.as_posix()} disposition table before allowlisting new paths.",
+                file=sys.stderr,
+            )
+            return 1
+
     findings = scan(paths, repo_root=repo_root, allowlist=allowlist)
     if findings:
         for finding in findings:

--- a/tests/test_dialect_portability_gate.py
+++ b/tests/test_dialect_portability_gate.py
@@ -53,3 +53,68 @@ def test_dialect_gate_honors_documented_allowlist(tmp_path: Path) -> None:
     findings = scan([module], repo_root=tmp_path, allowlist={"feature.py": {"PRAGMA table_info"}})
 
     assert findings == []
+
+
+def test_dialect_gate_reports_table_xinfo_as_distinct_token(tmp_path: Path) -> None:
+    module = tmp_path / "feature.py"
+    module.write_text(
+        "\n".join(
+            [
+                "from adapters.base import connect_db",
+                "",
+                "def inspect() -> None:",
+                "    conn = connect_db()",
+                "    conn.execute('PRAGMA table_xinfo(managers)')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = scan([module], repo_root=tmp_path, allowlist={})
+
+    assert len(findings) == 1
+    assert findings[0].token == "PRAGMA table_xinfo"
+
+
+def test_dialect_gate_rejects_unconditional_sqlite_placeholder(tmp_path: Path) -> None:
+    module = tmp_path / "feature.py"
+    module.write_text(
+        "\n".join(
+            [
+                "from adapters.base import connect_db",
+                "",
+                "def query() -> None:",
+                "    conn = connect_db()",
+                "    conn.execute('SELECT * FROM managers WHERE cik = ?', ('1',))",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = scan([module], repo_root=tmp_path, allowlist={})
+
+    assert len(findings) == 1
+    assert findings[0].token == "SQLITE ? placeholder"
+
+
+def test_dialect_gate_rejects_legacy_daily_diff_schema_names(tmp_path: Path) -> None:
+    module = tmp_path / "feature.py"
+    module.write_text(
+        "\n".join(
+            [
+                "from adapters.base import connect_db",
+                "",
+                "def query() -> None:",
+                "    conn = connect_db()",
+                "    conn.execute('SELECT d.change FROM daily_diff d')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = scan([module], repo_root=tmp_path, allowlist={})
+
+    assert [finding.token for finding in findings] == [
+        "legacy daily_diff table",
+        "legacy d.change column",
+    ]

--- a/tests/test_dialect_portability_gate.py
+++ b/tests/test_dialect_portability_gate.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_dialect_portability import AUDITED_SQLITE_ONLY_ALLOWLIST, scan
+
+
+def test_dialect_gate_accepts_current_audited_repo_state() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    findings = scan([repo_root], repo_root=repo_root, allowlist=AUDITED_SQLITE_ONLY_ALLOWLIST)
+
+    assert findings == []
+
+
+def test_dialect_gate_rejects_unaudited_sqlite_only_token(tmp_path: Path) -> None:
+    module = tmp_path / "feature.py"
+    module.write_text(
+        "\n".join(
+            [
+                "from adapters.base import connect_db",
+                "",
+                "def migrate() -> None:",
+                "    conn = connect_db()",
+                "    conn.execute('CREATE TABLE x (id INTEGER PRIMARY KEY AUTOINCREMENT)')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = scan([module], repo_root=tmp_path, allowlist={})
+
+    assert len(findings) == 1
+    assert findings[0].path == "feature.py"
+    assert findings[0].token == "AUTOINCREMENT"
+
+
+def test_dialect_gate_honors_documented_allowlist(tmp_path: Path) -> None:
+    module = tmp_path / "feature.py"
+    module.write_text(
+        "\n".join(
+            [
+                "from adapters.base import connect_db",
+                "",
+                "def migrate() -> None:",
+                "    conn = connect_db()",
+                "    conn.execute('PRAGMA table_info(managers)')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = scan([module], repo_root=tmp_path, allowlist={"feature.py": {"PRAGMA table_info"}})
+
+    assert findings == []

--- a/tests/test_dialect_portability_gate.py
+++ b/tests/test_dialect_portability_gate.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.check_dialect_portability import AUDITED_SQLITE_ONLY_ALLOWLIST, scan
+from scripts.check_dialect_portability import (
+    AUDITED_SQLITE_ONLY_ALLOWLIST,
+    allowlist_paths_missing_from_audit,
+    scan,
+)
 
 
 def test_dialect_gate_accepts_current_audited_repo_state() -> None:
@@ -118,3 +122,52 @@ def test_dialect_gate_rejects_legacy_daily_diff_schema_names(tmp_path: Path) -> 
         "legacy daily_diff table",
         "legacy d.change column",
     ]
+
+
+def test_allowlist_paths_missing_from_audit_reports_missing_entry(tmp_path: Path) -> None:
+    report = tmp_path / "docs" / "reports" / "dialect_portability_audit.md"
+    report.parent.mkdir(parents=True)
+    report.write_text(
+        "\n".join(
+            [
+                "# Dialect Portability Audit",
+                "",
+                "| Surface | Classification | Evidence | Failure Mode Or Justification | Disposition |",
+                "| --- | --- | --- | --- | --- |",
+                "| `api/chat.py` | postgres-incompatible | `PRAGMA table_info` | sample | Follow-up #1009 |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    missing = allowlist_paths_missing_from_audit(
+        repo_root=tmp_path,
+        allowlist={"api/chat.py": {"PRAGMA table_info"}, "api/search.py": {"PRAGMA table_info"}},
+    )
+
+    assert missing == ["api/search.py"]
+
+
+def test_allowlist_paths_missing_from_audit_accepts_documented_entries(tmp_path: Path) -> None:
+    report = tmp_path / "docs" / "reports" / "dialect_portability_audit.md"
+    report.parent.mkdir(parents=True)
+    report.write_text(
+        "\n".join(
+            [
+                "# Dialect Portability Audit",
+                "",
+                "| Surface | Classification | Evidence | Failure Mode Or Justification | Disposition |",
+                "| --- | --- | --- | --- | --- |",
+                "| `api/chat.py` | postgres-incompatible | `PRAGMA table_info` | sample | Follow-up #1009 |",
+                "| `api/search.py` | postgres-incompatible | `PRAGMA table_info` | sample | Follow-up #1009 |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    missing = allowlist_paths_missing_from_audit(
+        repo_root=tmp_path,
+        allowlist={"api/chat.py": {"PRAGMA table_info"}, "api/search.py": {"PRAGMA table_info"}},
+    )
+
+    assert missing == []


### PR DESCRIPTION
Implements #980

## Summary
- add `docs/reports/dialect_portability_audit.md` with the SQLite/Postgres portability classification and dispositions
- add `scripts/check_dialect_portability.py` plus pytest coverage so new unaudited SQLite-only SQL on `connect_db()` paths fails CI
- file dormant follow-up issues #1005, #1006, #1007, #1008, #1009, and #1010 without `agent:*` issue labels

## Validation
- `python scripts/check_dialect_portability.py`
- `python -m pytest tests/test_dialect_portability_gate.py --no-cov`
- `python -m ruff check docs/reports/dialect_portability_audit.md scripts/check_dialect_portability.py tests/test_dialect_portability_gate.py`
- `git diff --check`
