### PR TITLE
Issue #1032: Add Postgres chain integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,32 @@ jobs:
       coverage: true
       coverage-min: '78'
     secrets: inherit
+
+  postgres-integration:
+    name: Postgres chain integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      MGRDB_PG_TEST_URL: postgresql://postgres:postgres@localhost:5432/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install test dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Run Postgres chain integration tests
+        run: pytest tests/test_chain_postgres_integration.py -v

--- a/chains/holdings_analysis.py
+++ b/chains/holdings_analysis.py
@@ -358,13 +358,26 @@ class HoldingsAnalysisChain:
         except Exception:
             sections.extend(["", "Changes:", "No prior-period changes available."])
 
+        conviction_where_parts: list[str] = []
+        conviction_params: list[Any] = []
+        if manager_ids:
+            in_sql = ", ".join([placeholder] * len(manager_ids))
+            conviction_where_parts.append(f"manager_id IN ({in_sql})")
+            conviction_params.extend(manager_ids)
+        if date_range is not None:
+            conviction_where_parts.append(f"computed_at BETWEEN {placeholder} AND {placeholder}")
+            conviction_params.extend([date_range[0], date_range[1]])
+        conviction_where_sql = (
+            " AND ".join(conviction_where_parts) if conviction_where_parts else "1=1"
+        )
+
         try:
             conviction_query = (
                 "SELECT * FROM conviction_scores "
-                f"WHERE {where_sql} "
+                f"WHERE {conviction_where_sql} "
                 "ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
             )
-            conviction = self._execute_fetchall(conviction_query, tuple(where_params))
+            conviction = self._execute_fetchall(conviction_query, tuple(conviction_params))
             if conviction:
                 sections.extend(
                     ["", "Conviction Scores:", json.dumps(conviction[:20], default=str)]

--- a/chains/holdings_analysis.py
+++ b/chains/holdings_analysis.py
@@ -187,6 +187,19 @@ class HoldingsAnalysisChain:
         rows = cursor.fetchall()
         return self._cursor_rows_to_dicts(cursor, rows)
 
+    def _rollback_after_recoverable_error(self) -> None:
+        # Postgres aborts the current transaction on the first failing statement and
+        # refuses further commands until rollback. The context-build queries below
+        # tolerate schema mismatches and fall back to alternative shapes, so we must
+        # clear the aborted transaction before the next query. SQLite tolerates this
+        # but rollback is a safe no-op on SELECT-only chain work.
+        rollback = getattr(self.db, "rollback", None)
+        if callable(rollback):
+            try:
+                rollback()
+            except Exception:
+                pass
+
     def _build_holdings_query(
         self,
         *,
@@ -278,6 +291,7 @@ class HoldingsAnalysisChain:
                 self._is_missing_table_error(exc, "filings") or self._is_missing_column_error(exc)
             ):
                 raise
+            self._rollback_after_recoverable_error()
 
         direct_query, direct_params = self._build_holdings_query(
             manager_ids=manager_ids,
@@ -290,6 +304,7 @@ class HoldingsAnalysisChain:
         except Exception as exc:
             if not self._is_missing_column_error(exc):
                 raise
+            self._rollback_after_recoverable_error()
 
         no_date_query, no_date_params = self._build_holdings_query_without_report_date(
             manager_ids=manager_ids,
@@ -352,10 +367,12 @@ class HoldingsAnalysisChain:
                     break
                 except Exception as exc:
                     if self._is_missing_column_error(exc):
+                        self._rollback_after_recoverable_error()
                         continue
                     raise
             sections.extend(["", "Changes:", format_delta_summary(diffs)])
         except Exception:
+            self._rollback_after_recoverable_error()
             sections.extend(["", "Changes:", "No prior-period changes available."])
 
         conviction_where_parts: list[str] = []
@@ -388,6 +405,7 @@ class HoldingsAnalysisChain:
                 or self._is_missing_column_error(exc)
             ):
                 raise
+            self._rollback_after_recoverable_error()
 
         overlap_attempts: list[tuple[str, tuple[Any, ...]]] = []
 
@@ -434,6 +452,7 @@ class HoldingsAnalysisChain:
                     break
                 except Exception as exc:
                     if self._is_missing_column_error(exc):
+                        self._rollback_after_recoverable_error()
                         continue
                     raise
             if overlap:
@@ -441,7 +460,7 @@ class HoldingsAnalysisChain:
                     ["", "Cross-Manager Overlap:", json.dumps(overlap[:20], default=str)]
                 )
         except Exception:
-            pass
+            self._rollback_after_recoverable_error()
 
         return truncate_context("\n".join(sections), max_tokens=4000)
 

--- a/chains/holdings_analysis.py
+++ b/chains/holdings_analysis.py
@@ -362,7 +362,7 @@ class HoldingsAnalysisChain:
             conviction_query = (
                 "SELECT * FROM conviction_scores "
                 f"WHERE {where_sql} "
-                "ORDER BY report_date DESC, conviction_score DESC LIMIT 50"
+                "ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
             )
             conviction = self._execute_fetchall(conviction_query, tuple(where_params))
             if conviction:
@@ -370,7 +370,10 @@ class HoldingsAnalysisChain:
                     ["", "Conviction Scores:", json.dumps(conviction[:20], default=str)]
                 )
         except Exception as exc:
-            if not self._is_missing_table_error(exc, "conviction_scores"):
+            if not (
+                self._is_missing_table_error(exc, "conviction_scores")
+                or self._is_missing_column_error(exc)
+            ):
                 raise
 
         overlap_attempts: list[tuple[str, tuple[Any, ...]]] = []

--- a/tests/test_chain_postgres_integration.py
+++ b/tests/test_chain_postgres_integration.py
@@ -179,6 +179,33 @@ def _seed_chain_fixtures(conn: Any) -> dict[str, int]:
         )
         cur.execute(
             """
+            INSERT INTO conviction_scores(
+                manager_id,
+                filing_id,
+                cusip,
+                name_of_issuer,
+                shares,
+                value_usd,
+                conviction_pct,
+                portfolio_weight,
+                computed_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                manager_id,
+                filing_id,
+                SEEDED_CUSIP,
+                "Apple Inc.",
+                1000,
+                150000.0,
+                0.8125,
+                1.0,
+                "2026-04-16T00:00:00Z",
+            ),
+        )
+        cur.execute(
+            """
             INSERT INTO news_items(manager_id, published_at, source, headline, url, body_snippet)
             VALUES (%s, %s, %s, %s, %s, %s)
             """,
@@ -242,6 +269,13 @@ def test_holdings_analysis_postgres(pg_conn: PgFixture) -> None:
         model="test-model",
     )
     chain = HoldingsAnalysisChain(client_info=client, db_conn=pg_conn.conn)
+
+    context = chain._build_data_context(
+        manager_ids=[seed["manager_id"]],
+        date_range=(date(2026, 1, 1), date(2026, 12, 31)),
+    )
+    assert "Conviction Scores:" in context
+    assert "conviction_pct" in context
 
     result = chain.run(
         "Top positions",

--- a/tests/test_chain_postgres_integration.py
+++ b/tests/test_chain_postgres_integration.py
@@ -1,0 +1,257 @@
+"""Postgres-backed integration tests for chain query paths.
+
+Set ``MGRDB_PG_TEST_URL`` to run these against a live Postgres database:
+
+    MGRDB_PG_TEST_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+        pytest tests/test_chain_postgres_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langchain_core.runnables import RunnableLambda
+
+from chains.holdings_analysis import HoldingsAnalysisChain
+from chains.nl_query import NLQueryChain
+from chains.rag_search import RAGSearchChain
+from tools.langchain_client import ClientInfo
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_SQL = ROOT / "schema.sql"
+
+SEEDED_CUSIP = "037833100"
+SEEDED_MANAGER_NAME = "Elliott"
+
+
+class PgFixture:
+    def __init__(self, conn: Any, seed: dict[str, int]) -> None:
+        self.conn = conn
+        self.seed = seed
+
+
+class FakeResponse:
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.response_metadata: dict[str, str] = {}
+
+
+class FakeLLM:
+    def __init__(self, response_text: str) -> None:
+        self._response_text = response_text
+        self.prompts: list[str] = []
+
+    def invoke(self, prompt: str, config: Any = None) -> FakeResponse:
+        self.prompts.append(prompt)
+        return FakeResponse(self._response_text)
+
+
+@pytest.fixture(scope="module")
+def psycopg_module():
+    return pytest.importorskip("psycopg")
+
+
+@pytest.fixture(scope="module")
+def pg_url() -> str:
+    url = os.environ.get("MGRDB_PG_TEST_URL")
+    if not url:
+        pytest.skip("MGRDB_PG_TEST_URL not set; skipping Postgres chain integration tests")
+    return url
+
+
+@pytest.fixture(scope="module")
+def pg_conn(pg_url: str, psycopg_module) -> Generator[PgFixture, None, None]:
+    with psycopg_module.connect(pg_url, autocommit=False) as conn:
+        _reset_public_schema(conn)
+        _apply_schema_sql(conn)
+        seed = _seed_chain_fixtures(conn)
+        yield PgFixture(conn=conn, seed=seed)
+
+
+def _split_sql_statements(sql: str) -> list[str]:
+    stmts: list[str] = []
+    buf: list[str] = []
+    in_dollar_quote = False
+    dollar_tag = ""
+    i = 0
+    n = len(sql)
+
+    while i < n:
+        ch = sql[i]
+        if not in_dollar_quote:
+            if ch == "-" and i + 1 < n and sql[i + 1] == "-":
+                while i < n and sql[i] != "\n":
+                    i += 1
+                continue
+            if ch == "$":
+                j = i + 1
+                while j < n and sql[j] != "$":
+                    j += 1
+                if j < n:
+                    tag = sql[i : j + 1]
+                    in_dollar_quote = True
+                    dollar_tag = tag
+                    buf.append(tag)
+                    i = j + 1
+                    continue
+            if ch == ";":
+                buf.append(";")
+                stmt = "".join(buf).strip()
+                if stmt:
+                    stmts.append(stmt)
+                buf = []
+                i += 1
+                continue
+        else:
+            if sql[i : i + len(dollar_tag)] == dollar_tag:
+                buf.append(dollar_tag)
+                i += len(dollar_tag)
+                in_dollar_quote = False
+                dollar_tag = ""
+                continue
+
+        buf.append(ch)
+        i += 1
+
+    remaining = "".join(buf).strip()
+    if remaining:
+        stmts.append(remaining)
+    return stmts
+
+
+def _reset_public_schema(conn: Any) -> None:
+    with conn.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS public CASCADE")
+        cur.execute("CREATE SCHEMA public")
+        cur.execute("GRANT ALL ON SCHEMA public TO public")
+    conn.commit()
+
+
+def _apply_schema_sql(conn: Any) -> None:
+    for idx, stmt in enumerate(_split_sql_statements(SCHEMA_SQL.read_text()), 1):
+        try:
+            with conn.cursor() as cur:
+                cur.execute(stmt)
+        except Exception as exc:
+            conn.rollback()
+            preview = stmt if len(stmt) <= 400 else stmt[:400] + "..."
+            pytest.fail(
+                f"schema.sql failed at statement {idx}: {type(exc).__name__}: {exc}\n{preview}"
+            )
+    conn.commit()
+
+
+def _seed_chain_fixtures(conn: Any) -> dict[str, int]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO managers(name, cik) VALUES (%s, %s) RETURNING manager_id",
+            (SEEDED_MANAGER_NAME, "0001791786"),
+        )
+        manager_id = int(cur.fetchone()[0])
+        cur.execute(
+            """
+            INSERT INTO filings(manager_id, type, period_end, filed_date, source, url, raw_key)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            RETURNING filing_id
+            """,
+            (
+                manager_id,
+                "13F-HR",
+                date(2026, 3, 31),
+                date(2026, 4, 15),
+                "sec",
+                "https://example.com/filings/elliott-13f",
+                "seed-elliott-2026-q1",
+            ),
+        )
+        filing_id = int(cur.fetchone()[0])
+        cur.execute(
+            """
+            INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd)
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (filing_id, SEEDED_CUSIP, "Apple Inc.", 1000, 150000.0),
+        )
+        cur.execute(
+            """
+            INSERT INTO news_items(manager_id, published_at, source, headline, url, body_snippet)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (
+                manager_id,
+                "2026-04-16T08:00:00Z",
+                "Reuters",
+                "Elliott increases Apple stake",
+                "https://example.com/news/elliott-apple",
+                "Elliott disclosed a larger Apple position.",
+            ),
+        )
+    conn.commit()
+    return {"manager_id": manager_id, "filing_id": filing_id}
+
+
+def test_rag_search_postgres(pg_conn: PgFixture) -> None:
+    seed = pg_conn.seed
+    _assert_to_regclass_reachable(pg_conn.conn)
+    chain = RAGSearchChain(db_conn=pg_conn.conn)
+
+    _context, sources = chain._structured_search(
+        {
+            "manager_ids": [seed["manager_id"]],
+            "cusips": [],
+            "keywords": [],
+            "date_range": {"start": "2026-01-01", "end": "2026-12-31"},
+        }
+    )
+
+    assert any(source.get("filing_id") == seed["filing_id"] for source in sources)
+
+
+def test_nl_query_postgres(pg_conn: PgFixture) -> None:
+    seed = pg_conn.seed
+    llm = FakeLLM(
+        '{"sql": "SELECT manager_id, name FROM managers ORDER BY manager_id", '
+        '"columns": ["manager_id", "name"]}'
+    )
+    chain = NLQueryChain(llm=llm, db_conn=pg_conn.conn)
+
+    result = chain.run("List all managers")
+
+    assert result["results"] == [{"manager_id": seed["manager_id"], "name": SEEDED_MANAGER_NAME}]
+    assert result["sql"].endswith("LIMIT 100")
+
+
+def test_holdings_analysis_postgres(pg_conn: PgFixture) -> None:
+    seed = pg_conn.seed
+    client = ClientInfo(
+        client=RunnableLambda(
+            lambda _payload: {
+                "thesis": "ok",
+                "top_positions": [],
+                "period_changes": [],
+                "cross_manager_overlap": None,
+                "concentration_metrics": {},
+            }
+        ),
+        provider="test-provider",
+        model="test-model",
+    )
+    chain = HoldingsAnalysisChain(client_info=client, db_conn=pg_conn.conn)
+
+    result = chain.run(
+        "Top positions",
+        manager_ids=[seed["manager_id"]],
+        date_range=(date(2026, 1, 1), date(2026, 12, 31)),
+    )
+
+    assert result.thesis == "ok"
+
+
+def _assert_to_regclass_reachable(conn: Any) -> None:
+    row = conn.execute("SELECT to_regclass(%s)", ("managers",)).fetchone()
+    assert row and row[0] == "managers"

--- a/tests/test_chain_postgres_integration.py
+++ b/tests/test_chain_postgres_integration.py
@@ -8,6 +8,7 @@ Set ``MGRDB_PG_TEST_URL`` to run these against a live Postgres database:
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Generator
 from datetime import date
@@ -257,13 +258,15 @@ def test_holdings_analysis_postgres(pg_conn: PgFixture) -> None:
     seed = pg_conn.seed
     client = ClientInfo(
         client=RunnableLambda(
-            lambda _payload: {
-                "thesis": "ok",
-                "top_positions": [],
-                "period_changes": [],
-                "cross_manager_overlap": None,
-                "concentration_metrics": {},
-            }
+            lambda _payload: json.dumps(
+                {
+                    "thesis": "ok",
+                    "top_positions": [],
+                    "period_changes": [],
+                    "cross_manager_overlap": None,
+                    "concentration_metrics": {},
+                }
+            )
         ),
         provider="test-provider",
         model="test-model",

--- a/tests/test_holdings_analysis_chain.py
+++ b/tests/test_holdings_analysis_chain.py
@@ -132,7 +132,7 @@ def test_build_data_context_with_filters() -> None:
     )
     conviction_query = (
         "SELECT * FROM conviction_scores WHERE manager_id IN (%s, %s) AND report_date BETWEEN "
-        "%s AND %s ORDER BY report_date DESC, conviction_score DESC LIMIT 50"
+        "%s AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     overlap_query = (
         "SELECT * FROM crowded_trades WHERE manager_id IN (%s, %s) AND cusip IN (%s) "
@@ -198,7 +198,7 @@ def test_build_data_context_falls_back_to_cusip_only_for_crowded_trades() -> Non
     )
     conviction_query = (
         "SELECT * FROM conviction_scores WHERE manager_id IN (%s, %s) AND report_date BETWEEN "
-        "%s AND %s ORDER BY report_date DESC, conviction_score DESC LIMIT 50"
+        "%s AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     full_overlap_query = (
         "SELECT * FROM crowded_trades WHERE manager_id IN (%s, %s) AND cusip IN (%s) "
@@ -264,7 +264,7 @@ def test_build_data_context_falls_back_when_daily_diffs_has_no_cusip_column() ->
     )
     conviction_query = (
         "SELECT * FROM conviction_scores WHERE manager_id IN (%s, %s) AND report_date BETWEEN "
-        "%s AND %s ORDER BY report_date DESC, conviction_score DESC LIMIT 50"
+        "%s AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     full_overlap_query = (
         "SELECT * FROM crowded_trades WHERE manager_id IN (%s, %s) AND cusip IN (%s) "
@@ -331,8 +331,8 @@ def test_build_data_context_falls_back_when_filings_table_missing_in_non_sqlite_
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
 
@@ -389,7 +389,7 @@ def test_build_data_context_falls_back_when_holdings_report_date_column_missing(
     )
     conviction_query = (
         "SELECT * FROM conviction_scores WHERE manager_id IN (%s) AND report_date BETWEEN %s "
-        "AND %s ORDER BY report_date DESC, conviction_score DESC LIMIT 50"
+        "AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     overlap_query = (
         "SELECT * FROM crowded_trades WHERE manager_id IN (%s) AND cusip IN (%s) "
@@ -444,8 +444,8 @@ def test_chain_with_mocked_llm_response() -> None:
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -485,8 +485,8 @@ def test_build_data_context_skips_missing_conviction_scores_table() -> None:
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -521,8 +521,8 @@ def test_build_data_context_raises_for_non_table_conviction_error() -> None:
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     cursor = _MockCursor(
         {
@@ -569,8 +569,8 @@ def test_context_truncation_for_large_portfolio() -> None:
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     big_holdings = [
@@ -611,8 +611,8 @@ def test_injection_defense_blocks_malicious_question_before_llm_call() -> None:
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -652,8 +652,8 @@ def test_injection_defense_blocks_malicious_data_context_before_llm_call() -> No
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -717,8 +717,8 @@ def test_run_uses_structured_output_when_available() -> None:
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -759,8 +759,8 @@ def test_run_falls_back_to_json_parser_when_structured_output_fails() -> None:
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -803,8 +803,8 @@ def test_run_parses_structured_json_string_without_fallback_call() -> None:
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -846,8 +846,8 @@ def test_run_recovers_partial_structured_payload_without_fallback_call() -> None
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -881,8 +881,8 @@ def test_run_parses_uppercase_fenced_json_fallback() -> None:
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -946,8 +946,8 @@ def test_holdings_analysis_tracing_context_is_entered(
         "SELECT * FROM daily_diffs WHERE 1=1 ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY report_date DESC, "
-        "conviction_score DESC LIMIT 50"
+        "SELECT * FROM conviction_scores WHERE 1=1 ORDER BY computed_at DESC, "
+        "conviction_pct DESC LIMIT 50"
     )
     overlap_query = "SELECT * FROM crowded_trades WHERE 1=1 ORDER BY holder_count DESC, total_value_usd DESC LIMIT 50"
     cursor = _MockCursor(
@@ -999,7 +999,7 @@ def test_holdings_analysis_tracing_context_includes_filter_inputs(
     )
     conviction_query = (
         "SELECT * FROM conviction_scores WHERE manager_id IN (%s) AND report_date BETWEEN %s "
-        "AND %s ORDER BY report_date DESC, conviction_score DESC LIMIT 50"
+        "AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     overlap_query = (
         "SELECT * FROM crowded_trades WHERE manager_id IN (%s) AND cusip IN (%s) "

--- a/tests/test_holdings_analysis_chain.py
+++ b/tests/test_holdings_analysis_chain.py
@@ -131,7 +131,7 @@ def test_build_data_context_with_filters() -> None:
         "AND %s AND cusip IN (%s) ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE manager_id IN (%s, %s) AND report_date BETWEEN "
+        "SELECT * FROM conviction_scores WHERE manager_id IN (%s, %s) AND computed_at BETWEEN "
         "%s AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     overlap_query = (
@@ -197,7 +197,7 @@ def test_build_data_context_falls_back_to_cusip_only_for_crowded_trades() -> Non
         "AND %s AND cusip IN (%s) ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE manager_id IN (%s, %s) AND report_date BETWEEN "
+        "SELECT * FROM conviction_scores WHERE manager_id IN (%s, %s) AND computed_at BETWEEN "
         "%s AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     full_overlap_query = (
@@ -263,7 +263,7 @@ def test_build_data_context_falls_back_when_daily_diffs_has_no_cusip_column() ->
         "AND %s ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE manager_id IN (%s, %s) AND report_date BETWEEN "
+        "SELECT * FROM conviction_scores WHERE manager_id IN (%s, %s) AND computed_at BETWEEN "
         "%s AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     full_overlap_query = (
@@ -388,7 +388,7 @@ def test_build_data_context_falls_back_when_holdings_report_date_column_missing(
         "AND cusip IN (%s) ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE manager_id IN (%s) AND report_date BETWEEN %s "
+        "SELECT * FROM conviction_scores WHERE manager_id IN (%s) AND computed_at BETWEEN %s "
         "AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     overlap_query = (
@@ -998,7 +998,7 @@ def test_holdings_analysis_tracing_context_includes_filter_inputs(
         "AND cusip IN (%s) ORDER BY report_date DESC, value_curr DESC LIMIT 100"
     )
     conviction_query = (
-        "SELECT * FROM conviction_scores WHERE manager_id IN (%s) AND report_date BETWEEN %s "
+        "SELECT * FROM conviction_scores WHERE manager_id IN (%s) AND computed_at BETWEEN %s "
         "AND %s ORDER BY computed_at DESC, conviction_pct DESC LIMIT 50"
     )
     overlap_query = (

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -5,6 +5,7 @@
 - Automation: `pd-workloop-resume` (codex opener lane).
 - Source repo: `stranske/Manager-Database`.
 - Source issue: [#1032](https://github.com/stranske/Manager-Database/issues/1032) `Add Postgres-backed integration tests for RAG, holdings analysis, and NL-query chain execution` (labels `repo-review-approved`, `priority:normal`).
+- PR: [#1033](https://github.com/stranske/Manager-Database/pull/1033) `Issue #1032: Add Postgres chain integration coverage`.
 - Branch: `codex/issue-1032-postgres-chain-integration` from `origin/main` (`199ac21`).
 - Selection:
   - ACTION A succeeded from the neutral Code workspace. Cross-lane sentinel `active.source_repo=stranske/Counter_Risk active.source_issue=591 active.source_pr=592 active.next_action=wait_for_keepalive` was treated as informational only.
@@ -27,7 +28,13 @@
   - `git diff --check` -> passed.
   - Live Docker/Postgres validation was attempted but local Docker daemon was unavailable (`Cannot connect to the Docker daemon`); CI job now provides the live pgvector Postgres path.
 - Local notes: the original Code workspace `Manager-Database` checkout had a pre-existing `.gitignore` modification and was not writable under this sandbox. Implementation was done in a fresh writable `/tmp/manager-db-issue-1032-codex` clone and pushed back to the selected repo.
-- Next action: open a ready PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/check follow-up after PR creation.
+- Commit/push:
+  - Commit `a8c9b51` (`Issue #1032: add Postgres chain integration tests`) pushed to `codex/issue-1032-postgres-chain-integration`.
+- PR/routing:
+  - Opened ready-for-review PR [#1033](https://github.com/stranske/Manager-Database/pull/1033) with labels `agent:codex`, `agents:keepalive`, and `autofix`; verified `isDraft=false`.
+  - Relay emitted: `pr_opened active.source_pr=1033 active.next_action=wait_for_keepalive`.
+  - Post-open cap-health at `2026-05-13T19:57:03Z`: `total_opener_owned=1`, `raw_cap_reached=false`, `normal_cap_reached=false`, `non_drainable_cap_blocker=false`; PR #1033 state `draining`, reason `workflow run active after latest branch update: Gate`.
+- Next action: keepalive owns CI/check follow-up for PR #1033.
 
 ## 2026-05-09T22:12:00Z - opener lane selected issue #1007 activism dialect work
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,34 @@
 # Workloop State
 
+## 2026-05-13T20:05Z - opener opened Postgres chain integration PR
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Source repo: `stranske/Manager-Database`.
+- Source issue: [#1032](https://github.com/stranske/Manager-Database/issues/1032) `Add Postgres-backed integration tests for RAG, holdings analysis, and NL-query chain execution` (labels `repo-review-approved`, `priority:normal`).
+- Branch: `codex/issue-1032-postgres-chain-integration` from `origin/main` (`199ac21`).
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace. Cross-lane sentinel `active.source_repo=stranske/Counter_Risk active.source_issue=591 active.source_pr=592 active.next_action=wait_for_keepalive` was treated as informational only.
+  - Required fleet discovery ran across `repo-review-approved`, `priority:high`, `priority:normal`, and `priority:low`. `trip-planner#1184` and `Counter_Risk#591` were already linked to PRs; `Workflows#2073` was skipped as a credential/auth alert.
+  - Raw author-owned opener PR searches for `claude` and `codex` returned no direct `gh search prs` hits, while cap-health identified one opener-owned PR by branch/routing: `Counter_Risk#592`, state `draining`, reason `keepalive summary reports an agent currently running`.
+  - `opener-repair-infra-stalls.py --json` repaired nothing and skipped `Counter_Risk#592` because it was already draining. Mandatory fresh cap-health remained healthy: `total_opener_owned=1`, `raw_cap_reached=false`, `normal_cap_reached=false`, `non_drainable_cap_blocker=false`.
+  - Approved queue item selected by normal-priority queue order after excluding already-materialized items. Duplicate checks found no existing Manager-Database issue or PR for this title.
+- Implementation:
+  - Added `tests/test_chain_postgres_integration.py` with `MGRDB_PG_TEST_URL`-gated real-Postgres tests for `RAGSearchChain._structured_search()`, `NLQueryChain.run()`, and `HoldingsAnalysisChain.run()`.
+  - The fixture resets `public`, applies `schema.sql` with a dollar-quote-aware splitter, seeds one manager, filing, holding, and news row, and asserts concrete chain results including the seeded RAG filing source.
+  - Added a repo-local `postgres-integration` CI job using `pgvector/pgvector:pg16`, `MGRDB_PG_TEST_URL=postgresql://postgres:postgres@localhost:5432/postgres`, and `pytest tests/test_chain_postgres_integration.py -v`.
+  - Updated `HoldingsAnalysisChain` to order `conviction_scores` by the schema-backed `computed_at` / `conviction_pct` columns and tolerate missing-column schema variants in the optional conviction section.
+  - Updated holdings-analysis tests to match the schema-backed conviction ordering.
+- Validation:
+  - `pytest tests/test_chain_postgres_integration.py -v` without `MGRDB_PG_TEST_URL` -> 3 skipped, no import-time breakage.
+  - `rg "MGRDB_PG_TEST_URL" tests/test_chain_postgres_integration.py | wc -l` -> 4.
+  - `pytest tests/test_chain_dialect_portability.py tests/test_holdings_analysis_chain.py tests/test_rag_search_chain.py tests/test_nl_query_chain.py tests/test_chain_postgres_integration.py -v --no-cov` -> 40 passed, 3 skipped.
+  - `ruff check chains/holdings_analysis.py tests/test_chain_postgres_integration.py tests/test_holdings_analysis_chain.py` -> passed.
+  - `black --target-version py312 --check chains/holdings_analysis.py tests/test_chain_postgres_integration.py tests/test_holdings_analysis_chain.py` -> passed.
+  - `git diff --check` -> passed.
+  - Live Docker/Postgres validation was attempted but local Docker daemon was unavailable (`Cannot connect to the Docker daemon`); CI job now provides the live pgvector Postgres path.
+- Local notes: the original Code workspace `Manager-Database` checkout had a pre-existing `.gitignore` modification and was not writable under this sandbox. Implementation was done in a fresh writable `/tmp/manager-db-issue-1032-codex` clone and pushed back to the selected repo.
+- Next action: open a ready PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/check follow-up after PR creation.
+
 ## 2026-05-09T22:12:00Z - opener lane selected issue #1007 activism dialect work
 
 - Automation: `pd-workloop-resume` (codex opener lane).


### PR DESCRIPTION
Implements #1032

## Summary
- add MGRDB_PG_TEST_URL-gated Postgres integration coverage for RAG, NL query, and holdings analysis chains
- add a repo-local pgvector Postgres CI job for the new integration tests
- align optional holdings conviction-score ordering with schema-backed columns

## Validation
- pytest tests/test_chain_postgres_integration.py -v (3 skipped without MGRDB_PG_TEST_URL)
- pytest tests/test_chain_dialect_portability.py tests/test_holdings_analysis_chain.py tests/test_rag_search_chain.py tests/test_nl_query_chain.py tests/test_chain_postgres_integration.py -v --no-cov (40 passed, 3 skipped)
- ruff check chains/holdings_analysis.py tests/test_chain_postgres_integration.py tests/test_holdings_analysis_chain.py
- black --target-version py312 --check chains/holdings_analysis.py tests/test_chain_postgres_integration.py tests/test_holdings_analysis_chain.py
- git diff --check

Note: live local Docker validation could not run because the Docker daemon is not running; the new CI job runs the live pgvector Postgres path.