### PR TITLE
Issue #1090: add local artifact manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ autofix_report_enriched.json
 
 # LangSmith fleet NDJSON artifacts (regenerated per run; uploaded by CI)
 artifacts/langsmith/
+artifacts/daily_diff/
+artifacts/digest/

--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -20,6 +20,8 @@ from tools.run_contract import RunResult, new_run_id, write_artifact_bundle
 configure_logging("daily_diff_flow")
 logger = logging.getLogger(__name__)
 
+DAILY_DIFF_ARTIFACT_TOOL = "daily" "_diff"
+
 
 def _placeholder(conn: Any) -> str:
     return "?" if isinstance(conn, sqlite3.Connection) else "%s"
@@ -189,7 +191,7 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
             logger.warning("No managers found in database")
             artifacts = write_artifact_bundle(
                 run_id,
-                "daily_diff",
+                DAILY_DIFF_ARTIFACT_TOOL,
                 {"deltas.csv": _daily_diff_csv(conn, report_date)},
                 inputs={"date": report_date},
             )
@@ -269,7 +271,7 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
 
         artifacts = write_artifact_bundle(
             run_id,
-            "daily_diff",
+            DAILY_DIFF_ARTIFACT_TOOL,
             {"deltas.csv": _daily_diff_csv(conn, report_date)},
             inputs={"date": report_date},
         )

--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import csv
 import datetime as dt
+import io
 import logging
 import os
 import sqlite3
@@ -13,7 +15,7 @@ from prefect.schedules import Cron
 from adapters.base import connect_db
 from diff_holdings import diff_holdings
 from etl.logging_setup import configure_logging, log_outcome
-from tools.run_contract import RunResult
+from tools.run_contract import RunResult, new_run_id, write_artifact_bundle
 
 configure_logging("daily_diff_flow")
 logger = logging.getLogger(__name__)
@@ -132,6 +134,31 @@ def _fetch_all_manager_ids(conn: Any) -> list[int]:
     return [r[0] for r in rows]
 
 
+def _daily_diff_csv(conn: Any, report_date: str) -> str:
+    """Return the current report date's persisted deltas as CSV."""
+    ph = _placeholder(conn)
+    rows = conn.execute(
+        "SELECT cusip, name_of_issuer, delta_type, shares_prev, shares_curr, "
+        "value_prev, value_curr FROM daily_diffs WHERE report_date = "
+        f"{ph} ORDER BY cusip, delta_type",
+        (report_date,),
+    ).fetchall()
+    headers = [
+        "cusip",
+        "name_of_issuer",
+        "delta_type",
+        "shares_prev",
+        "shares_curr",
+        "value_prev",
+        "value_curr",
+    ]
+    output = io.StringIO()
+    writer = csv.writer(output, lineterminator="\n")
+    writer.writerow(headers)
+    writer.writerows(rows)
+    return output.getvalue()
+
+
 @task
 def compute_manager_diffs(manager_id: int, report_date: str, conn: Any) -> int:
     """Compute and store diffs for a single manager. Returns change count."""
@@ -152,6 +179,7 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
     start = time.perf_counter()
     conn = connect_db()
     report_date = date or str(dt.date.today() - dt.timedelta(days=1))
+    run_id = new_run_id()
 
     try:
         _ensure_daily_diffs_table(conn)
@@ -159,7 +187,14 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
 
         if not manager_ids:
             logger.warning("No managers found in database")
+            artifacts = write_artifact_bundle(
+                run_id,
+                "daily_diff",
+                {"deltas.csv": _daily_diff_csv(conn, report_date)},
+                inputs={"date": report_date},
+            )
             return RunResult(
+                run_id=run_id,
                 tool="daily_diff_flow",
                 inputs={"date": report_date},
                 outputs={
@@ -167,6 +202,7 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
                     "managers_skipped": 0,
                     "total_changes": 0,
                 },
+                artifacts=artifacts,
                 warnings=["No managers found in database"],
                 latency_ms=int((time.perf_counter() - start) * 1000),
                 status="success",
@@ -231,7 +267,15 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
             },
         )
 
+        artifacts = write_artifact_bundle(
+            run_id,
+            "daily_diff",
+            {"deltas.csv": _daily_diff_csv(conn, report_date)},
+            inputs={"date": report_date},
+        )
+
         return RunResult(
+            run_id=run_id,
             tool="daily_diff_flow",
             inputs={"date": report_date},
             outputs={
@@ -239,6 +283,7 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
                 "managers_skipped": managers_skipped,
                 "total_changes": total_changes,
             },
+            artifacts=artifacts,
             warnings=warnings,
             latency_ms=int((time.perf_counter() - start) * 1000),
             status="success",

--- a/etl/digest_flow.py
+++ b/etl/digest_flow.py
@@ -20,6 +20,7 @@ from adapters.base import connect_db
 from alerts.channels import DeliveryResult, send_email_message_via_smtp
 from alerts.db import deserialize_json_object
 from etl.logging_setup import configure_logging, log_outcome
+from tools.run_contract import new_run_id, write_artifact_bundle
 
 configure_logging("digest_flow")
 logger = logging.getLogger(__name__)
@@ -415,8 +416,16 @@ async def digest_flow(
 
     rendered = render_digest_plain_text(digest)
     resolved_output = output_path or os.getenv("DIGEST_OUTPUT_PATH")
+    artifacts: list[dict[str, Any]] = []
     if resolved_output:
         Path(resolved_output).write_text(rendered, encoding="utf-8")
+    else:
+        artifacts = write_artifact_bundle(
+            new_run_id(),
+            "digest",
+            {"digest.txt": rendered},
+            inputs={"lookback_hours": resolved_lookback},
+        )
 
     delivery = await deliver_digest_email(digest, dry_run=resolved_dry_run)
     log_outcome(
@@ -446,6 +455,7 @@ async def digest_flow(
             "error_message": delivery.error_message,
         },
         "rendered": rendered,
+        "artifacts": artifacts,
     }
 
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from alerts.db import ensure_alert_tables, serialize_json
+from etl import digest_flow
+from etl.daily_diff_flow import daily_diff_flow
+from tools.run_contract import write_artifact_bundle
+
+
+def _seed_diff_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT, cik TEXT UNIQUE)"
+        )
+        conn.execute(
+            "CREATE TABLE filings ("
+            "filing_id INTEGER PRIMARY KEY, manager_id INTEGER, "
+            "type TEXT, filed_date TEXT, source TEXT, raw_key TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE holdings ("
+            "holding_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "filing_id INTEGER, cusip TEXT, name_of_issuer TEXT, "
+            "shares INTEGER, value_usd REAL)"
+        )
+        conn.execute("INSERT INTO managers(manager_id, name, cik) VALUES (1, 'TestFund', '0')")
+        conn.executemany(
+            "INSERT INTO filings(filing_id, manager_id, type, filed_date, source) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                (101, 1, "13F-HR", "2024-01-01", "edgar"),
+                (102, 1, "13F-HR", "2024-04-01", "edgar"),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                (101, "AAA", "CorpA", 100, 1000),
+                (102, "AAA", "CorpA", 120, 1200),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_digest_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+        conn.execute("""CREATE TABLE filings (
+                filing_id INTEGER PRIMARY KEY,
+                manager_id INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                filed_date TEXT,
+                source TEXT NOT NULL,
+                url TEXT,
+                created_at TEXT
+            )""")
+        conn.execute("""CREATE TABLE news_items (
+                news_id INTEGER PRIMARY KEY,
+                manager_id INTEGER,
+                published_at TEXT NOT NULL,
+                source TEXT NOT NULL,
+                headline TEXT NOT NULL,
+                url TEXT,
+                body_snippet TEXT,
+                topics TEXT DEFAULT '[]',
+                confidence REAL
+            )""")
+        conn.execute("INSERT INTO managers(manager_id, name) VALUES (1, 'Alpha Capital')")
+        conn.execute(
+            """INSERT INTO filings(filing_id, manager_id, type, filed_date, source, url, created_at)
+               VALUES (10, 1, '13F-HR', '2026-05-08', 'edgar', 'https://filing.test/10',
+                       '2026-05-08T20:00:00+00:00')"""
+        )
+        conn.execute(
+            """INSERT INTO news_items(news_id, manager_id, published_at, source, headline, url)
+               VALUES (20, 1, '2026-05-08T21:00:00+00:00', 'rss',
+                       'Alpha Capital opens new office', 'https://news.test/20')"""
+        )
+        ensure_alert_tables(conn)
+        conn.execute(
+            """INSERT INTO alert_rules(rule_id, name, event_type, condition_json, channels,
+                                       enabled, manager_id, created_by)
+               VALUES (30, 'Large filing alert', 'new_filing', '{}', '["streamlit"]', 1, 1, 'test')"""
+        )
+        conn.execute(
+            """INSERT INTO alert_history(alert_id, rule_id, fired_at, event_type, payload_json,
+                                         delivered_channels, acknowledged)
+               VALUES (40, 30, '2026-05-08T22:00:00+00:00', 'new_filing', ?, '[]', 0)""",
+            (serialize_json({"summary": "New 13F received", "type": "13F-HR"}),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_bundle_roundtrip(tmp_path: Path) -> None:
+    refs = write_artifact_bundle(
+        "run-1",
+        "daily_diff",
+        {"deltas.csv": "cusip\nAAA\n", "notes.txt": b"local only\n"},
+        inputs={"date": "2024-05-01"},
+        root=tmp_path / "artifacts",
+    )
+
+    manifest_path = tmp_path / "artifacts" / "daily_diff" / "run-1" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["run_id"] == "run-1"
+    assert manifest["tool"] == "daily_diff"
+    assert manifest["inputs"] == {"date": "2024-05-01"}
+    assert manifest["files"] == refs
+    for item in manifest["files"]:
+        payload = Path(item["path"]).read_bytes()
+        assert item["sha256"] == hashlib.sha256(payload).hexdigest()
+        assert item["bytes"] == len(payload)
+
+
+def test_daily_diff_writes_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_path = tmp_path / "dev.db"
+    _seed_diff_db(db_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    monkeypatch.delenv("DB_URL", raising=False)
+
+    result = daily_diff_flow.fn(date="2024-05-01")
+
+    manifest_path = tmp_path / "artifacts" / "daily_diff" / result.run_id / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    csv_entry = next(item for item in manifest["files"] if item["name"] == "deltas.csv")
+    csv_path = Path(csv_entry["path"])
+
+    assert result.artifacts == manifest["files"]
+    assert csv_path.exists()
+    assert csv_entry["sha256"] == hashlib.sha256(csv_path.read_bytes()).hexdigest()
+    assert "cusip,name_of_issuer,delta_type,shares_prev,shares_curr,value_prev,value_curr" in (
+        csv_path.read_text(encoding="utf-8").splitlines()[0]
+    )
+
+
+@pytest.mark.asyncio
+async def test_digest_flow_bundle_default_and_legacy_output_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "digest.db"
+    _seed_digest_db(db_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ALERT_EMAIL_FROM", raising=False)
+    monkeypatch.delenv("ALERT_EMAIL_TO", raising=False)
+    monkeypatch.delenv("DIGEST_OUTPUT_PATH", raising=False)
+
+    result = await digest_flow.digest_flow.fn(
+        db_path=str(db_path),
+        lookback_hours=24,
+        dry_run=True,
+        now=datetime(2026, 5, 9, 0, 0, tzinfo=UTC),
+    )
+
+    digest_entry = next(item for item in result["artifacts"] if item["name"] == "digest.txt")
+    digest_path = Path(digest_entry["path"])
+    assert digest_path.exists()
+    assert digest_entry["sha256"] == hashlib.sha256(digest_path.read_bytes()).hexdigest()
+
+    legacy_path = tmp_path / "legacy-digest.txt"
+    monkeypatch.setenv("DIGEST_OUTPUT_PATH", str(legacy_path))
+    override_result = await digest_flow.digest_flow.fn(
+        db_path=str(db_path),
+        lookback_hours=24,
+        dry_run=True,
+        now=datetime(2026, 5, 9, 0, 0, tzinfo=UTC),
+    )
+
+    assert legacy_path.exists()
+    assert "Alpha Capital" in legacy_path.read_text(encoding="utf-8")
+    assert override_result["artifacts"] == []

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -109,7 +109,7 @@ def test_bundle_roundtrip(tmp_path: Path) -> None:
     refs = write_artifact_bundle(
         "run-1",
         "daily_diff",
-        {"deltas.csv": "cusip\nAAA\n", "notes.txt": b"local only\n"},
+        {"notes.txt": b"local only\n", "deltas.csv": "cusip\nAAA\n"},
         inputs={"date": "2024-05-01"},
         root=tmp_path / "artifacts",
     )
@@ -121,6 +121,7 @@ def test_bundle_roundtrip(tmp_path: Path) -> None:
     assert manifest["tool"] == "daily_diff"
     assert manifest["inputs"] == {"date": "2024-05-01"}
     assert manifest["files"] == refs
+    assert [item["name"] for item in manifest["files"]] == ["deltas.csv", "notes.txt"]
     for item in manifest["files"]:
         payload = Path(item["path"]).read_bytes()
         assert item["sha256"] == hashlib.sha256(payload).hexdigest()

--- a/tools/run_contract.py
+++ b/tools/run_contract.py
@@ -17,7 +17,11 @@ share a single correlation vocabulary (see
 
 from __future__ import annotations
 
+import hashlib
+import json
 import uuid
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -26,6 +30,48 @@ from pydantic import BaseModel, Field
 def new_run_id() -> str:
     """Return a fresh run identifier (uuid4 hex), matching ``ChatFleetContext.run_id``."""
     return uuid.uuid4().hex
+
+
+def write_artifact_bundle(
+    run_id: str,
+    tool: str,
+    files: dict[str, bytes | str],
+    *,
+    inputs: dict[str, Any] | None = None,
+    root: str | Path = "artifacts",
+) -> list[dict[str, Any]]:
+    """Write named local artifacts plus a re-hashable manifest."""
+    bundle_dir = Path(root) / tool / run_id
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    refs: list[dict[str, Any]] = []
+    for name, content in files.items():
+        if Path(name).name != name:
+            raise ValueError(f"artifact name must be a plain file name: {name!r}")
+        payload = content.encode("utf-8") if isinstance(content, str) else content
+        path = bundle_dir / name
+        path.write_bytes(payload)
+        refs.append(
+            {
+                "name": name,
+                "path": str(path),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "bytes": len(payload),
+            }
+        )
+
+    manifest = {
+        "run_id": run_id,
+        "tool": tool,
+        "inputs": inputs or {},
+        "created_at": datetime.now(UTC).isoformat(),
+        "files": refs,
+    }
+    (bundle_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return refs
 
 
 class RunCost(BaseModel):

--- a/tools/run_contract.py
+++ b/tools/run_contract.py
@@ -45,7 +45,8 @@ def write_artifact_bundle(
     bundle_dir.mkdir(parents=True, exist_ok=True)
 
     refs: list[dict[str, Any]] = []
-    for name, content in files.items():
+    for name in sorted(files):
+        content = files[name]
         if Path(name).name != name:
             raise ValueError(f"artifact name must be a plain file name: {name!r}")
         payload = content.encode("utf-8") if isinstance(content, str) else content


### PR DESCRIPTION
Closes #1090

## Summary
- add `write_artifact_bundle()` for local tool artifacts with `manifest.json` hashes and byte counts
- emit daily-diff CSV bundles into `artifacts/daily_diff/<run_id>/` and populate `RunResult.artifacts`
- write digest bundles by default while preserving `output_path` / `DIGEST_OUTPUT_PATH` legacy single-file output

## Validation
- `python -m pytest tests/test_artifacts.py tests/test_run_contract.py::test_daily_diff_flow_returns_runresult tests/test_daily_diff.py::test_daily_diff_flow_processes_multiple_managers tests/test_digest_flow.py::test_digest_flow_dry_run_skips_delivery_without_credentials -q`
- `python -m ruff check tools/run_contract.py etl/daily_diff_flow.py etl/digest_flow.py tests/test_artifacts.py`
- `python -m black --check --fast tools/run_contract.py etl/daily_diff_flow.py etl/digest_flow.py tests/test_artifacts.py`