### PR TITLE
Issue #1005: Make embeddings persistence dialect-aware

### DIFF
--- a/docs/reports/dialect_portability_audit.md
+++ b/docs/reports/dialect_portability_audit.md
@@ -32,7 +32,7 @@ python scripts/check_dialect_portability.py
 
 | Surface | Classification | Evidence | Failure Mode Or Justification | Disposition |
 | --- | --- | --- | --- | --- |
-| `embeddings.py` | postgres-incompatible | `AUTOINCREMENT`, `PRAGMA table_info`, `INSERT OR IGNORE`; `connect_db(db_path)` | Document table setup and introspection are SQLite-specific while the helper can receive a Postgres-capable connection path. | Follow-up #1005: `dialect_portability_audit embeddings`. |
+| `embeddings.py` | dialect-aware | SQLite table setup, column introspection, and duplicate handling avoid audited SQLite-only tokens; Postgres paths use `bigserial`, `information_schema`-free inserts/searches, `%s` placeholders, and `ON CONFLICT`. | Follow-up #1005 resolved: `python scripts/check_dialect_portability.py --no-allowlist embeddings.py` now passes. | Allowed by gate without an allowlist entry. |
 | `chains/holdings_analysis.py` | postgres-incompatible | `AUTOINCREMENT`; imports `connect_db` through chain DB paths | Cache table setup uses SQLite DDL in a chain module that participates in DB-backed analysis flows. | Follow-up #1006: `dialect_portability_audit chains`. |
 | `chains/filing_summary.py` | postgres-incompatible | `AUTOINCREMENT`; imports `connect_db` through chain DB paths | Filing summary cache/setup uses SQLite DDL without a Postgres branch. | Follow-up #1006: `dialect_portability_audit chains`. |
 | `etl/activism_detection.py` | postgres-incompatible | `AUTOINCREMENT`, `INSERT OR IGNORE` | Activism event persistence uses SQLite DDL/upsert syntax on an ETL path that should not assume SQLite. | Follow-up #1007: `dialect_portability_audit etl-activism`. |

--- a/embeddings.py
+++ b/embeddings.py
@@ -49,7 +49,7 @@ def embed_text(text: str) -> list[float]:
 
 
 def _is_postgres_connection(conn: Any) -> bool:
-    return conn.__class__.__name__ == "Connection" and hasattr(conn, "info")
+    return not isinstance(conn, sqlite3.Connection)
 
 
 def _sqlite_columns(conn: sqlite3.Connection, table: str) -> set[str]:

--- a/embeddings.py
+++ b/embeddings.py
@@ -7,6 +7,7 @@ import heapq
 import json
 import math
 import os
+import sqlite3
 from collections import Counter
 from typing import Any
 
@@ -47,6 +48,20 @@ def embed_text(text: str) -> list[float]:
     return vec.tolist()
 
 
+def _is_postgres_connection(conn: Any) -> bool:
+    return conn.__class__.__name__ == "Connection" and hasattr(conn, "info")
+
+
+def _sqlite_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        cursor = conn.execute(f"SELECT * FROM {table} LIMIT 0")
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return set()
+        raise
+    return {str(column[0]) for column in cursor.description or ()}
+
+
 def store_document(
     text: str,
     db_path: str | None = None,
@@ -67,7 +82,7 @@ def store_document(
         doc_id of the inserted/existing document
     """
     conn = connect_db(db_path)
-    is_pg = conn.__class__.__name__ == "Connection" and hasattr(conn, "info")
+    is_pg = _is_postgres_connection(conn)
     sha256 = hashlib.sha256(text.encode("utf-8")).hexdigest()
     if is_pg:
         if register_vector:
@@ -110,7 +125,7 @@ def store_document(
             doc_id = int(existing[0])
     else:
         conn.execute("""CREATE TABLE IF NOT EXISTS documents (
-                doc_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                doc_id INTEGER PRIMARY KEY,
                 manager_id INTEGER,
                 kind TEXT NOT NULL DEFAULT 'note',
                 filename TEXT,
@@ -119,7 +134,7 @@ def store_document(
                 embedding TEXT,
                 created_at TEXT DEFAULT (datetime('now'))
             )""")
-        columns = {row[1] for row in conn.execute("PRAGMA table_info(documents)").fetchall()}
+        columns = _sqlite_columns(conn, "documents")
         id_col = "doc_id" if "doc_id" in columns else "id"
         text_col = "text" if "text" in columns else "content"
         if "sha256" in columns:
@@ -147,11 +162,15 @@ def store_document(
         insert_cols.append("embedding")
         insert_values.append(emb)
         placeholders = ",".join("?" for _ in insert_cols)
-        insert_verb = "INSERT OR IGNORE" if "sha256" in columns else "INSERT"
-        cur = conn.execute(
-            f"{insert_verb} INTO documents({', '.join(insert_cols)}) VALUES ({placeholders})",
-            insert_values,
-        )
+        cur = None
+        try:
+            cur = conn.execute(
+                f"INSERT INTO documents({', '.join(insert_cols)}) VALUES ({placeholders})",
+                insert_values,
+            )
+        except sqlite3.IntegrityError:
+            if "sha256" not in columns:
+                raise
         if "sha256" in columns:
             existing = conn.execute(
                 f"SELECT {id_col} FROM documents WHERE sha256 = ?",
@@ -177,10 +196,13 @@ def search_documents(
     if k <= 0:
         return []
     conn = connect_db(db_path)
-    is_pg = conn.__class__.__name__ == "Connection" and hasattr(conn, "info")
-    if is_pg and register_vector:
-        register_vector(conn)
-        qvec = Vector(embed_text(query))
+    is_pg = _is_postgres_connection(conn)
+    if is_pg:
+        if register_vector:
+            register_vector(conn)
+            qvec = Vector(embed_text(query))
+        else:
+            qvec = embed_text(query)
         where_clause = ""
         params: list[Any] = [qvec]
         if manager_id is not None:
@@ -210,22 +232,17 @@ def search_documents(
         ]
     # Process documents one at a time to avoid loading entire dataset into memory
     # Use a heap to keep only top k results, bounding memory to O(k) instead of O(n)
-    columns = {row[1] for row in conn.execute("PRAGMA table_info(documents)").fetchall()}
+    columns = _sqlite_columns(conn, "documents")
     if not columns:
         conn.close()
         return []
     id_col = "doc_id" if "doc_id" in columns else "id"
     text_col = "text" if "text" in columns else "content"
     has_manager_id = "manager_id" in columns
-    manager_table_exists = bool(
-        conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='managers'"
-        ).fetchone()
-    )
     manager_pk_col = None
     manager_columns: set[str] = set()
-    if has_manager_id and manager_table_exists:
-        manager_columns = {row[1] for row in conn.execute("PRAGMA table_info(managers)").fetchall()}
+    if has_manager_id:
+        manager_columns = _sqlite_columns(conn, "managers")
         if "manager_id" in manager_columns:
             manager_pk_col = "manager_id"
         elif "id" in manager_columns:

--- a/scripts/check_dialect_portability.py
+++ b/scripts/check_dialect_portability.py
@@ -48,7 +48,6 @@ AUDITED_SQLITE_ONLY_ALLOWLIST: dict[str, set[str]] = {
     "api/signals.py": {"PRAGMA table_info"},
     "chains/filing_summary.py": {"AUTOINCREMENT"},
     "chains/holdings_analysis.py": {"AUTOINCREMENT"},
-    "embeddings.py": {"AUTOINCREMENT", "INSERT OR IGNORE", "PRAGMA table_info"},
     "etl/activism_detection.py": {"AUTOINCREMENT", "INSERT OR IGNORE"},
     "etl/activism_flow.py": {"AUTOINCREMENT"},
     "etl/conviction_flow.py": {"AUTOINCREMENT"},

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -5,6 +5,14 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from embeddings import embed_text, search_documents, store_document
+from scripts.check_dialect_portability import scan
+
+
+def _assert_postgres_safe(sql: str) -> None:
+    forbidden = ("AUTOINCREMENT", "INSERT OR IGNORE", "PRAGMA")
+    upper_sql = sql.upper()
+    assert not any(token in upper_sql for token in forbidden), sql
+    assert "?" not in sql, sql
 
 
 def test_store_document_with_metadata_populates_columns(tmp_path, monkeypatch):
@@ -227,6 +235,7 @@ def test_store_and_search_pgvector(monkeypatch):
             self.closed = False
 
         def execute(self, sql, params=None):
+            _assert_postgres_safe(sql)
             self.executed.append((sql, params))
             if sql.startswith("SELECT doc_id FROM documents WHERE sha256"):
                 return type("Result", (), {"fetchone": lambda self: None})()
@@ -282,6 +291,7 @@ def test_store_document_pgvector_conflict_returns_existing(monkeypatch):
             self.closed = False
 
         def execute(self, sql, params=None):
+            _assert_postgres_safe(sql)
             self.executed.append((sql, params))
             if sql.startswith("INSERT INTO documents"):
                 return type("Result", (), {"fetchone": lambda self: None})()
@@ -309,3 +319,55 @@ def test_store_document_pgvector_conflict_returns_existing(monkeypatch):
     )
     assert conn.committed is True
     assert conn.closed is True
+
+
+def test_search_documents_postgres_without_registered_vector_uses_percent_placeholders(
+    monkeypatch,
+):
+    class Connection:
+        def __init__(self):
+            self.info = object()
+            self.executed = []
+            self.closed = False
+
+        def execute(self, sql, params=None):
+            _assert_postgres_safe(sql)
+            self.executed.append((sql, params))
+            if sql.startswith("SELECT d.doc_id"):
+                return type(
+                    "Result",
+                    (),
+                    {"fetchall": lambda self: [(7, "alpha", "memo", None, None, 0.25)]},
+                )()
+            return type("Result", (), {"fetchall": lambda self: []})()
+
+        def close(self):
+            self.closed = True
+
+    conn = Connection()
+    monkeypatch.setattr("embeddings.connect_db", lambda _path=None: conn)
+    monkeypatch.setattr("embeddings.register_vector", None)
+    monkeypatch.setattr("embeddings.embed_text", lambda _text: [0.1, 0.9])
+
+    results = search_documents("alpha", "ignored.db", k=1, manager_id=99)
+
+    assert results == [
+        {
+            "doc_id": 7,
+            "content": "alpha",
+            "kind": "memo",
+            "filename": None,
+            "manager_name": None,
+            "distance": 0.25,
+        }
+    ]
+    assert conn.executed[0][1] == ([0.1, 0.9], 99, 1)
+    assert conn.closed is True
+
+
+def test_embeddings_pass_dialect_gate_without_allowlist() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    findings = scan([repo_root / "embeddings.py"], repo_root=repo_root, allowlist={})
+
+    assert findings == []

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from embeddings import embed_text, search_documents, store_document
+from embeddings import _is_postgres_connection, embed_text, search_documents, store_document
 from scripts.check_dialect_portability import scan
 
 
@@ -224,6 +224,19 @@ def test_embed_text_uses_model_when_available(monkeypatch):
     monkeypatch.delenv("USE_SIMPLE_EMBED", raising=False)
     monkeypatch.setattr("embeddings.MODEL", FakeModel())
     assert embed_text("hello") == [1.0, 2.0]
+
+
+def test_connection_dialect_detection_matches_adapter_branching(tmp_path):
+    sqlite_conn = sqlite3.connect(tmp_path / "dev.db")
+
+    class WrappedPostgresConnection:
+        pass
+
+    try:
+        assert _is_postgres_connection(sqlite_conn) is False
+        assert _is_postgres_connection(WrappedPostgresConnection()) is True
+    finally:
+        sqlite_conn.close()
 
 
 def test_store_and_search_pgvector(monkeypatch):


### PR DESCRIPTION
Closes #1005.\n\n## Summary\n- Remove audited SQLite-only SQL tokens from embeddings persistence while preserving SQLite document storage/search behavior.\n- Keep Postgres embedding search on the Postgres path even when pgvector registration is unavailable, using %s placeholders.\n- Remove embeddings.py from the dialect portability allowlist and mark the audit row resolved.\n\n## Validation\n- python scripts/check_dialect_portability.py --no-allowlist embeddings.py\n- python -m pytest tests/test_embeddings.py tests/test_dialect_portability_gate.py --no-cov\n- python -m ruff check embeddings.py tests/test_embeddings.py scripts/check_dialect_portability.py docs/reports/dialect_portability_audit.md\n- python -m black --target-version py312 --check embeddings.py tests/test_embeddings.py scripts/check_dialect_portability.py\n- git diff --check