### PR TITLE
Issue #1089: Add offline golden CI gate for eval thresholds + diff_holdings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,24 @@ jobs:
       - name: Run Postgres chain integration tests
         run: pytest tests/test_chain_postgres_integration.py -v
 
+  golden:
+    name: Golden offline gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install test dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Run offline golden/threshold gate
+        # No service container and no provider secrets: the golden tests run the
+        # deterministic eval suite and diff_holdings goldens over in-memory
+        # SQLite fixtures, so zero external dependency must be required here.
+        run: pytest -m golden -v
+
   docker-smoke:
     name: Docker stack smoke
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ pythonpath = ["."]
 markers = [
     "nightly: nightly regression tests",
     "integration: integration tests",
+    "golden: offline credential-free golden/threshold gate runs",
 ]
 
 [tool.black]

--- a/tests/eval_datasets/README.md
+++ b/tests/eval_datasets/README.md
@@ -14,3 +14,20 @@ Datasets:
 - `filing_summary_eval.json`: filing summary quality checks.
 - `nl_query_eval.json`: NL-to-SQL correctness and safety checks.
 - `rag_search_eval.json`: RAG faithfulness, source attribution, and hallucination checks.
+
+## Golden CI gate
+
+The `golden` pytest marker backs a dedicated, **offline and synthetic** CI job
+(`golden` in `.github/workflows/ci.yml`) that runs `pytest -m golden -v`. It
+gates two things on every PR, using only in-memory SQLite and the deterministic
+fake providers — no `LANGSMITH_API_KEY`, `OPENAI_API_KEY`, or any provider
+secret, and no external LLM calls:
+
+- `tests/test_evaluation.py::test_live_eval_meets_thresholds` runs
+  `run_live_evaluation_suite()` over the seeded corpus and asserts every metric
+  in `summary["metrics"]` meets its bound in
+  `etl.evaluation_flow.QUALITY_THRESHOLDS` with no recorded failures. Raising any
+  threshold above what the deterministic fixtures score makes this fail.
+- `tests/test_diff_holdings.py::test_diff_holdings_golden` asserts the exact
+  `diff_holdings` delta list for a fixture exercising all four `delta_type`
+  branches (ADD/EXIT/INCREASE/DECREASE), pinning the classification logic.

--- a/tests/test_diff_holdings.py
+++ b/tests/test_diff_holdings.py
@@ -99,6 +99,59 @@ def test_diff_holdings_returns_structured_four_delta_types():
     ]
 
 
+@pytest.mark.golden
+def test_diff_holdings_golden():
+    """Golden gate: the exact delta list for a fixture exercising all four branches.
+
+    Two filings per manager produce one of each ``delta_type``
+    (INCREASE/EXIT/ADD/DECREASE). Asserting the exact list pins the
+    classification logic in ``diff_holdings`` — e.g. swapping INCREASE/DECREASE
+    in ``_compare_optional`` handling makes this test fail.
+    """
+    conn = _setup_canonical_db()
+    rows = diff_holdings(1, conn).deltas
+    conn.close()
+
+    assert rows == [
+        {
+            "cusip": "AAA",
+            "name_of_issuer": "CorpA",
+            "delta_type": "INCREASE",
+            "shares_prev": 100,
+            "shares_curr": 120,
+            "value_prev": 1000,
+            "value_curr": 1200,
+        },
+        {
+            "cusip": "BBB",
+            "name_of_issuer": "CorpB",
+            "delta_type": "EXIT",
+            "shares_prev": 30,
+            "shares_curr": None,
+            "value_prev": 300,
+            "value_curr": None,
+        },
+        {
+            "cusip": "CCC",
+            "name_of_issuer": "CorpC",
+            "delta_type": "ADD",
+            "shares_prev": None,
+            "shares_curr": 40,
+            "value_prev": None,
+            "value_curr": 400,
+        },
+        {
+            "cusip": "EEE",
+            "name_of_issuer": "CorpE",
+            "delta_type": "DECREASE",
+            "shares_prev": 10,
+            "shares_curr": 8,
+            "value_prev": 100,
+            "value_curr": 80,
+        },
+    ]
+
+
 def test_diff_holdings_accepts_cik_lookup():
     """CIK string should resolve to the same results as integer manager_id."""
     conn = _setup_canonical_db()

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -4,7 +4,10 @@ import json
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 import etl.evaluation_flow as evaluation_flow
+from etl.evaluation_flow import QUALITY_THRESHOLDS
 from llm.evaluation import ManagerDBEvaluator
 
 
@@ -203,6 +206,29 @@ def test_live_evaluation_suite_scores_live_chain_outputs(tmp_path):
     assert summary["metrics"]["rag_faithfulness"] == 1.0
     assert summary["metrics"]["source_attribution"] == 1.0
     assert summary["metrics"]["hallucination"] == 1.0
+    assert summary["failures"] == {}
+    conn.close()
+
+
+@pytest.mark.golden
+def test_live_eval_meets_thresholds(tmp_path):
+    """Golden gate: every live metric must meet its QUALITY_THRESHOLDS bound.
+
+    Runs the deterministic, credential-free live evaluation suite over the
+    in-memory seeded corpus and asserts each metric clears its threshold with
+    no recorded failures. This is the assertion the CI ``golden`` job depends
+    on: temporarily raising any bound in ``QUALITY_THRESHOLDS`` above what the
+    deterministic fixtures score makes this test fail.
+    """
+    conn = sqlite3.connect(tmp_path / "golden-eval.db")
+
+    summary = evaluation_flow.run_live_evaluation_suite.fn(db_conn=conn)
+
+    metrics = summary["metrics"]
+    # Every threshold key must be scored and clear its bound.
+    for key, bound in QUALITY_THRESHOLDS.items():
+        assert key in metrics, f"metric {key!r} missing from live summary"
+        assert metrics[key] >= bound, f"{key}={metrics[key]} below threshold {bound}"
     assert summary["failures"] == {}
     conn.close()
 


### PR DESCRIPTION
## Summary
Implements #1089 by gating the existing offline eval thresholds and the `diff_holdings` classification as a credential-free CI **golden** run with zero data egress.

## Changes
- Register a `golden` pytest marker in `pyproject.toml`.
- `tests/test_evaluation.py::test_live_eval_meets_thresholds` — runs `run_live_evaluation_suite()` over the in-memory seeded corpus and asserts every metric in `summary["metrics"]` meets its bound in `etl.evaluation_flow.QUALITY_THRESHOLDS`, with `summary["failures"] == {}`.
- `tests/test_diff_holdings.py::test_diff_holdings_golden` — seeds two filings per manager exercising all four `delta_type` branches (ADD/EXIT/INCREASE/DECREASE) and asserts the exact returned delta list.
- Add a `golden` job to `.github/workflows/ci.yml` (mirrors the `postgres-integration` job but with **no service container and no secrets**) running `pytest -m golden -v` on Python 3.12.
- Document the offline/synthetic golden-run contract in `tests/eval_datasets/README.md`.

## Privacy
The gate uses only the deterministic in-memory providers (`_DeterministicFilingSummaryLLM`/`_DeterministicNLQueryLLM`/`_DeterministicRAGLLM`) and committed synthetic fixtures — no `LANGSMITH_API_KEY`, `OPENAI_API_KEY`, or any provider secret, and no external LLM calls.

## Validation
- `pytest -m golden -v` with `LANGSMITH_API_KEY`/`OPENAI_API_KEY`/`ANTHROPIC_API_KEY` unset in the environment -> 2 passed, 837 deselected (proves zero external dependency).
- `pytest tests/test_evaluation.py tests/test_diff_holdings.py` -> 20 passed.
- Gate-bites check: live metrics all score 1.0 with headroom over every threshold; raising any `QUALITY_THRESHOLDS` value above the scored value makes `test_live_eval_meets_thresholds` fail. The exact-list assertion in `test_diff_holdings_golden` fails if INCREASE/DECREASE classification is swapped.
- `ruff check` and `black --check` on the touched test files -> pass. `mypy` on the touched test files -> clean (the `etl/` package is excluded from mypy by the repo's existing config).

Closes #1089.
