### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/issue_context_utils.js
+++ b/.github/scripts/issue_context_utils.js
@@ -37,7 +37,7 @@ function buildCappedIssuePayload(issueBody, options = {}) {
     const output = childProcess.execFileSync('python3', args, { encoding: 'utf8' });
     const payload = JSON.parse(output);
     return {
-      formattedBody: String(payload.formatted_body || body),
+      formattedBody: String(payload.formatted_body ?? body),
       truncated: Boolean(payload.truncated),
       estimatedTokens: payload.estimated_tokens,
       tokenBudget: payload.token_budget,

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -151,7 +151,10 @@ function issueHasMarker(issue = {}, markerPattern = null) {
   return patternMatches(issue.body || '', markerPattern);
 }
 
-function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } = {}) {
+function issueMatchesTracker(
+  issue = {},
+  { label, titlePattern, markerPattern, allowBodylessTitleCandidate = false } = {},
+) {
   if (issue.pull_request) {
     return false;
   }
@@ -160,12 +163,14 @@ function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } 
   const hasRequiredLabel = requiredLabels.length === 0 ||
     requiredLabels.some((name) => names.includes(name));
   const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
-  const hasTitle = patternMatches(issue.title || '', titlePattern);
+  const hasTitle = Boolean(titlePattern) && patternMatches(issue.title || '', titlePattern);
   const hasMarker = issueHasMarker(issue, markerPattern);
-  if (titlePattern && hasTitle) {
-    return true;
-  }
-  if (markerPattern && hasTitle && !cleanString(issue.body)) {
+  if (
+    allowBodylessTitleCandidate &&
+    markerPattern &&
+    hasTitle &&
+    !cleanString(issue.body)
+  ) {
     return true;
   }
   return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
@@ -215,7 +220,12 @@ async function findTracker({ github, owner, repo, label, titlePattern, markerPat
     }
   }
   for (const issue of byNumber.values()) {
-    if (!issueMatchesTracker(issue, { label, titlePattern, markerPattern })) {
+    if (!issueMatchesTracker(issue, {
+      label,
+      titlePattern,
+      markerPattern,
+      allowBodylessTitleCandidate: true,
+    })) {
       continue;
     }
     const fullIssue = await getIssue({ github, owner, repo, issueNumber: issue.number, core, withRetry });

--- a/.github/workflows/agents-80-pr-event-hub.yml
+++ b/.github/workflows/agents-80-pr-event-hub.yml
@@ -71,10 +71,17 @@ jobs:
       debug: ${{ steps.resolve.outputs.debug }}
       should_run: ${{ steps.eligibility.outputs.should-run || 'false' }}
     steps:
+      - name: Checkout eligibility action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          sparse-checkout: .github/actions/agent-event-eligibility
+          sparse-checkout-cone-mode: false
+
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
         id: eligibility
-        uses: stranske/Workflows/.github/actions/agent-event-eligibility@main
+        uses: ./.github/actions/agent-event-eligibility
         with:
           expected-actions: >-
             workflow_dispatch,created,opened,synchronize,reopened,edited,

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -32,10 +32,17 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'automated')
 
     steps:
+      - name: Checkout eligibility action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          sparse-checkout: .github/actions/agent-event-eligibility
+          sparse-checkout-cone-mode: false
+
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
         id: eligibility
-        uses: stranske/Workflows/.github/actions/agent-event-eligibility@main
+        uses: ./.github/actions/agent-event-eligibility
         with:
           expected-actions: opened,reopened,edited
           custom-predicate: >-

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -70,10 +70,17 @@ jobs:
     outputs:
       proceed: ${{ steps.eligibility.outputs.should-run }}
     steps:
+      - name: Checkout eligibility action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          sparse-checkout: .github/actions/agent-event-eligibility
+          sparse-checkout-cone-mode: false
+
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
         id: eligibility
-        uses: stranske/Workflows/.github/actions/agent-event-eligibility@main
+        uses: ./.github/actions/agent-event-eligibility
         with:
           expected-actions: workflow_dispatch,labeled,closed
           custom-predicate: >-

--- a/.github/workflows/agents-autofix-dispatcher.yml
+++ b/.github/workflows/agents-autofix-dispatcher.yml
@@ -1,5 +1,9 @@
 name: Agents Autofix Dispatch
 
+# Compatibility bridge for legacy Gate repository_dispatch events. Gate-driven
+# repair routing now lives in agents-81-gate-followups.yml via workflow_run, so
+# this workflow only validates and logs the old dispatch payload.
+
 on:
   repository_dispatch:
     types:

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -30,10 +30,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout eligibility action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          sparse-checkout: .github/actions/agent-event-eligibility
+          sparse-checkout-cone-mode: false
+
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
         id: eligibility
-        uses: stranske/Workflows/.github/actions/agent-event-eligibility@main
+        uses: ./.github/actions/agent-event-eligibility
         with:
           expected-labels: >-
             agent:auto,agent:codex,agent:claude,agent:copilot,

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -66,10 +66,17 @@ jobs:
       dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
       dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
+      - name: Checkout eligibility action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          sparse-checkout: .github/actions/agent-event-eligibility
+          sparse-checkout-cone-mode: false
+
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
         id: eligibility
-        uses: stranske/Workflows/.github/actions/agent-event-eligibility@main
+        uses: ./.github/actions/agent-event-eligibility
         with:
           expected-actions: completed,labeled
           custom-predicate: >-

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -411,6 +411,30 @@ def _decode_record_candidate(candidate: str) -> str:
     return value
 
 
+def _marker_safe_text(value: Any, limit: int = 1000) -> str:
+    text = "" if value is None else str(value)
+    if len(text) > limit:
+        text = f"{text[:limit]}...[truncated {len(text) - limit} chars]"
+    return text.replace("-->", "--\\u003e")
+
+
+def _compact_runner_result_payload(result_payload: dict[str, Any]) -> dict[str, Any]:
+    final_message_value = result_payload.get("final_message")
+    final_message = "" if final_message_value is None else str(final_message_value)
+    compact: dict[str, Any] = {
+        "schema": "runner-result-summary/v1",
+        "provider": str(result_payload.get("provider") or ""),
+        "success": bool(result_payload.get("success")),
+        "summary": _marker_safe_text(result_payload.get("summary")),
+        "error": _marker_safe_text(result_payload.get("error")),
+        "truncated": bool(result_payload.get("truncated")),
+    }
+    if final_message:
+        compact["final_message_sha256"] = hashlib.sha256(final_message.encode("utf-8")).hexdigest()
+        compact["final_message_chars"] = len(final_message)
+    return compact
+
+
 def _extract_record(value: str | None, pr_number: int, provider: str) -> dict[str, Any] | None:
     if not value:
         return None
@@ -695,17 +719,13 @@ def record_completion(
         dataclasses.asdict(result) if dataclasses.is_dataclass(result) else dict(result)
     )
     status = "completed" if result_payload.get("success") else "error"
+    compact_result = _compact_runner_result_payload(result_payload)
     prior = storage.read_record(pr_number, provider) or {}
     completed_at = (
         prior.get("completed_at")
         if prior.get("key") == key and prior.get("status") in TERMINAL_STATUSES
         else _utc_now()
     )
-    compact_result = {
-        field: result_payload.get(field)
-        for field in ("provider", "success", "summary", "error", "truncated")
-        if field in result_payload
-    }
     record = {
         **prior,
         "provider": provider,

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -34,9 +34,9 @@ else:
 PYPROJECT_FILE = Path("pyproject.toml")
 DEV_EXTRA = "dev"
 
-# Stdlib modules that don't need to be installed (keep in sync with
-# tests/test_dependency_enforcement.py)
-STDLIB_MODULES = {
+# Stdlib modules that don't need to be installed. Prefer Python's runtime
+# inventory and keep a fallback for older runtimes/consumer scripts.
+_FALLBACK_STDLIB_MODULES = {
     "abc",
     "argparse",
     "ast",
@@ -75,9 +75,9 @@ STDLIB_MODULES = {
     "re",
     "runpy",
     "email",
-    "secrets",
     "shlex",
     "shutil",
+    "secrets",
     "signal",
     "sitecustomize",
     "socket",
@@ -109,8 +109,7 @@ STDLIB_MODULES = {
     "traceback",
     "pprint",
 }
-if hasattr(sys, "stdlib_module_names"):
-    STDLIB_MODULES.update(sys.stdlib_module_names)
+STDLIB_MODULES = set(getattr(sys, "stdlib_module_names", ())) | _FALLBACK_STDLIB_MODULES
 
 # Known test framework modules
 TEST_FRAMEWORK_MODULES = {


### PR DESCRIPTION
## Sync Summary

### Files Updated
- autofix.yml: Autofix workflow - automatically fixes lint/format issues
- agents-80-pr-event-hub.yml: PR event hub - consolidates PR meta, bot comments, and verify-to-issue handlers
- agents-autofix-dispatcher.yml: Autofix dispatch bridge - acknowledges legacy Gate repository_dispatch events; agents-81-gate-followups handles repair work
- agents-auto-label.yml: Auto-label - suggests/applies labels based on semantic matching (Phase 5A)
- agents-guard.yml: Agents guard - enforces agents workflow protections (Health 45)
- agents-auto-pilot.yml: Auto-pilot - end-to-end automation orchestrator (format → optimize → agent → verify)
- runner_lib/ (1 files): Shared runner prompt assembly, output parsing, and dispatch debounce helpers
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow
- issue_context_utils.js: Utilities for issue context extraction
- sync_tracker_state/ (1 files): Shared durable tracker and open PR state helpers for consumer sync workflows

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `f3098b759f619007b4850f52956ef7525273f651`
**Template hash:** `a603a11faca0`
**Sync branch:** `sync/workflows-a603a11faca0`
**Consumer repo:** `stranske/Manager-Database`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Manager-Database","source_repository":"stranske/Workflows","source_sha":"f3098b759f619007b4850f52956ef7525273f651","template_hash":"a603a11faca0","sync_branch":"sync/workflows-a603a11faca0","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"25895311539","run_attempt":"1","changes_count":10} -->