### PR TITLE
Issue #1087: Introduce uniform tool RunResult envelope

### DIFF
--- a/adapters/base.py
+++ b/adapters/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import time
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from importlib import import_module
 from types import ModuleType
@@ -124,7 +125,13 @@ def _ensure_postgres_usage_schema(conn: Any) -> None:
 
 
 @asynccontextmanager
-async def tracked_call(source: str, endpoint: str, *, db_path: str | None = None):
+async def tracked_call(
+    source: str,
+    endpoint: str,
+    *,
+    db_path: str | None = None,
+    cost_usd: float | Callable[[Any], float] | None = None,
+):
     """Record API usage metrics in the ``api_usage`` table.
 
     Parameters
@@ -137,6 +144,11 @@ async def tracked_call(source: str, endpoint: str, *, db_path: str | None = None
         Optional path to a database. If ``DB_URL`` is set and points to
         a Postgres instance, that URL is used instead; otherwise defaults
         to ``DB_PATH`` or ``dev.db``.
+    cost_usd:
+        Optional per-call cost. A ``float`` is recorded directly; a callable is
+        invoked with the logged response and must return a ``float`` (e.g. a
+        per-byte or per-token rate). When ``None`` (the default, i.e. no rate
+        configured for the source) the recorded cost is ``0.0``.
 
     Usage::
 
@@ -158,6 +170,12 @@ async def tracked_call(source: str, endpoint: str, *, db_path: str | None = None
         latency = int((time.perf_counter() - start) * 1000)
         status = getattr(resp, "status_code", 0)
         size = len(getattr(resp, "content", b""))
+        if callable(cost_usd):
+            computed_cost = float(cost_usd(resp))
+        elif cost_usd is not None:
+            computed_cost = float(cost_usd)
+        else:
+            computed_cost = 0.0
         conn = connect_db(db_path)
         if isinstance(conn, sqlite3.Connection):
             _ensure_sqlite_usage_schema(conn)
@@ -170,7 +188,7 @@ async def tracked_call(source: str, endpoint: str, *, db_path: str | None = None
             "INSERT INTO api_usage(source, endpoint, status, bytes, latency_ms, cost_usd)"
             f" VALUES ({values_clause})"
         )
-        conn.execute(sql, (source, endpoint, status, size, latency, 0.0))
+        conn.execute(sql, (source, endpoint, status, size, latency, computed_cost))
         conn.commit()
         conn.close()
 

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -147,8 +147,8 @@ async def tracked_call(
     cost_usd:
         Optional per-call cost. A ``float`` is recorded directly; a callable is
         invoked with the logged response and must return a ``float`` (e.g. a
-        per-byte or per-token rate). When ``None`` (the default, i.e. no rate
-        configured for the source) the recorded cost is ``0.0``.
+        per-byte or per-token rate). When no rate is configured, or no response
+        was logged before the call failed, the recorded cost is ``0.0``.
 
     Usage::
 
@@ -171,7 +171,7 @@ async def tracked_call(
         status = getattr(resp, "status_code", 0)
         size = len(getattr(resp, "content", b""))
         if callable(cost_usd):
-            computed_cost = float(cost_usd(resp))
+            computed_cost = float(cost_usd(resp)) if resp is not None else 0.0
         elif cost_usd is not None:
             computed_cost = float(cost_usd)
         else:

--- a/diff_holdings.py
+++ b/diff_holdings.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import sqlite3
 import sys
+import time
 from typing import Any
 
 from adapters.base import connect_db
+from tools.run_contract import RunResult
 
 
 def _placeholder(conn: Any) -> str:
@@ -86,7 +88,7 @@ def _compare_optional(curr: int | float | None, prev: int | float | None) -> int
     return 0
 
 
-def diff_holdings(manager_id: int | str, conn: Any = None) -> list[dict[str, Any]]:
+def diff_holdings(manager_id: int | str, conn: Any = None) -> RunResult:
     """Compute structured diffs between the two most-recent filings.
 
     Parameters
@@ -99,10 +101,13 @@ def diff_holdings(manager_id: int | str, conn: Any = None) -> list[dict[str, Any
 
     Returns
     -------
-    list of dicts, each with keys:
+    RunResult
+        A replayable envelope whose ``outputs`` (also exposed as ``.deltas``) is
+        the list of delta dicts, each with keys:
         cusip, name_of_issuer, delta_type, shares_prev, shares_curr,
-        value_prev, value_curr
+        value_prev, value_curr.  ``inputs`` echoes the resolved ``manager_id``.
     """
+    start = time.perf_counter()
     owns_connection = False
     if conn is None:
         conn = connect_db()
@@ -172,7 +177,14 @@ def diff_holdings(manager_id: int | str, conn: Any = None) -> list[dict[str, Any
             }
         )
 
-    return results
+    return RunResult(
+        tool="diff_holdings",
+        inputs={"manager_id": resolved},
+        outputs=results,
+        provenance={"manager_id": resolved},
+        latency_ms=int((time.perf_counter() - start) * 1000),
+        status="success",
+    )
 
 
 if __name__ == "__main__":
@@ -181,7 +193,7 @@ if __name__ == "__main__":
         sys.exit(1)
     # Always pass as string — _resolve_manager_id handles CIK lookup
     # and numeric fallback without losing leading zeros.
-    for row in diff_holdings(sys.argv[1]):
+    for row in diff_holdings(sys.argv[1]).deltas:
         print(
             f"{row['cusip']}: {row['delta_type']} "
             f"(shares {row['shares_prev']} -> {row['shares_curr']}, "

--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -4,6 +4,7 @@ import datetime as dt
 import logging
 import os
 import sqlite3
+import time
 from typing import Any
 
 from prefect import flow, task
@@ -12,6 +13,7 @@ from prefect.schedules import Cron
 from adapters.base import connect_db
 from diff_holdings import diff_holdings
 from etl.logging_setup import configure_logging, log_outcome
+from tools.run_contract import RunResult
 
 configure_logging("daily_diff_flow")
 logger = logging.getLogger(__name__)
@@ -133,15 +135,21 @@ def _fetch_all_manager_ids(conn: Any) -> list[int]:
 @task
 def compute_manager_diffs(manager_id: int, report_date: str, conn: Any) -> int:
     """Compute and store diffs for a single manager. Returns change count."""
-    diffs = diff_holdings(manager_id, conn)
+    diffs = diff_holdings(manager_id, conn).deltas
     _delete_existing_diffs(conn, manager_id, report_date)
     _insert_diffs(conn, manager_id, report_date, diffs)
     return len(diffs)
 
 
 @flow
-def daily_diff_flow(date: str | None = None) -> None:
-    """Compute holdings diffs for all managers and store in daily_diffs."""
+def daily_diff_flow(date: str | None = None) -> RunResult:
+    """Compute holdings diffs for all managers and store in daily_diffs.
+
+    Returns a replayable :class:`RunResult` whose ``outputs`` summarizes the run
+    (``managers_processed``, ``managers_skipped``, ``total_changes``) and whose
+    ``warnings`` records any managers skipped for having fewer than two filings.
+    """
+    start = time.perf_counter()
     conn = connect_db()
     report_date = date or str(dt.date.today() - dt.timedelta(days=1))
 
@@ -151,7 +159,18 @@ def daily_diff_flow(date: str | None = None) -> None:
 
         if not manager_ids:
             logger.warning("No managers found in database")
-            return
+            return RunResult(
+                tool="daily_diff_flow",
+                inputs={"date": report_date},
+                outputs={
+                    "managers_processed": 0,
+                    "managers_skipped": 0,
+                    "total_changes": 0,
+                },
+                warnings=["No managers found in database"],
+                latency_ms=int((time.perf_counter() - start) * 1000),
+                status="success",
+            )
 
         # Postgres runs with autocommit=True, so an explicit transaction is
         # required to make the DELETE-then-INSERT cycle atomic per batch.
@@ -161,6 +180,7 @@ def daily_diff_flow(date: str | None = None) -> None:
         total_changes = 0
         managers_processed = 0
         managers_skipped = 0
+        warnings: list[str] = []
 
         for mid in manager_ids:
             try:
@@ -180,6 +200,7 @@ def daily_diff_flow(date: str | None = None) -> None:
             except SystemExit:
                 # diff_holdings raises SystemExit when < 2 filings exist.
                 managers_skipped += 1
+                warnings.append(f"manager {mid} skipped (< 2 filings)")
                 logger.debug(
                     "Skipped manager %d (< 2 filings)",
                     mid,
@@ -208,6 +229,19 @@ def daily_diff_flow(date: str | None = None) -> None:
                 "managers_skipped": managers_skipped,
                 "total_changes": total_changes,
             },
+        )
+
+        return RunResult(
+            tool="daily_diff_flow",
+            inputs={"date": report_date},
+            outputs={
+                "managers_processed": managers_processed,
+                "managers_skipped": managers_skipped,
+                "total_changes": total_changes,
+            },
+            warnings=warnings,
+            latency_ms=int((time.perf_counter() - start) * 1000),
+            status="success",
         )
     finally:
         conn.close()

--- a/tests/test_daily_diff.py
+++ b/tests/test_daily_diff.py
@@ -6,6 +6,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from etl.daily_diff_flow import compute_manager_diffs, daily_diff_flow
+from tools.run_contract import RunResult
 
 
 class FixedDate(date):
@@ -264,7 +265,9 @@ def test_daily_diff_flow_refreshes_matview_on_postgres(monkeypatch):
     import etl.daily_diff_flow as ddf
 
     monkeypatch.setattr(ddf, "connect_db", lambda: FakePostgresConn())
-    monkeypatch.setattr(ddf, "diff_holdings", lambda mid, conn: [])
+    monkeypatch.setattr(
+        ddf, "diff_holdings", lambda mid, conn: RunResult(tool="diff_holdings", outputs=[])
+    )
 
     daily_diff_flow.fn(date="2024-01-01")
 

--- a/tests/test_diff_holdings.py
+++ b/tests/test_diff_holdings.py
@@ -56,7 +56,7 @@ def _setup_canonical_db() -> sqlite3.Connection:
 def test_diff_holdings_returns_structured_four_delta_types():
     """All four delta types must appear with correct values."""
     conn = _setup_canonical_db()
-    rows = diff_holdings(1, conn)
+    rows = diff_holdings(1, conn).deltas
     conn.close()
 
     assert rows == [
@@ -102,8 +102,8 @@ def test_diff_holdings_returns_structured_four_delta_types():
 def test_diff_holdings_accepts_cik_lookup():
     """CIK string should resolve to the same results as integer manager_id."""
     conn = _setup_canonical_db()
-    by_cik = diff_holdings("0000000000", conn)
-    by_id = diff_holdings(1, conn)
+    by_cik = diff_holdings("0000000000", conn).deltas
+    by_id = diff_holdings(1, conn).deltas
     conn.close()
     assert by_cik == by_id
 
@@ -111,7 +111,7 @@ def test_diff_holdings_accepts_cik_lookup():
 def test_diff_holdings_accepts_numeric_string_manager_id():
     """A digit-only string should be treated as a manager_id."""
     conn = _setup_canonical_db()
-    rows = diff_holdings("1", conn)
+    rows = diff_holdings("1", conn).deltas
     conn.close()
     assert len(rows) == 4  # Same 4 delta types as above
 
@@ -223,7 +223,7 @@ def test_diff_holdings_uses_default_connect_db_when_conn_missing(monkeypatch):
         diff_holdings_module, "_fetch_latest_sets", lambda _manager_id, _conn: ({}, {})
     )
 
-    rows = diff_holdings_module.diff_holdings("0000000000")
+    rows = diff_holdings_module.diff_holdings("0000000000").deltas
 
     assert rows == []
     assert calls == [None, "closed"]

--- a/tests/test_run_contract.py
+++ b/tests/test_run_contract.py
@@ -1,0 +1,187 @@
+"""Acceptance tests for the uniform tool ``RunResult`` envelope (issue #1087)."""
+
+import sqlite3
+import sys
+from dataclasses import fields as dataclass_fields
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from diff_holdings import diff_holdings
+from etl.daily_diff_flow import daily_diff_flow
+from llm.langsmith_fleet import ChatFleetContext
+from tools.run_contract import RunCost, RunResult, new_run_id
+
+
+def _seed_canonical_db(conn: sqlite3.Connection) -> None:
+    """Seed the canonical managers/filings/holdings schema with two filings."""
+    conn.execute(
+        "CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT, cik TEXT UNIQUE)"
+    )
+    conn.execute(
+        "CREATE TABLE filings ("
+        "filing_id INTEGER PRIMARY KEY, manager_id INTEGER, "
+        "type TEXT, filed_date TEXT, source TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE holdings ("
+        "holding_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "filing_id INTEGER, cusip TEXT, name_of_issuer TEXT, "
+        "shares INTEGER, value_usd REAL)"
+    )
+    conn.execute("INSERT INTO managers(manager_id, name, cik) VALUES (1, 'TestFund', '0000000000')")
+    conn.executemany(
+        "INSERT INTO filings(filing_id, manager_id, type, filed_date, source) VALUES (?,?,?,?,?)",
+        [(101, 1, "13F-HR", "2024-04-01", "edgar"), (102, 1, "13F-HR", "2024-01-01", "edgar")],
+    )
+    conn.executemany(
+        "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) VALUES (?,?,?,?,?)",
+        [
+            (101, "AAA", "CorpA", 120, 1200),  # INCREASE
+            (101, "CCC", "CorpC", 40, 400),  # ADD
+            (101, "EEE", "CorpE", 8, 80),  # DECREASE
+            (102, "AAA", "CorpA", 100, 1000),
+            (102, "BBB", "CorpB", 30, 300),  # EXIT
+            (102, "EEE", "CorpE", 10, 100),
+        ],
+    )
+    conn.commit()
+
+
+def test_diff_holdings_returns_runresult():
+    """``diff_holdings`` returns a populated, replayable ``RunResult``."""
+    conn = sqlite3.connect(":memory:")
+    _seed_canonical_db(conn)
+
+    result = diff_holdings(1, conn)
+    conn.close()
+
+    assert isinstance(result, RunResult)
+    assert result.tool == "diff_holdings"
+    assert result.run_id  # non-empty correlation id
+    assert result.inputs == {"manager_id": 1}
+    # ``.deltas`` is the back-compat accessor for the historical list return.
+    assert result.deltas == [
+        {
+            "cusip": "AAA",
+            "name_of_issuer": "CorpA",
+            "delta_type": "INCREASE",
+            "shares_prev": 100,
+            "shares_curr": 120,
+            "value_prev": 1000,
+            "value_curr": 1200,
+        },
+        {
+            "cusip": "BBB",
+            "name_of_issuer": "CorpB",
+            "delta_type": "EXIT",
+            "shares_prev": 30,
+            "shares_curr": None,
+            "value_prev": 300,
+            "value_curr": None,
+        },
+        {
+            "cusip": "CCC",
+            "name_of_issuer": "CorpC",
+            "delta_type": "ADD",
+            "shares_prev": None,
+            "shares_curr": 40,
+            "value_prev": None,
+            "value_curr": 400,
+        },
+        {
+            "cusip": "EEE",
+            "name_of_issuer": "CorpE",
+            "delta_type": "DECREASE",
+            "shares_prev": 10,
+            "shares_curr": 8,
+            "value_prev": 100,
+            "value_curr": 80,
+        },
+    ]
+    assert result.deltas is result.outputs
+
+
+def test_runresult_json_roundtrip():
+    """A populated ``RunResult`` survives a JSON serialize/reconstruct cycle (replay)."""
+    original = RunResult(
+        run_id=new_run_id(),
+        tool="diff_holdings",
+        requested_by="analyst@example.test",
+        reason="quarterly review",
+        inputs={"manager_id": 7},
+        outputs=[{"cusip": "AAA", "delta_type": "ADD"}],
+        artifacts=["s3://bucket/run.json"],
+        warnings=["manager 9 skipped (< 2 filings)"],
+        cost=RunCost(usd=0.42, tokens=128),
+        latency_ms=12,
+        provenance={"manager_id": 7},
+        status="success",
+    )
+
+    rebuilt = RunResult.model_validate_json(original.model_dump_json())
+
+    assert rebuilt == original
+    assert rebuilt.deltas == original.outputs
+
+
+@pytest.mark.asyncio
+async def test_cost_not_constant_zero(tmp_path):
+    """``tracked_call`` records a real cost when a per-call rate is configured.
+
+    Fails against the previous implementation, which hard-coded ``cost_usd=0.0``.
+    """
+    from adapters.base import tracked_call
+
+    db_path = tmp_path / "usage.db"
+
+    class DummyResp:
+        status_code = 200
+        content = b"abcdefghij"  # 10 bytes
+
+    # Configured per-call rate: $0.001 per response byte.
+    async with tracked_call(
+        "paid-source",
+        "http://x",
+        db_path=str(db_path),
+        cost_usd=lambda resp: len(resp.content) * 0.001,
+    ) as log:
+        log(DummyResp())
+
+    conn = sqlite3.connect(db_path)
+    cost = conn.execute("SELECT cost_usd FROM api_usage").fetchone()[0]
+    conn.close()
+
+    assert cost > 0.0
+
+
+def test_daily_diff_flow_returns_runresult(tmp_path, monkeypatch):
+    """``daily_diff_flow`` returns a ``RunResult`` whose total_changes matches the rows written."""
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    _seed_canonical_db(conn)
+    conn.close()
+
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    monkeypatch.delenv("DB_URL", raising=False)
+
+    result = daily_diff_flow.fn(date="2024-05-01")
+
+    assert isinstance(result, RunResult)
+    assert result.tool == "daily_diff_flow"
+
+    conn = sqlite3.connect(db_path)
+    written = conn.execute("SELECT COUNT(*) FROM daily_diffs").fetchone()[0]
+    conn.close()
+
+    assert result.outputs["total_changes"] == written
+    assert result.outputs["managers_processed"] == 1
+
+
+def test_run_id_field_name_matches_chat_context():
+    """Tool runs reuse the ``run_id`` field name standardized by the chat surface."""
+    chat_fields = {f.name for f in dataclass_fields(ChatFleetContext)}
+    assert "run_id" in chat_fields
+    assert "run_id" in RunResult.model_fields

--- a/tests/test_tracked_call.py
+++ b/tests/test_tracked_call.py
@@ -39,6 +39,28 @@ async def test_tracked_call_defaults_when_no_response(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_tracked_call_callable_cost_preserves_error_without_response(tmp_path: Path):
+    db_path = tmp_path / "dev.db"
+
+    def cost_from_response(resp):
+        raise AssertionError(f"cost callable should not receive {resp!r}")
+
+    with pytest.raises(RuntimeError, match="request failed before response"):
+        async with tracked_call(
+            "empty",
+            "http://none",
+            db_path=str(db_path),
+            cost_usd=cost_from_response,
+        ):
+            raise RuntimeError("request failed before response")
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute("SELECT source, endpoint, status, bytes, cost_usd FROM api_usage").fetchone()
+    conn.close()
+    assert row == ("empty", "http://none", 0, 0, 0.0)
+
+
+@pytest.mark.asyncio
 async def test_tracked_call_postgres_uses_strict_backend_safe_sql(monkeypatch):
     dummy = StrictPostgresConn()
     monkeypatch.setattr(base, "connect_db", lambda _db_path=None: dummy)

--- a/tools/run_contract.py
+++ b/tools/run_contract.py
@@ -1,0 +1,69 @@
+"""Uniform ``RunResult`` envelope shared across Manager-Database tools.
+
+Backplane interoperability requires every tool run to be representable as one
+JSON object so an orchestrator can capture, replay, and diff it. The design
+intent already existed for the chat surface — ``api.chat.ChatResponse`` carries a
+stable ``response_id``/``trace_url``/``latency_ms`` and the per-turn
+``langsmith-fleet/v1`` record standardizes ``run_id``/``request_id``
+(``llm.langsmith_fleet.ChatFleetContext``). The deterministic tools, by
+contrast, returned bare data with no run metadata. ``RunResult`` gives them the
+same JSON-representable envelope.
+
+The ``run_id`` field name is deliberately the same one used by
+:class:`llm.langsmith_fleet.ChatFleetContext` so chat-api turns and tool runs
+share a single correlation vocabulary (see
+``tests/test_run_contract.py::test_run_id_field_name_matches_chat_context``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def new_run_id() -> str:
+    """Return a fresh run identifier (uuid4 hex), matching ``ChatFleetContext.run_id``."""
+    return uuid.uuid4().hex
+
+
+class RunCost(BaseModel):
+    """Cost accounting for a single tool run."""
+
+    usd: float = 0.0
+    tokens: int = 0
+
+
+class RunResult(BaseModel):
+    """One JSON-representable record of a single tool run.
+
+    A populated ``RunResult`` is enough to replay, audit, and diff a tool run.
+    ``outputs`` holds the tool's named result payload (a list for
+    ``diff_holdings``, a summary dict for ``daily_diff_flow``); ``inputs`` echoes
+    the validated invocation arguments; ``provenance`` records the source IDs the
+    run was derived from.
+    """
+
+    run_id: str = Field(default_factory=new_run_id)
+    tool: str
+    requested_by: str | None = None
+    reason: str | None = None
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    outputs: Any = None
+    artifacts: list[Any] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    cost: RunCost = Field(default_factory=RunCost)
+    latency_ms: int | None = None
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    status: str = "success"
+
+    @property
+    def deltas(self) -> Any:
+        """Back-compat accessor: the holdings-delta list lives in ``outputs``.
+
+        ``diff_holdings`` historically returned the delta list directly; callers
+        that still want just the deltas can read ``result.deltas`` instead of
+        ``result.outputs``.
+        """
+        return self.outputs


### PR DESCRIPTION
Closes #1087.

## Summary
Introduces a shared, JSON-representable `RunResult` envelope so every deterministic tool run can be captured, replayed, and diffed — extending the correlation vocabulary the chat surface already standardizes (`run_id`/`request_id` in `llm.langsmith_fleet.ChatFleetContext`) to the core tools.

## Changes
- **New `tools/run_contract.py`**: Pydantic `RunResult` model with `run_id`, `tool`, `requested_by`, `reason`, `inputs`, `outputs`, `artifacts`, `warnings`, `cost` (`RunCost{usd, tokens}`), `latency_ms`, `provenance`, `status`; a `new_run_id()` uuid4-hex helper; and a back-compat `.deltas` property. The `run_id` field name deliberately matches `ChatFleetContext.run_id`.
- **`diff_holdings.diff_holdings()`** now returns a `RunResult` whose `outputs`/`.deltas` is the existing delta list and whose `inputs` echoes the resolved `manager_id`. CLI `__main__` reads `.deltas`.
- **`etl.daily_diff_flow.daily_diff_flow()`** signature changed `-> None` → `-> RunResult`, populating `outputs={managers_processed, managers_skipped, total_changes}` and `warnings` for skipped managers; `compute_manager_diffs` reads `.deltas`.
- **`adapters.base.tracked_call`** gains an optional `cost_usd: float | Callable[[Any], float]`; records the computed cost instead of the hard-coded `0.0` (default remains `0.0` when no rate is configured).

## Non-Goals
No re-architecting of `FilingSummary`/`HoldingsAnalysis` content models, no new DB table, no UI. This is the foundation for the downstream artifact/evidence/conflict/data-zone issues.

## Tests
New `tests/test_run_contract.py` covers the four acceptance criteria — `RunResult` return shape, JSON round-trip replay, non-zero cost when a rate is configured, and `daily_diff_flow` `total_changes` matching written `daily_diffs` rows — plus a `run_id` field-name guard. Existing `diff_holdings`/`daily_diff` tests were updated for the new return type.

Local validation: targeted + affected modules pass (`test_run_contract`, `test_diff_holdings`, `test_daily_diff`, `test_tracked_call`, `test_adapter_base`, `test_etl_flows_additional`, `test_daily_diff_deployment`, `test_summariser`, `test_daily_report`); `ruff check` / `ruff format --check` clean; `mypy` clean on `tools/run_contract.py` + `diff_holdings.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)