### PR TITLE
Issue #1088: Promote RAG sources to Evidence objects

### DIFF
--- a/chains/evidence.py
+++ b/chains/evidence.py
@@ -1,0 +1,31 @@
+"""Evidence objects for per-fact RAG source attribution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Evidence(BaseModel):
+    """Structured source evidence for a retrieved or database-backed fact."""
+
+    model_config = ConfigDict(extra="allow")
+
+    source_id: str
+    source_type: str
+    locator: dict[str, Any] = Field(default_factory=dict)
+    excerpt: str
+    method: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    description: str = ""
+    type: str | None = None
+    document_id: str | int | None = None
+    filing_id: int | None = None
+    filing_url: str | None = None
+    news_reference: str | None = None
+    url: str | None = None
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Dictionary-style compatibility for existing source consumers."""
+        return self.model_dump().get(key, default)

--- a/chains/evidence.py
+++ b/chains/evidence.py
@@ -18,7 +18,7 @@ class Evidence(BaseModel):
     locator: dict[str, Any] = Field(default_factory=dict)
     excerpt: str
     method: str
-    confidence: float = Field(ge=0.0, le=1.0)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
     description: str = ""
     type: str | None = None
     document_id: str | int | None = None

--- a/chains/evidence.py
+++ b/chains/evidence.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class Evidence(BaseModel):
@@ -25,6 +26,29 @@ class Evidence(BaseModel):
     filing_url: str | None = None
     news_reference: str | None = None
     url: str | None = None
+
+    @field_validator("confidence")
+    @classmethod
+    def _validate_confidence(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("confidence must be finite")
+        return value
+
+    @model_validator(mode="after")
+    def _populate_legacy_fields(self) -> Evidence:
+        """Populate legacy source keys from locator when not explicitly provided."""
+        if self.document_id is None and "doc_id" in self.locator:
+            self.document_id = self.locator["doc_id"]
+        if self.filing_id is None and "filing_id" in self.locator:
+            try:
+                self.filing_id = int(self.locator["filing_id"])
+            except (TypeError, ValueError):
+                self.filing_id = None
+        if self.filing_url is None and isinstance(self.locator.get("filing_url"), str):
+            self.filing_url = self.locator["filing_url"]
+        if self.url is None and isinstance(self.locator.get("url"), str):
+            self.url = self.locator["url"]
+        return self
 
     def get(self, key: str, default: Any = None) -> Any:
         """Dictionary-style compatibility for existing source consumers."""

--- a/chains/rag_search.py
+++ b/chains/rag_search.py
@@ -10,6 +10,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from adapters.base import connect_db
+from chains.evidence import Evidence
 from embeddings import search_documents
 from llm.injection import guard_input
 from tools.llm_provider import (
@@ -40,7 +41,7 @@ class RAGSearchResult(BaseModel):
     """Structured output for the RAG search chain."""
 
     answer: str
-    sources: list[dict[str, Any]] = Field(default_factory=list)
+    sources: list[Evidence] = Field(default_factory=list)
     confidence: str = Field(default="low")
     trace_url: str | None = None
 
@@ -212,11 +213,11 @@ class RAGSearchChain:
             merged["date_range"] = explicit_date_range
         return merged
 
-    def _structured_search(self, entities: dict[str, Any]) -> tuple[str, list[dict[str, Any]]]:
+    def _structured_search(self, entities: dict[str, Any]) -> tuple[str, list[Evidence]]:
         """Build compact structured context from holdings, filings, news, and activism tables."""
         conn, should_close = self._acquire_connection()
         context_sections: list[str] = []
-        sources: list[dict[str, Any]] = []
+        sources: list[Evidence] = []
         manager_ids = [int(manager_id) for manager_id in entities.get("manager_ids", [])]
         cusips = [str(cusip) for cusip in entities.get("cusips", [])]
         date_range = self._parse_date_range(entities.get("date_range"))
@@ -249,13 +250,20 @@ class RAGSearchChain:
                     lines = [f"Filing {row[0]}: {row[1]} filed {row[2]}" for row in filing_rows]
                     context_sections.append("Recent filings:\n" + "\n".join(lines))
                     for filing_id, filing_type, filed_date, url in filing_rows:
+                        description = f"{filing_type} filed {filed_date}"
                         sources.append(
-                            {
-                                "type": "filing",
-                                "filing_id": int(filing_id),
-                                "description": f"{filing_type} filed {filed_date}",
-                                "filing_url": url,
-                            }
+                            Evidence(
+                                source_id=f"filing:{filing_id}",
+                                source_type="filing",
+                                type="filing",
+                                locator={"filing_id": int(filing_id), "url": url},
+                                excerpt=description,
+                                method="db_lookup",
+                                confidence=0.85,
+                                description=description,
+                                filing_id=int(filing_id),
+                                filing_url=url,
+                            )
                         )
 
                 holding_params: list[Any] = list(manager_ids)
@@ -296,13 +304,21 @@ class RAGSearchChain:
                         lines = [f"{row[1]}: {row[0]}" for row in news_rows]
                         context_sections.append("Recent news:\n" + "\n".join(lines))
                         for headline, published_at, url in news_rows:
+                            headline_text = str(headline)
+                            description = f"Published {published_at}"
                             sources.append(
-                                {
-                                    "type": "news",
-                                    "news_reference": headline,
-                                    "description": f"Published {published_at}",
-                                    "url": url,
-                                }
+                                Evidence(
+                                    source_id=f"news:{headline_text}",
+                                    source_type="news",
+                                    type="news",
+                                    locator={"url": url},
+                                    excerpt=headline_text,
+                                    method="db_lookup",
+                                    confidence=0.8,
+                                    description=description,
+                                    news_reference=headline,
+                                    url=url,
+                                )
                             )
 
                 if self._table_exists(conn, "activism_filings"):
@@ -320,12 +336,19 @@ class RAGSearchChain:
                         lines = [f"{row[1]} on {row[0]} filed {row[2]}" for row in activism_rows]
                         context_sections.append("Activism filings:\n" + "\n".join(lines))
                         for subject_company, filing_type, filed_date, url in activism_rows:
+                            excerpt = f"{filing_type} for {subject_company} filed {filed_date}"
                             sources.append(
-                                {
-                                    "type": "activism_filing",
-                                    "description": f"{filing_type} for {subject_company} filed {filed_date}",
-                                    "filing_url": url,
-                                }
+                                Evidence(
+                                    source_id=f"activism:{subject_company}:{filed_date}",
+                                    source_type="activism_filing",
+                                    type="activism_filing",
+                                    locator={"filing_url": url},
+                                    excerpt=excerpt,
+                                    method="db_lookup",
+                                    confidence=0.8,
+                                    description=excerpt,
+                                    filing_url=url,
+                                )
                             )
 
             if cusips and self._table_exists(conn, "crowded_trades"):
@@ -354,31 +377,38 @@ class RAGSearchChain:
             if should_close:
                 conn.close()
 
-    def _document_context(
-        self, documents: list[dict[str, Any]]
-    ) -> tuple[str, list[dict[str, Any]]]:
+    def _document_context(self, documents: list[dict[str, Any]]) -> tuple[str, list[Evidence]]:
         lines: list[str] = []
-        sources: list[dict[str, Any]] = []
+        sources: list[Evidence] = []
         for document in documents:
             snippet = str(document.get("content", "")).strip().replace("\n", " ")[:400]
+            doc_id = str(document.get("doc_id") or "")
+            description = str(document.get("filename") or document.get("kind") or "document")
             lines.append(
                 f"doc {document.get('doc_id')}: {document.get('filename') or document.get('kind') or 'document'} | {snippet}"
             )
             sources.append(
-                {
-                    "type": "document",
-                    "document_id": document.get("doc_id"),
-                    "description": document.get("filename") or document.get("kind") or "document",
-                }
+                Evidence(
+                    source_id=doc_id,
+                    source_type="document",
+                    type="document",
+                    locator={"doc_id": doc_id},
+                    excerpt=snippet,
+                    method="vector_search",
+                    confidence=0.9,
+                    description=description,
+                    document_id=document.get("doc_id"),
+                )
             )
         return "\n".join(lines) if lines else "No relevant document excerpts found.", sources
 
-    def _confidence(
-        self, documents: list[dict[str, Any]], structured_sources: list[dict[str, Any]]
-    ) -> str:
-        if documents and structured_sources:
+    def _confidence(self, evidence: list[Evidence]) -> str:
+        if not evidence:
+            return "low"
+        best = max(item.confidence for item in evidence)
+        if best >= 0.85 and len(evidence) >= 2:
             return "high"
-        if documents or structured_sources:
+        if best >= 0.65:
             return "medium"
         return "low"
 
@@ -418,7 +448,7 @@ class RAGSearchChain:
         structured_context, structured_sources = self._structured_search(entities)
         document_context, document_sources = self._document_context(documents)
         all_sources = document_sources + structured_sources
-        confidence = self._confidence(documents, structured_sources)
+        confidence = self._confidence(all_sources)
 
         if not documents and not structured_sources:
             return RAGSearchResult(

--- a/tests/test_rag_search_chain.py
+++ b/tests/test_rag_search_chain.py
@@ -169,6 +169,22 @@ def test_document_excerpt_carried(monkeypatch):
     conn.close()
 
 
+def test_evidence_model_json_and_legacy_fields_from_locator():
+    evidence = Evidence(
+        source_id="filing:11",
+        source_type="filing",
+        locator={"filing_id": "11", "url": "https://example.com/filings/11"},
+        excerpt="13F-HR filed 2026-03-01",
+        method="db_lookup",
+        confidence=0.85,
+    )
+
+    payload = evidence.model_dump()
+    assert payload["filing_id"] == 11
+    assert payload["url"] == "https://example.com/filings/11"
+    assert '"source_id":"filing:11"' in evidence.model_dump_json()
+
+
 def test_run_returns_low_confidence_without_context(monkeypatch):
     conn = _build_db()
     chain = RAGSearchChain(db_conn=conn)

--- a/tests/test_rag_search_chain.py
+++ b/tests/test_rag_search_chain.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from chains.evidence import Evidence
 from chains.rag_search import RAGSearchChain
 from llm.injection import PromptInjectionError
 
@@ -113,6 +114,58 @@ def test_run_combines_vector_and_structured_context(monkeypatch):
     assert any(source.get("document_id") == 7 for source in result["sources"])
     assert any(source.get("filing_id") == 11 for source in result["sources"])
     assert llm.prompts and "Structured data" in llm.prompts[0]
+    conn.close()
+
+
+def test_sources_are_evidence_objects(monkeypatch):
+    conn = _build_db()
+    chain = RAGSearchChain(llm=FakeLLM("Evidence answer."), db_conn=conn)
+    monkeypatch.setattr(
+        "chains.rag_search.search_documents",
+        lambda query, k=5, manager_id=None: [
+            {
+                "doc_id": "doc-live-1",
+                "content": "Apple Inc remained a top holding for Elliott.",
+                "filename": "elliott-apple-note.md",
+                "kind": "memo",
+            }
+        ],
+    )
+
+    documents = chain._vector_search("What does Elliott hold?")
+    _document_context, document_sources = chain._document_context(documents)
+    _structured_context, structured_sources = chain._structured_search(
+        {"manager_ids": [1], "cusips": [], "keywords": [], "date_range": None}
+    )
+    result = chain.run("What does Elliott hold?")
+
+    direct_sources = document_sources + structured_sources
+    assert direct_sources
+    assert all(isinstance(source, Evidence) for source in direct_sources)
+    for source in result["sources"]:
+        assert source["source_id"]
+        assert source["excerpt"]
+        assert source["method"] in {"vector_search", "db_lookup"}
+        assert 0.0 <= source["confidence"] <= 1.0
+    conn.close()
+
+
+def test_document_excerpt_carried(monkeypatch):
+    conn = _build_db()
+    chain = RAGSearchChain(llm=FakeLLM("Evidence answer."), db_conn=conn)
+    document_text = "A" * 450
+    monkeypatch.setattr(
+        "chains.rag_search.search_documents",
+        lambda query, k=5, manager_id=None: [
+            {"doc_id": "doc-live-1", "content": document_text, "filename": "note.md"}
+        ],
+    )
+
+    result = chain.run("What does Elliott hold?")
+    document_source = next(
+        source for source in result["sources"] if source["source_type"] == "document"
+    )
+    assert document_source["excerpt"] == document_text[:400]
     conn.close()
 
 

--- a/tests/test_rag_search_chain.py
+++ b/tests/test_rag_search_chain.py
@@ -185,6 +185,17 @@ def test_evidence_model_json_and_legacy_fields_from_locator():
     assert '"source_id":"filing:11"' in evidence.model_dump_json()
 
 
+def test_evidence_confidence_defaults_to_zero_when_omitted():
+    evidence = Evidence(
+        source_id="doc:1",
+        source_type="document",
+        excerpt="excerpt",
+        method="vector",
+    )
+
+    assert evidence.confidence == 0.0
+
+
 def test_run_returns_low_confidence_without_context(monkeypatch):
     conn = _build_db()
     chain = RAGSearchChain(db_conn=conn)


### PR DESCRIPTION
## Summary
Implements #1088 by promoting RAG source attribution from loose dicts to structured Evidence objects.

## Changes
- Add `chains/evidence.py` with a JSON-serializable `Evidence` model carrying source ID/type, locator, excerpt, method, and per-fact confidence.
- Emit Evidence from document vector hits, filings, news, and activism structured lookups while preserving legacy source keys for UI/test compatibility.
- Roll result-level confidence up from evidence confidence values.
- Add acceptance coverage for Evidence objects and 400-character document excerpt threading.

## Validation
- `python -m pytest -q tests/test_rag_search_chain.py tests/test_chain_postgres_integration.py tests/test_evaluation.py --no-cov` -> 23 passed, 4 skipped.
- `ruff check chains/evidence.py chains/rag_search.py tests/test_rag_search_chain.py` -> pass.
- `black --check chains/evidence.py chains/rag_search.py tests/test_rag_search_chain.py` -> pass.
- `mypy chains/evidence.py chains/rag_search.py` -> pass.

Closes #1088.