### PR TITLE
Issue #1091: Record manager quality flags

### DIFF
--- a/adapters/asic.py
+++ b/adapters/asic.py
@@ -32,7 +32,7 @@ def _csv_resource_url(payload: dict[str, Any]) -> str | None:
 
 async def list_new_filings(identifier: str, since: str):
     """Return ASIC register metadata records for the configured identifier."""
-    params = {"q": f"ASIC companies {identifier}", "rows": 5}
+    params: dict[str, str | int] = {"q": f"ASIC companies {identifier}", "rows": 5}
     async with httpx.AsyncClient() as client:
         async with tracked_call("au", BASE_URL) as log:
             response = await client.get(BASE_URL, params=params)

--- a/api/managers.py
+++ b/api/managers.py
@@ -454,6 +454,17 @@ def _manager_conflict_flags(
     observed_at = datetime.now(UTC).isoformat()
     flags: list[dict[str, object]] = []
 
+    def _identifier_conflict_flag(field: str, old_value: str, new_value: str) -> dict[str, object]:
+        return {
+            "type": "identifier_conflict",
+            "field": field,
+            "old": old_value,
+            "new": new_value,
+            "previous_value": old_value,
+            "current_value": new_value,
+            "observed_at": observed_at,
+        }
+
     for field, current in (("cik", current_cik), ("lei", current_lei)):
         if field not in updates:
             continue
@@ -461,14 +472,7 @@ def _manager_conflict_flags(
         old_text = "" if current is None else str(current).strip()
         new_text = "" if new_value is None else str(new_value).strip()
         if old_text and new_text and old_text != new_text:
-            flags.append(
-                {
-                    "field": field,
-                    "old": old_text,
-                    "new": new_text,
-                    "observed_at": observed_at,
-                }
-            )
+            flags.append(_identifier_conflict_flag(field, old_text, new_text))
 
     registry_update = updates.get("registry_ids")
     if isinstance(registry_update, dict):
@@ -478,12 +482,11 @@ def _manager_conflict_flags(
             new_value = "" if raw_new is None else str(raw_new).strip()
             if old_value and new_value and old_value != new_value:
                 flags.append(
-                    {
-                        "field": f"registry_ids.{registry_key}",
-                        "old": old_value,
-                        "new": new_value,
-                        "observed_at": observed_at,
-                    }
+                    _identifier_conflict_flag(
+                        f"registry_ids.{registry_key}",
+                        old_value,
+                        new_value,
+                    )
                 )
     return flags
 

--- a/api/managers.py
+++ b/api/managers.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import sqlite3
+from datetime import UTC, datetime
 from functools import wraps
 from typing import Annotated, Any, cast
 
@@ -140,11 +141,20 @@ def _ensure_manager_table(conn) -> None:
                 jurisdictions TEXT NOT NULL DEFAULT '[]',
                 tags TEXT NOT NULL DEFAULT '[]',
                 registry_ids TEXT NOT NULL DEFAULT '{}',
+                quality_flags TEXT NOT NULL DEFAULT '[]',
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             )""")
+        columns = {
+            str(row[0]) for row in conn.execute(SQLITE_TABLE_INFO_SQL, ("managers",)).fetchall()
+        }
+        if "quality_flags" not in columns:
+            conn.execute("ALTER TABLE managers ADD COLUMN quality_flags TEXT NOT NULL DEFAULT '[]'")
         return
     conn.execute("SELECT 1 FROM managers LIMIT 1")
+    conn.execute(
+        "ALTER TABLE managers ADD COLUMN IF NOT EXISTS quality_flags jsonb DEFAULT '[]'::jsonb"
+    )
 
 
 def _manager_id_column(conn) -> str:
@@ -192,10 +202,31 @@ def _json_dict(raw: object) -> dict[str, str]:
     return {}
 
 
+def _json_object_list(raw: object) -> list[dict[str, object]]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)]
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(parsed, list):
+            return [item for item in parsed if isinstance(item, dict)]
+    return []
+
+
 def _to_manager_response(row: tuple[object, ...]) -> ManagerResponse:
     manager_id_raw = row[0]
     if not isinstance(manager_id_raw, (int, str)):
         manager_id_raw = 0
+    quality_flags_raw = row[8] if len(row) > 10 else []
+    created_at_raw = row[9] if len(row) > 10 else row[8]
+    updated_at_raw = row[10] if len(row) > 10 else row[9]
     return ManagerResponse(
         manager_id=int(cast(int | str, manager_id_raw)),
         name=str(row[1]),
@@ -205,8 +236,9 @@ def _to_manager_response(row: tuple[object, ...]) -> ManagerResponse:
         jurisdictions=_json_array(row[5]),
         tags=_json_array(row[6]),
         registry_ids=_json_dict(row[7]),
-        created_at=str(row[8]) if row[8] is not None else None,
-        updated_at=str(row[9]) if row[9] is not None else None,
+        quality_flags=_json_object_list(quality_flags_raw),
+        created_at=str(created_at_raw) if created_at_raw is not None else None,
+        updated_at=str(updated_at_raw) if updated_at_raw is not None else None,
     )
 
 
@@ -243,6 +275,8 @@ def _ensure_universe_schema(conn: Any) -> None:
             conn.execute(
                 "UPDATE managers SET updated_at = CURRENT_TIMESTAMP WHERE updated_at IS NULL"
             )
+        if "quality_flags" not in columns:
+            conn.execute("ALTER TABLE managers ADD COLUMN quality_flags TEXT NOT NULL DEFAULT '[]'")
         conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_managers_cik_unique ON managers(cik)")
         conn.commit()
         return
@@ -255,6 +289,9 @@ def _ensure_universe_schema(conn: Any) -> None:
     )
     conn.execute(
         "ALTER TABLE managers ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now()"
+    )
+    conn.execute(
+        "ALTER TABLE managers ADD COLUMN IF NOT EXISTS quality_flags jsonb DEFAULT '[]'::jsonb"
     )
     conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_managers_cik_unique ON managers(cik)")
 
@@ -352,6 +389,20 @@ def _update_manager(conn, manager_id: int, payload: ManagerUpdate) -> bool:
     set_clauses: list[str] = []
     params: list[object] = []
     placeholder = "?" if isinstance(conn, sqlite3.Connection) else "%s"
+    id_column = _manager_id_column(conn)
+    current_row = conn.execute(
+        f"SELECT cik, lei, registry_ids, quality_flags FROM managers WHERE {id_column} = {placeholder}",
+        (manager_id,),
+    ).fetchone()
+    if current_row is None:
+        return False
+    quality_flags = _json_object_list(current_row[3] if len(current_row) > 3 else [])
+    conflict_flags = _manager_conflict_flags(
+        current_cik=current_row[0] if len(current_row) > 0 else None,
+        current_lei=current_row[1] if len(current_row) > 1 else None,
+        current_registry_ids=_json_dict(current_row[2] if len(current_row) > 2 else {}),
+        updates=fields,
+    )
 
     for field, value in fields.items():
         if field in {"aliases", "jurisdictions", "tags"}:
@@ -373,10 +424,17 @@ def _update_manager(conn, manager_id: int, payload: ManagerUpdate) -> bool:
         set_clauses.append(f"{field} = {placeholder}")
         params.append(value)
 
+    if conflict_flags:
+        quality_flags.extend(conflict_flags)
+        if isinstance(conn, sqlite3.Connection):
+            set_clauses.append(f"quality_flags = {placeholder}")
+        else:
+            set_clauses.append(f"quality_flags = {placeholder}::jsonb")
+        params.append(json.dumps(quality_flags))
+
     set_clauses.append("updated_at = CURRENT_TIMESTAMP")
     params.append(manager_id)
 
-    id_column = _manager_id_column(conn)
     cursor = conn.execute(
         f"UPDATE managers SET {', '.join(set_clauses)} WHERE {id_column} = {placeholder}",
         params,
@@ -384,6 +442,50 @@ def _update_manager(conn, manager_id: int, payload: ManagerUpdate) -> bool:
     if isinstance(conn, sqlite3.Connection):
         conn.commit()
     return cursor.rowcount > 0
+
+
+def _manager_conflict_flags(
+    *,
+    current_cik: object,
+    current_lei: object,
+    current_registry_ids: dict[str, str],
+    updates: dict[str, object],
+) -> list[dict[str, object]]:
+    observed_at = datetime.now(UTC).isoformat()
+    flags: list[dict[str, object]] = []
+
+    for field, current in (("cik", current_cik), ("lei", current_lei)):
+        if field not in updates:
+            continue
+        new_value = updates[field]
+        old_text = "" if current is None else str(current).strip()
+        new_text = "" if new_value is None else str(new_value).strip()
+        if old_text and new_text and old_text != new_text:
+            flags.append(
+                {
+                    "field": field,
+                    "old": old_text,
+                    "new": new_text,
+                    "observed_at": observed_at,
+                }
+            )
+
+    registry_update = updates.get("registry_ids")
+    if isinstance(registry_update, dict):
+        for key, raw_new in registry_update.items():
+            registry_key = str(key)
+            old_value = current_registry_ids.get(registry_key, "")
+            new_value = "" if raw_new is None else str(raw_new).strip()
+            if old_value and new_value and old_value != new_value:
+                flags.append(
+                    {
+                        "field": f"registry_ids.{registry_key}",
+                        "old": old_value,
+                        "new": new_value,
+                        "observed_at": observed_at,
+                    }
+                )
+    return flags
 
 
 def _delete_manager(conn, manager_id: int) -> bool:
@@ -450,7 +552,7 @@ def _fetch_managers(
     params.extend([limit, offset])
     id_column = _manager_id_column(conn)
     cursor = conn.execute(
-        f"SELECT {id_column}, name, cik, lei, aliases, jurisdictions, tags, registry_ids, created_at, updated_at "
+        f"SELECT {id_column}, name, cik, lei, aliases, jurisdictions, tags, registry_ids, quality_flags, created_at, updated_at "
         f"FROM managers {where_clause} "
         f"ORDER BY {id_column} LIMIT {placeholder} OFFSET {placeholder}",
         params,
@@ -465,7 +567,7 @@ def _fetch_manager(conn, db_identity: str, manager_id: int) -> tuple[object, ...
     id_column = _manager_id_column(conn)
     cursor = conn.execute(
         (
-            f"SELECT {id_column}, name, cik, lei, aliases, jurisdictions, tags, registry_ids, created_at, updated_at "
+            f"SELECT {id_column}, name, cik, lei, aliases, jurisdictions, tags, registry_ids, quality_flags, created_at, updated_at "
             f"FROM managers WHERE {id_column} = {placeholder}"
         ),
         (manager_id,),
@@ -811,6 +913,7 @@ async def create_manager(
         jurisdictions=payload.jurisdictions,
         tags=payload.tags,
         registry_ids=payload.registry_ids,
+        quality_flags=[],
         created_at=None,
         updated_at=None,
     )
@@ -1048,6 +1151,7 @@ async def bulk_import_managers(
                             jurisdictions=payload.jurisdictions,
                             tags=payload.tags,
                             registry_ids=payload.registry_ids,
+                            quality_flags=[],
                             created_at=None,
                             updated_at=None,
                         ),

--- a/api/models.py
+++ b/api/models.py
@@ -20,6 +20,7 @@ class ManagerResponse(BaseModel):
                     "jurisdictions": ["us"],
                     "tags": ["activist"],
                     "registry_ids": {"fca_frn": "122927"},
+                    "quality_flags": [],
                     "created_at": "2026-02-01T10:00:00Z",
                     "updated_at": "2026-02-01T10:00:00Z",
                 }
@@ -34,6 +35,10 @@ class ManagerResponse(BaseModel):
     jurisdictions: list[str] = Field(default_factory=list, description="Filing jurisdictions")
     tags: list[str] = Field(default_factory=list, description="Classification tags")
     registry_ids: dict[str, str] = Field(default_factory=dict, description="External registry IDs")
+    quality_flags: list[dict[str, object]] = Field(
+        default_factory=list,
+        description="Structured data-quality observations such as identifier conflicts",
+    )
     created_at: str | None = Field(None, description="Creation timestamp")
     updated_at: str | None = Field(None, description="Last update timestamp")
 
@@ -55,6 +60,7 @@ class ManagerListResponse(BaseModel):
                             "jurisdictions": ["us"],
                             "tags": ["activist"],
                             "registry_ids": {"fca_frn": "122927"},
+                            "quality_flags": [],
                             "created_at": "2026-02-01T10:00:00Z",
                             "updated_at": "2026-02-01T10:00:00Z",
                         }
@@ -117,6 +123,7 @@ class BulkImportResponse(BaseModel):
                                 "jurisdictions": ["us"],
                                 "tags": ["activist"],
                                 "registry_ids": {"fca_frn": "122927"},
+                                "quality_flags": [],
                                 "created_at": "2026-02-01T10:00:00Z",
                                 "updated_at": "2026-02-01T10:00:00Z",
                             },

--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -161,6 +161,38 @@ def _daily_diff_csv(conn: Any, report_date: str) -> str:
     return output.getvalue()
 
 
+def _daily_diff_data_quality(conn: Any, report_date: str) -> dict[str, Any]:
+    ph = _placeholder(conn)
+    rows = conn.execute(
+        "SELECT manager_id, cusip, shares_prev, shares_curr, value_prev, value_curr "
+        "FROM daily_diffs WHERE report_date = "
+        f"{ph} ORDER BY manager_id, cusip, delta_type",
+        (report_date,),
+    ).fetchall()
+    missing_fields: list[dict[str, Any]] = []
+    for manager_id, cusip, shares_prev, shares_curr, value_prev, value_curr in rows:
+        for field, value in (
+            ("shares_prev", shares_prev),
+            ("shares_curr", shares_curr),
+            ("value_prev", value_prev),
+            ("value_curr", value_curr),
+        ):
+            if value is None:
+                missing_fields.append(
+                    {
+                        "manager_id": manager_id,
+                        "cusip": cusip,
+                        "field": field,
+                    }
+                )
+    confidence = "low" if missing_fields else "high"
+    return {
+        "missing_fields": missing_fields,
+        "conflicts": [],
+        "confidence": confidence,
+    }
+
+
 @task
 def compute_manager_diffs(manager_id: int, report_date: str, conn: Any) -> int:
     """Compute and store diffs for a single manager. Returns change count."""
@@ -203,6 +235,11 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
                     "managers_processed": 0,
                     "managers_skipped": 0,
                     "total_changes": 0,
+                    "data_quality": {
+                        "missing_fields": [],
+                        "conflicts": [],
+                        "confidence": "unknown",
+                    },
                 },
                 artifacts=artifacts,
                 warnings=["No managers found in database"],
@@ -284,6 +321,7 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
                 "managers_processed": managers_processed,
                 "managers_skipped": managers_skipped,
                 "total_changes": total_changes,
+                "data_quality": _daily_diff_data_quality(conn, report_date),
             },
             artifacts=artifacts,
             warnings=warnings,

--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -170,7 +170,10 @@ def _daily_diff_data_quality(conn: Any, report_date: str) -> dict[str, Any]:
         (report_date,),
     ).fetchall()
     missing_fields: list[dict[str, Any]] = []
-    for manager_id, cusip, shares_prev, shares_curr, value_prev, value_curr in rows:
+    for row in rows:
+        if len(row) < 6:
+            continue
+        manager_id, cusip, shares_prev, shares_curr, value_prev, value_curr = row
         for field, value in (
             ("shares_prev", shares_prev),
             ("shares_curr", shares_curr),

--- a/etl/digest_flow.py
+++ b/etl/digest_flow.py
@@ -228,17 +228,20 @@ def render_digest_plain_text(digest: DigestDocument) -> str:
         return "\n".join(lines)
 
     lines.append(f"Filings ({len(digest.filings)})")
-    for item in digest.filings:
+    for filing in digest.filings:
         lines.append(
-            f"- {item.manager_name}: {item.filing_type} filed {item.filed_date} via {item.source}"
+            f"- {filing.manager_name}: {filing.filing_type} filed {filing.filed_date} via {filing.source}"
         )
     lines.extend(["", f"News ({len(digest.news)})"])
-    for item in digest.news:
-        lines.append(f"- {item.manager_name}: {item.headline} ({item.source}, {item.published_at})")
+    for news_item in digest.news:
+        lines.append(
+            f"- {news_item.manager_name}: {news_item.headline} "
+            f"({news_item.source}, {news_item.published_at})"
+        )
     lines.extend(["", f"Important alerts ({len(digest.alerts)})"])
-    for item in digest.alerts:
-        manager = f" [{item.manager_name}]" if item.manager_name else ""
-        lines.append(f"- {item.rule_name}{manager}: {item.summary} ({item.fired_at})")
+    for alert in digest.alerts:
+        manager = f" [{alert.manager_name}]" if alert.manager_name else ""
+        lines.append(f"- {alert.rule_name}{manager}: {alert.summary} ({alert.fired_at})")
     return "\n".join(lines)
 
 

--- a/etl/evaluation_flow.py
+++ b/etl/evaluation_flow.py
@@ -247,7 +247,7 @@ def build_live_evaluation_datasets(db_conn: sqlite3.Connection) -> dict[str, lis
     )
     nl_chain = NLQueryChain(llm=_DeterministicNLQueryLLM(), db_conn=db_conn)
     rag_chain = RAGSearchChain(llm=_DeterministicRAGLLM(), db_conn=db_conn)
-    rag_chain._vector_search = lambda _query, k=5, manager_id=None: [  # type: ignore[method-assign]
+    rag_chain._vector_search = lambda _query, k=5, manager_id=None: [  # type: ignore[assignment,method-assign]
         {
             "doc_id": "doc-live-1",
             "content": "Apple Inc (037833100) remained a top holding on 2026-03-01.",
@@ -255,7 +255,9 @@ def build_live_evaluation_datasets(db_conn: sqlite3.Connection) -> dict[str, lis
             "kind": "memo",
             "manager_id": manager_id,
         }
-    ][:k]
+    ][
+        :k
+    ]
 
     filing_summary = filing_chain.run(1).model_dump()
     nl_result = nl_chain.run("How many managers are in the database?")

--- a/tests/test_manager_api.py
+++ b/tests/test_manager_api.py
@@ -297,6 +297,7 @@ def test_manager_list_returns_new_manager_shape(tmp_path, monkeypatch):
         "jurisdictions",
         "tags",
         "registry_ids",
+        "quality_flags",
         "created_at",
         "updated_at",
     }
@@ -307,6 +308,7 @@ def test_manager_list_returns_new_manager_shape(tmp_path, monkeypatch):
     assert item["jurisdictions"] == ["us"]
     assert item["tags"] == ["activist"]
     assert item["registry_ids"] == {}
+    assert item["quality_flags"] == []
 
 
 def test_manager_list_filter_by_jurisdiction_returns_subset(tmp_path, monkeypatch):

--- a/tests/test_quality_flags.py
+++ b/tests/test_quality_flags.py
@@ -22,9 +22,11 @@ def test_conflicting_update_records_flag(tmp_path: Path) -> None:
     updated = managers_module._update_manager(
         conn,
         manager_id,
-        managers_module.ManagerUpdate(
-            lei="LEI-B",
-            registry_ids={"fca_frn": "998877"},
+        managers_module.ManagerUpdate.model_validate(
+            {
+                "lei": "LEI-B",
+                "registry_ids": {"fca_frn": "998877"},
+            }
         ),
     )
     row = managers_module._fetch_manager(conn, str(db_path), manager_id)

--- a/tests/test_quality_flags.py
+++ b/tests/test_quality_flags.py
@@ -1,0 +1,105 @@
+import sqlite3
+from pathlib import Path
+
+from api import managers as managers_module
+from etl.daily_diff_flow import daily_diff_flow
+
+
+def test_conflicting_update_records_flag(tmp_path: Path) -> None:
+    db_path = tmp_path / "quality.db"
+    conn = sqlite3.connect(db_path)
+    managers_module._ensure_manager_table(conn)
+    manager_id = managers_module._insert_manager(
+        conn,
+        managers_module.ManagerCreate(
+            name="Conflict Manager",
+            cik="0000000001",
+            lei="LEI-A",
+            registry_ids={"fca_frn": "122927"},
+        ),
+    )
+
+    updated = managers_module._update_manager(
+        conn,
+        manager_id,
+        managers_module.ManagerUpdate(
+            lei="LEI-B",
+            registry_ids={"fca_frn": "998877"},
+        ),
+    )
+    row = managers_module._fetch_manager(conn, str(db_path), manager_id)
+    conn.close()
+
+    assert updated is True
+    assert row is not None
+    manager = managers_module._to_manager_response(row)
+    assert manager.lei == "LEI-B"
+    assert manager.registry_ids == {"fca_frn": "998877"}
+    assert {
+        "field": "lei",
+        "old": "LEI-A",
+        "new": "LEI-B",
+    }.items() <= manager.quality_flags[0].items()
+    assert {
+        "field": "registry_ids.fca_frn",
+        "old": "122927",
+        "new": "998877",
+    }.items() <= manager.quality_flags[1].items()
+
+
+def test_delta_missing_fields(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "diff_quality.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT, cik TEXT UNIQUE)"
+    )
+    conn.execute(
+        "CREATE TABLE filings ("
+        "filing_id INTEGER PRIMARY KEY, manager_id INTEGER, "
+        "type TEXT, filed_date TEXT, source TEXT, raw_key TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE holdings ("
+        "holding_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "filing_id INTEGER, cusip TEXT, name_of_issuer TEXT, "
+        "shares INTEGER, value_usd REAL)"
+    )
+    conn.execute(
+        "INSERT INTO managers(manager_id, name, cik) VALUES (1, 'Quality Manager', '0000000001')"
+    )
+    conn.executemany(
+        "INSERT INTO filings(filing_id, manager_id, type, filed_date, source) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            (101, 1, "13F-HR", "2024-01-01", "edgar"),
+            (102, 1, "13F-HR", "2024-04-01", "edgar"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            (101, "MISS12345", "Missing Shares Corp", None, 100.0),
+            (102, "MISS12345", "Missing Shares Corp", None, 130.0),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    monkeypatch.delenv("DB_URL", raising=False)
+
+    result = daily_diff_flow.fn(date="2024-05-01")
+
+    missing_fields = result.outputs["data_quality"]["missing_fields"]
+    assert result.outputs["data_quality"]["confidence"] == "low"
+    assert {
+        "manager_id": 1,
+        "cusip": "MISS12345",
+        "field": "shares_prev",
+    } in missing_fields
+    assert {
+        "manager_id": 1,
+        "cusip": "MISS12345",
+        "field": "shares_curr",
+    } in missing_fields

--- a/tests/test_quality_flags.py
+++ b/tests/test_quality_flags.py
@@ -36,15 +36,19 @@ def test_conflicting_update_records_flag(tmp_path: Path) -> None:
     assert manager.lei == "LEI-B"
     assert manager.registry_ids == {"fca_frn": "998877"}
     assert {
+        "type": "identifier_conflict",
         "field": "lei",
         "old": "LEI-A",
         "new": "LEI-B",
     }.items() <= manager.quality_flags[0].items()
     assert {
+        "type": "identifier_conflict",
         "field": "registry_ids.fca_frn",
         "old": "122927",
         "new": "998877",
     }.items() <= manager.quality_flags[1].items()
+    assert manager.quality_flags[0]["previous_value"] == "LEI-A"
+    assert manager.quality_flags[0]["current_value"] == "LEI-B"
 
 
 def test_delta_missing_fields(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
Closes #1091

## Summary
- add manager response support for structured quality_flags and persist identifier conflict records on manager updates
- expose quality_flags through manager list/detail fetches across SQLite/Postgres-compatible paths
- add daily_diff_flow data_quality output with missing-field entries derived from persisted delta rows

## Validation
- python -m pytest tests/test_quality_flags.py tests/test_manager_api.py::test_manager_postgres_writes_return_and_filter_by_manager_id tests/test_run_contract.py::test_daily_diff_flow_returns_runresult tests/test_daily_diff.py::test_daily_diff_flow_processes_multiple_managers -q
- python -m black --check --fast api/models.py api/managers.py etl/daily_diff_flow.py tests/test_quality_flags.py
- python -m ruff check api/models.py api/managers.py etl/daily_diff_flow.py tests/test_quality_flags.py