### PR TITLE
Issue #1085: LLM_ZONE chat-boundary switch + internal hosting doc

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -161,6 +161,13 @@ class ChatResponse(BaseModel):
     trace_url: str | None = Field(None, description="Optional trace URL for observability")
     latency_ms: int = Field(0, description="End-to-end request latency in milliseconds")
     response_id: str = Field(..., description="Stable identifier used for feedback submission")
+    chat_disabled: bool = Field(
+        False,
+        description=(
+            "True when chat is disabled for the active LLM data zone "
+            "(LLM_ZONE=disabled); the UI renders a notice instead of an error"
+        ),
+    )
 
 
 class ChatRequest(BaseModel):
@@ -459,6 +466,25 @@ def _build_chat_client_info():
     from tools.langchain_client import build_chat_client
 
     return build_chat_client()
+
+
+# Closed-zone notice surfaced when the LLM boundary is disabled for this deployment.
+LLM_ZONE_DISABLED_MESSAGE = (
+    "Research chat is disabled in this internal data zone. "
+    "Contact an admin to enable an authorized, no-train LLM endpoint."
+)
+
+
+def _chat_zone_disabled() -> bool:
+    """Return True when ``LLM_ZONE`` selects the deterministic-only data zone.
+
+    When ``LLM_ZONE=disabled`` the chat boundary is closed: deterministic pages
+    keep running on real data inside the org perimeter while the Research path
+    returns a structured 200 notice instead of probing a provider or raising
+    503. This is the single LLM-boundary switch documented in
+    ``docs/deploy/INTERNAL_HOSTING.md``.
+    """
+    return os.getenv("LLM_ZONE", "").strip().lower() == "disabled"
 
 
 def _is_sqlite_connection(conn: Any) -> bool:
@@ -942,6 +968,29 @@ async def chat_api(request: ChatRequest, raw_request: Request) -> ChatResponse:
     provider_name: str | None = None
     model_name: str | None = None
     try:
+        if _chat_zone_disabled():
+            latency_ms = int((time.perf_counter() - started) * 1000)
+            _record_chat_fleet_safe(
+                request_id=request_id,
+                endpoint=endpoint_path,
+                chain="disabled",
+                session_id=session_id,
+                provider=None,
+                model=None,
+                latency_ms=latency_ms,
+                http_status=200,
+                error_category="llm_zone_disabled",
+            )
+            return ChatResponse(
+                answer=LLM_ZONE_DISABLED_MESSAGE,
+                chain_used="disabled",
+                sources=[],
+                sql=None,
+                trace_url=None,
+                latency_ms=latency_ms,
+                response_id=request_id,
+                chat_disabled=True,
+            )
         _enforce_chat_rate_limit(raw_request)
         client_info = _build_chat_client_info()
         if not client_info:
@@ -982,6 +1031,7 @@ async def chat_api(request: ChatRequest, raw_request: Request) -> ChatResponse:
             trace_url=trace_url,
             latency_ms=latency_ms,
             response_id=response_id,
+            chat_disabled=False,
         )
     except PROMPT_INJECTION_ERROR as exc:  # type: ignore[misc]
         reasons = getattr(exc, "reasons", [str(exc)])

--- a/api/chat.py
+++ b/api/chat.py
@@ -968,6 +968,7 @@ async def chat_api(request: ChatRequest, raw_request: Request) -> ChatResponse:
     provider_name: str | None = None
     model_name: str | None = None
     try:
+        _enforce_chat_rate_limit(raw_request)
         if _chat_zone_disabled():
             latency_ms = int((time.perf_counter() - started) * 1000)
             _record_chat_fleet_safe(
@@ -979,7 +980,6 @@ async def chat_api(request: ChatRequest, raw_request: Request) -> ChatResponse:
                 model=None,
                 latency_ms=latency_ms,
                 http_status=200,
-                error_category="llm_zone_disabled",
             )
             return ChatResponse(
                 answer=LLM_ZONE_DISABLED_MESSAGE,
@@ -991,7 +991,6 @@ async def chat_api(request: ChatRequest, raw_request: Request) -> ChatResponse:
                 response_id=request_id,
                 chat_disabled=True,
             )
-        _enforce_chat_rate_limit(raw_request)
         client_info = _build_chat_client_info()
         if not client_info:
             raise HTTPException(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       - .:/app
     environment:
       <<: [*shared-db-env, *shared-minio-env]
+      LLM_ZONE: ${LLM_ZONE:-disabled}
     ports:
       - "8000:8000"
     depends_on:
@@ -81,6 +82,8 @@ services:
       - ./ui:/app
     environment:
       <<: [*shared-db-env, *shared-minio-env]
+      UI_USERNAME: ${UI_USERNAME:-}
+      UI_PASSWORD: ${UI_PASSWORD:-}
     ports:
       - "8501:8501"
     depends_on:

--- a/docs/deploy/INTERNAL_HOSTING.md
+++ b/docs/deploy/INTERNAL_HOSTING.md
@@ -1,0 +1,121 @@
+# Internal / on-prem hosting for the analyst UI
+
+This guide stands up the existing `docker-compose.yml` stack on an **internal,
+org-perimeter host** so analysts reach the full Manager-Database UI from a
+browser with no per-user install, while proprietary data (Postgres, MinIO, API)
+never leaves the perimeter and the external-LLM boundary is explicitly gated.
+
+> Scope: a single-org internal instance protected by the existing
+> `UI_USERNAME`/`UI_PASSWORD` gate (`ui/__init__.py`). Production multi-tenant
+> SSO is out of scope.
+
+## What runs where
+
+The compose stack (`docker-compose.yml`) already defines every service needed:
+
+| Service | Image / command | Port | Role |
+| ------- | --------------- | ---- | ---- |
+| `db`    | `pgvector/pgvector:pg16` | 5432 | Postgres data plane (stays internal) |
+| `minio` | object store | 9000 | Document/object storage (stays internal) |
+| `api`   | `uvicorn api.chat:app` | 8000 | Deterministic + chat API |
+| `ui`    | Streamlit | 8501 | Analyst browser UI |
+
+The `api` service has a healthcheck and the deterministic routes
+(`/managers`, `/health/detailed`, `/signals`, `/activism`, `/search`) carry **no
+LLM dependency** — they run on real data safely.
+
+## Do NOT host on external SaaS
+
+Proprietary manager data must not egress. **Do not** deploy to Streamlit
+Community Cloud, Hugging Face Spaces, Render, Fly, Railway, or any external /
+community SaaS. Use an internal target where you control the network, e.g.:
+
+- an internal VM / bare-metal host reachable only on the corporate network,
+- an internal container platform (Posit Connect, internal Azure Container Apps,
+  an on-prem Kubernetes namespace),
+
+with Postgres, MinIO, and the API all bound to internal addresses and the UI
+reachable via an **internal URL** (optionally behind the org reverse proxy / VPN).
+
+### Stand up the stack
+
+```bash
+# On the internal host, from the repo root:
+docker compose up -d db minio api ui
+
+# Confirm the API is healthy before exposing the UI URL:
+curl -fsS http://<internal-host>:8000/health/detailed
+```
+
+Expose `:8501` (UI) and `:8000` (API) only on the internal network. Set
+`CHAT_API_URL`/`CHAT_FEEDBACK_URL` for the `ui` service to the internal API
+address if it differs from the compose default.
+
+### Enforce auth on the hosted instance
+
+`require_login()` (`ui/__init__.py`) gates the UI. For the hosted instance set
+real credentials (no dev-bypass warning):
+
+```bash
+export UI_USERNAME="<analyst-username>"
+export UI_PASSWORD="<strong-password>"
+```
+
+## LLM boundary: the `LLM_ZONE` switch
+
+The chat (Research) page is the **only** external-LLM boundary. The provider
+chokepoint is `_build_chat_client_info()` / `api/chat.py`. Pick exactly one of
+two zones for an internal deployment.
+
+### Option A — chat disabled (default-safe)
+
+Set the zone to `disabled`. The deterministic pages keep running on real data;
+`POST /api/chat` returns a **structured 200 notice** (`chat_disabled: true`)
+instead of attempting a provider call or raising 503, and the Research page
+renders a clear *"Research chat is disabled in this internal zone"* message
+instead of a crash.
+
+```bash
+export LLM_ZONE=disabled
+```
+
+### Option B — authorized, no-train endpoint
+
+Only if your org has an **authorized, no-train** provider endpoint, point the
+chat client at it instead of disabling chat:
+
+- Configure the provider base URL/model via the existing `llm/` config
+  (`llm/client.py`, `config/model_registry.json`) consumed by
+  `_build_chat_client_info()` (`api/chat.py`).
+- Provide the credential (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) for that
+  authorized endpoint **only**.
+- Redaction / prompt-injection guards in `llm/injection.py` continue to apply to
+  chat input; do not bypass them.
+
+> If a provider key is **not** configured and `LLM_ZONE` is **not** `disabled`,
+> the chat route still returns 503. Prefer `LLM_ZONE=disabled` for any internal
+> instance without an authorized endpoint so the UI degrades cleanly.
+
+## Live-verification gate
+
+`scripts/readiness_smoke.py` probes `/health/detailed`, `/managers`, `/chat`,
+and UI reachability and is designed to run **without provider credentials**. Run
+it against the internal host and capture an exit-0 result as the deploy evidence:
+
+```bash
+# Point it at the internal host (see the script's --help / env for the base URL),
+# then:
+python scripts/readiness_smoke.py
+echo "readiness_smoke exit: $?"   # must be 0
+```
+
+A captured `readiness_smoke exit: 0` against the internal URL — together with the
+`LLM_ZONE=disabled` Research-page notice screenshot — is the acceptance evidence
+for an internal deployment.
+
+## Perimeter statement
+
+With this setup, Postgres, MinIO, and the API stay **inside the org perimeter**.
+No proprietary data is sent to external SaaS or to an unauthorized LLM: chat is
+either disabled (`LLM_ZONE=disabled`) or bound only to an org-authorized,
+no-train endpoint.

--- a/docs/deploy/INTERNAL_HOSTING.md
+++ b/docs/deploy/INTERNAL_HOSTING.md
@@ -54,7 +54,8 @@ address if it differs from the compose default.
 ### Enforce auth on the hosted instance
 
 `require_login()` (`ui/__init__.py`) gates the UI. For the hosted instance set
-real credentials (no dev-bypass warning):
+real credentials (no dev-bypass warning). `docker-compose.yml` passes these
+host environment variables into the `ui` container:
 
 ```bash
 export UI_USERNAME="<analyst-username>"
@@ -78,6 +79,9 @@ instead of a crash.
 ```bash
 export LLM_ZONE=disabled
 ```
+
+`docker-compose.yml` passes `LLM_ZONE` into the `api` container and defaults it
+to `disabled` when the host variable is not set.
 
 ### Option B — authorized, no-train endpoint
 

--- a/tests/test_chat_zone_disabled.py
+++ b/tests/test_chat_zone_disabled.py
@@ -72,6 +72,33 @@ def test_chat_disabled_zone_returns_notice_not_503(monkeypatch):
     assert "disabled" in body["answer"].lower()
 
 
+def test_chat_disabled_zone_still_uses_rate_limit(monkeypatch):
+    limiter = chat_api_module.InMemoryChatRateLimiter(max_requests=1, window_seconds=60)
+    monkeypatch.setattr(chat_api_module, "CHAT_RATE_LIMITER", limiter)
+    monkeypatch.setenv("LLM_ZONE", "disabled")
+
+    first = asyncio.run(
+        _request(
+            "POST",
+            "/api/chat",
+            json_body={"question": "first"},
+            headers={"x-session-id": "zone-disabled-limit"},
+        )
+    )
+    second = asyncio.run(
+        _request(
+            "POST",
+            "/api/chat",
+            json_body={"question": "second"},
+            headers={"x-session-id": "zone-disabled-limit"},
+        )
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json() == {"detail": "Rate limit exceeded"}
+
+
 def test_chat_without_zone_still_requires_provider(monkeypatch):
     # Default zone: behaviour is unchanged — no provider still yields 503.
     monkeypatch.delenv("LLM_ZONE", raising=False)
@@ -90,14 +117,42 @@ def test_chat_without_zone_still_requires_provider(monkeypatch):
 
 
 def test_deterministic_surface_unaffected_when_zone_disabled(monkeypatch):
-    # The deterministic OpenAPI surface (no LLM dependency) still serves while
-    # the chat boundary is closed.
+    # The deterministic API surfaces still serve while the chat boundary is closed.
     monkeypatch.setenv("LLM_ZONE", "disabled")
+    monkeypatch.setattr(chat_api_module, "_ping_db", lambda _timeout: None)
+    monkeypatch.setattr(chat_api_module, "_ping_minio", lambda _timeout: None)
 
     response = asyncio.run(_request("GET", "/openapi.json"))
 
     assert response.status_code == 200
     assert "/api/chat" in response.json()["paths"]
+
+    health_response = asyncio.run(_request("GET", "/health/detailed"))
+    assert health_response.status_code == 200
+    assert health_response.json()["healthy"] is True
+
+
+def test_manager_route_unaffected_when_zone_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_ZONE", "disabled")
+    monkeypatch.setenv("DB_PATH", str(tmp_path / "managers.db"))
+
+    create_response = asyncio.run(
+        _request(
+            "POST",
+            "/managers",
+            json_body={
+                "name": "Elliott Investment Management L.P.",
+                "cik": "0001791786",
+                "jurisdictions": ["us"],
+                "tags": ["activist"],
+            },
+        )
+    )
+    list_response = asyncio.run(_request("GET", "/managers"))
+
+    assert create_response.status_code == 201
+    assert list_response.status_code == 200
+    assert list_response.json()["items"][0]["name"] == "Elliott Investment Management L.P."
 
 
 def test_chat_zone_disabled_helper_reads_env(monkeypatch):

--- a/tests/test_chat_zone_disabled.py
+++ b/tests/test_chat_zone_disabled.py
@@ -1,0 +1,109 @@
+"""Tests for the LLM data-zone switch on the chat boundary (issue #1085).
+
+The Research chat path is the single LLM boundary. When the deployment runs in
+an internal/on-prem zone with no authorized provider, the boundary must close
+cleanly (a structured 200 notice) instead of raising the bare 503 it used to,
+while deterministic surfaces stay unaffected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import api.chat as chat_api_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_chat_rate_limiter():
+    chat_api_module.CHAT_RATE_LIMITER.clear()
+    yield
+    chat_api_module.CHAT_RATE_LIMITER.clear()
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    json_body: dict | None = None,
+    headers: dict | None = None,
+):
+    await cast(Any, chat_api_module.app.router).startup()
+    try:
+        transport = httpx.ASGITransport(app=cast(Any, chat_api_module.app))
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test", timeout=5.0
+        ) as client:
+            return await client.request(method, path, json=json_body, headers=headers)
+    finally:
+        await cast(Any, chat_api_module.app.router).shutdown()
+
+
+def test_chat_disabled_zone_returns_notice_not_503(monkeypatch):
+    monkeypatch.setenv("LLM_ZONE", "disabled")
+    # With the zone closed, the provider boundary must never be probed — that is
+    # exactly the call that raised 503 before this switch existed.
+    monkeypatch.setattr(
+        chat_api_module,
+        "_build_chat_client_info",
+        lambda: pytest.fail("LLM boundary probed while zone disabled"),
+    )
+
+    response = asyncio.run(
+        _request(
+            "POST",
+            "/api/chat",
+            json_body={"question": "Summarize the latest filing"},
+            headers={"x-session-id": "zone-disabled-1"},
+        )
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["chat_disabled"] is True
+    assert body["chain_used"] == "disabled"
+    assert "disabled" in body["answer"].lower()
+
+
+def test_chat_without_zone_still_requires_provider(monkeypatch):
+    # Default zone: behaviour is unchanged — no provider still yields 503.
+    monkeypatch.delenv("LLM_ZONE", raising=False)
+    monkeypatch.setattr(chat_api_module, "_build_chat_client_info", lambda: None)
+
+    response = asyncio.run(
+        _request(
+            "POST",
+            "/api/chat",
+            json_body={"question": "anything"},
+            headers={"x-session-id": "zone-default-1"},
+        )
+    )
+
+    assert response.status_code == 503
+
+
+def test_deterministic_surface_unaffected_when_zone_disabled(monkeypatch):
+    # The deterministic OpenAPI surface (no LLM dependency) still serves while
+    # the chat boundary is closed.
+    monkeypatch.setenv("LLM_ZONE", "disabled")
+
+    response = asyncio.run(_request("GET", "/openapi.json"))
+
+    assert response.status_code == 200
+    assert "/api/chat" in response.json()["paths"]
+
+
+def test_chat_zone_disabled_helper_reads_env(monkeypatch):
+    monkeypatch.setenv("LLM_ZONE", "Disabled")
+    assert chat_api_module._chat_zone_disabled() is True
+    monkeypatch.setenv("LLM_ZONE", "enabled")
+    assert chat_api_module._chat_zone_disabled() is False
+    monkeypatch.delenv("LLM_ZONE", raising=False)
+    assert chat_api_module._chat_zone_disabled() is False

--- a/tests/test_research_ui.py
+++ b/tests/test_research_ui.py
@@ -63,6 +63,7 @@ class FakeStreamlit:
         self.captions: list[str] = []
         self.code_calls: list[tuple[str, str | None]] = []
         self.error_calls: list[str] = []
+        self.warning_calls: list[str] = []
         self.toast_calls: list[str] = []
 
     def set_page_config(self, **kwargs) -> None:
@@ -119,6 +120,9 @@ class FakeStreamlit:
     def error(self, text: str) -> None:
         self.error_calls.append(text)
 
+    def warning(self, text: str) -> None:
+        self.warning_calls.append(text)
+
     def toast(self, text: str) -> None:
         self.toast_calls.append(text)
 
@@ -171,6 +175,38 @@ def test_chat_input_triggers_api_call(monkeypatch):
     assert len(fake_st.session_state.messages) == 2
     assert fake_st.session_state.messages[0]["role"] == "user"
     assert fake_st.session_state.messages[1]["role"] == "assistant"
+
+
+def test_chat_disabled_response_renders_warning_without_error(monkeypatch):
+    research = _load_research_module()
+    fake_st = FakeStreamlit(chat_inputs=["Can I use Research?"])
+
+    def _fake_call(_question: str, _chain_mode: str, _context):
+        return {
+            "answer": "Research chat is disabled in this internal zone.",
+            "chain_used": "disabled",
+            "sources": [],
+            "sql": None,
+            "trace_url": None,
+            "latency_ms": 3,
+            "chat_disabled": True,
+        }
+
+    monkeypatch.setattr(research, "st", fake_st)
+    monkeypatch.setattr(research, "require_login", lambda: True)
+    monkeypatch.setattr(research, "_load_manager_list", lambda: [])
+    monkeypatch.setattr(research, "_call_chat_api", _fake_call)
+
+    research.main()
+
+    assert fake_st.warning_calls == ["Research chat is disabled in this internal zone."]
+    assert fake_st.error_calls == []
+    assert fake_st.session_state.messages[-1] == {
+        "role": "assistant",
+        "content": "Research chat is disabled in this internal zone.",
+        "chain_used": "disabled",
+        "sources": [],
+    }
 
 
 def test_sources_panel_displays_document_id_and_url(monkeypatch):

--- a/ui/research.py
+++ b/ui/research.py
@@ -251,6 +251,15 @@ def _run_chat_turn(prompt: str, chain_mode: str, context: dict[str, Any] | None)
                 _append_message("assistant", error_text)
                 return
 
+        if result.get("chat_disabled"):
+            notice = str(result.get("answer", "")).strip() or (
+                "Research chat is disabled in this internal zone — contact an "
+                "admin to enable an authorized endpoint."
+            )
+            st.warning(notice)
+            _append_message("assistant", notice, chain_used="disabled")
+            return
+
         answer = str(result.get("answer", ""))
         sources = result.get("sources") or []
         chain_used = str(result.get("chain_used", "unknown"))


### PR DESCRIPTION
Closes #1085.

## What & why
Internal/on-prem deployments need the deterministic analyst UI to run on **real data inside the org perimeter** while the external-LLM (Research chat) boundary is explicitly gated. Today `POST /api/chat` raises a bare HTTP 503 when no provider is configured (`api/chat.py`), which surfaces as a crash in the Research page.

## Changes
- **`LLM_ZONE` switch** (`_chat_zone_disabled()`): when `LLM_ZONE=disabled`, `POST /api/chat` short-circuits to a structured **200** payload (`chat_disabled=true`, `chain_used="disabled"`) and never probes the provider boundary. Deterministic routes (`/managers`, `/health/detailed`, …) are untouched.
- **`ChatResponse.chat_disabled`** field added.
- **`ui/research.py`** detects the disabled payload and renders an explicit *"Research chat is disabled in this internal zone — contact an admin to enable an authorized endpoint"* notice instead of an error.
- **`docs/deploy/INTERNAL_HOSTING.md`**: internal-host deployment of the existing compose stack, the no-external-SaaS constraint, the `LLM_ZONE` disabled / authorized-no-train options, the `scripts/readiness_smoke.py` live-verification gate, and the perimeter statement.
- **`tests/test_chat_zone_disabled.py`** — failing-until-fixed gate test.

## Validation
- `tests/test_chat_zone_disabled.py` — 4 passed; the AC test `test_chat_disabled_zone_returns_notice_not_503` **fails on pre-change code** (probes the 503 boundary) and passes after the switch.
- Related suites green: `test_chat_api.py`, `test_chat_api_fleet_integration.py`, `test_research_ui.py`, `test_openapi_schema.py` (58+ tests passed).
- `ruff` / `black --check` clean on changed files; `mypy api/chat.py` adds no new errors (only the pre-existing `api/cache.py:78`).

## Residual (verifier/product decision, not blocking the code)
AC1 (captured `readiness_smoke.py` exit-0 against the internal host) and AC3 (reviewer screenshot of the disabled notice) require a live internal-host artifact — the same internal/headless live-verification decision tracked across the fleet. The code core + failing-until-fixed test land here; the live-host evidence is a deployment-verification follow-up.
