### PR TITLE
Issue #1092: Declare tool data-zone registry

### DIFF
--- a/diff_holdings.py
+++ b/diff_holdings.py
@@ -8,6 +8,7 @@ import time
 from typing import Any
 
 from adapters.base import connect_db
+from tools.registry import run_contract_fields
 from tools.run_contract import RunResult
 
 
@@ -181,6 +182,7 @@ def diff_holdings(manager_id: int | str, conn: Any = None) -> RunResult:
         tool="diff_holdings",
         inputs={"manager_id": resolved},
         outputs=results,
+        **run_contract_fields("diff_holdings"),
         provenance={"manager_id": resolved},
         latency_ms=int((time.perf_counter() - start) * 1000),
         status="success",

--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -15,6 +15,7 @@ from prefect.schedules import Cron
 from adapters.base import connect_db
 from diff_holdings import diff_holdings
 from etl.logging_setup import configure_logging, log_outcome
+from tools.registry import run_contract_fields
 from tools.run_contract import RunResult, new_run_id, write_artifact_bundle
 
 configure_logging("daily_diff_flow")
@@ -205,6 +206,7 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
                     "total_changes": 0,
                 },
                 artifacts=artifacts,
+                **run_contract_fields("daily_diff_flow"),
                 warnings=["No managers found in database"],
                 latency_ms=int((time.perf_counter() - start) * 1000),
                 status="success",
@@ -286,6 +288,7 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
                 "total_changes": total_changes,
             },
             artifacts=artifacts,
+            **run_contract_fields("daily_diff_flow"),
             warnings=warnings,
             latency_ms=int((time.perf_counter() - start) * 1000),
             status="success",

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,65 @@
+"""Acceptance tests for machine-readable tool data-zone declarations."""
+
+import sqlite3
+
+from diff_holdings import diff_holdings
+from tools.registry import TOOL_REGISTRY
+
+
+def _seed_canonical_db(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT, cik TEXT UNIQUE)"
+    )
+    conn.execute(
+        "CREATE TABLE filings ("
+        "filing_id INTEGER PRIMARY KEY, manager_id INTEGER, "
+        "type TEXT, filed_date TEXT, source TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE holdings ("
+        "holding_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "filing_id INTEGER, cusip TEXT, name_of_issuer TEXT, "
+        "shares INTEGER, value_usd REAL)"
+    )
+    conn.execute("INSERT INTO managers(manager_id, name, cik) VALUES (1, 'TestFund', '0000000000')")
+    conn.executemany(
+        "INSERT INTO filings(filing_id, manager_id, type, filed_date, source) VALUES (?,?,?,?,?)",
+        [
+            (101, 1, "13F-HR", "2024-04-01", "edgar"),
+            (102, 1, "13F-HR", "2024-01-01", "edgar"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) VALUES (?,?,?,?,?)",
+        [
+            (101, "AAA", "CorpA", 120, 1200),
+            (102, "AAA", "CorpA", 100, 1000),
+        ],
+    )
+    conn.commit()
+
+
+def test_every_tool_declares_zone():
+    assert TOOL_REGISTRY
+    for descriptor in TOOL_REGISTRY.values():
+        assert descriptor.data_zone
+        assert descriptor.llm_boundary in {"none", "external_authorized"}
+
+
+def test_deterministic_tools_have_no_llm():
+    assert TOOL_REGISTRY["diff_holdings"].llm_boundary == "none"
+    assert TOOL_REGISTRY["daily_diff_flow"].llm_boundary == "none"
+    assert TOOL_REGISTRY["RAGSearchChain"].llm_boundary == "external_authorized"
+    assert TOOL_REGISTRY["FilingSummaryChain"].llm_boundary == "external_authorized"
+    assert TOOL_REGISTRY["NLQueryChain"].llm_boundary == "external_authorized"
+
+
+def test_diff_holdings_runresult_reports_registry_boundary():
+    conn = sqlite3.connect(":memory:")
+    _seed_canonical_db(conn)
+
+    result = diff_holdings(1, conn)
+    conn.close()
+
+    assert result.llm_boundary == "none"
+    assert result.data_zone == "public_filings"

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, TypedDict
 
 from pydantic import BaseModel, Field
 
+DataZone = Literal["public_filings", "internal_notes"]
 LlmBoundary = Literal["none", "external_authorized"]
 
 
@@ -13,7 +14,7 @@ class ToolDescriptor(BaseModel):
     """Declare the data and external-LLM boundary for one tool or chain."""
 
     name: str
-    data_zone: str
+    data_zone: DataZone
     external_sources: list[str] = Field(default_factory=list)
     db_writes: list[str] = Field(default_factory=list)
     llm_boundary: LlmBoundary
@@ -63,7 +64,14 @@ def descriptor_for(name: str) -> ToolDescriptor:
     return TOOL_REGISTRY[name]
 
 
-def run_contract_fields(name: str) -> dict[str, str]:
+class RunContractFields(TypedDict):
+    """The descriptor fields spliced into a ``RunResult`` envelope."""
+
+    data_zone: str
+    llm_boundary: str
+
+
+def run_contract_fields(name: str) -> RunContractFields:
     """Return descriptor fields that belong in a ``RunResult`` envelope."""
     descriptor = descriptor_for(name)
     return {

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -1,0 +1,72 @@
+"""Machine-readable tool permissions and data-zone registry."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+LlmBoundary = Literal["none", "external_authorized"]
+
+
+class ToolDescriptor(BaseModel):
+    """Declare the data and external-LLM boundary for one tool or chain."""
+
+    name: str
+    data_zone: str
+    external_sources: list[str] = Field(default_factory=list)
+    db_writes: list[str] = Field(default_factory=list)
+    llm_boundary: LlmBoundary
+
+
+TOOL_REGISTRY: dict[str, ToolDescriptor] = {
+    "diff_holdings": ToolDescriptor(
+        name="diff_holdings",
+        data_zone="public_filings",
+        external_sources=["EDGAR"],
+        db_writes=[],
+        llm_boundary="none",
+    ),
+    "daily_diff_flow": ToolDescriptor(
+        name="daily_diff_flow",
+        data_zone="public_filings",
+        external_sources=["EDGAR"],
+        db_writes=["daily_diffs"],
+        llm_boundary="none",
+    ),
+    "RAGSearchChain": ToolDescriptor(
+        name="RAGSearchChain",
+        data_zone="internal_notes",
+        external_sources=["uploaded_documents", "vector_index"],
+        db_writes=[],
+        llm_boundary="external_authorized",
+    ),
+    "FilingSummaryChain": ToolDescriptor(
+        name="FilingSummaryChain",
+        data_zone="public_filings",
+        external_sources=["EDGAR"],
+        db_writes=["api_usage"],
+        llm_boundary="external_authorized",
+    ),
+    "NLQueryChain": ToolDescriptor(
+        name="NLQueryChain",
+        data_zone="internal_notes",
+        external_sources=["database_schema"],
+        db_writes=[],
+        llm_boundary="external_authorized",
+    ),
+}
+
+
+def descriptor_for(name: str) -> ToolDescriptor:
+    """Return the registered descriptor for ``name``."""
+    return TOOL_REGISTRY[name]
+
+
+def run_contract_fields(name: str) -> dict[str, str]:
+    """Return descriptor fields that belong in a ``RunResult`` envelope."""
+    descriptor = descriptor_for(name)
+    return {
+        "data_zone": descriptor.data_zone,
+        "llm_boundary": descriptor.llm_boundary,
+    }

--- a/tools/run_contract.py
+++ b/tools/run_contract.py
@@ -99,6 +99,8 @@ class RunResult(BaseModel):
     inputs: dict[str, Any] = Field(default_factory=dict)
     outputs: Any = None
     artifacts: list[Any] = Field(default_factory=list)
+    data_zone: str | None = None
+    llm_boundary: str | None = None
     warnings: list[str] = Field(default_factory=list)
     cost: RunCost = Field(default_factory=RunCost)
     latency_ms: int | None = None


### PR DESCRIPTION
Closes #1092

## Summary
- add a ToolDescriptor registry for deterministic tools and LLM-backed chains
- extend RunResult with data_zone and llm_boundary fields
- stamp diff_holdings and daily_diff_flow envelopes from the registry

## Validation
- python -m pytest tests/test_tool_registry.py tests/test_run_contract.py::test_diff_holdings_returns_runresult tests/test_run_contract.py::test_runresult_json_roundtrip tests/test_run_contract.py::test_daily_diff_flow_returns_runresult -q
- python -m ruff check tools/registry.py tools/run_contract.py diff_holdings.py etl/daily_diff_flow.py tests/test_tool_registry.py
- python -m black --check --fast tools/registry.py tools/run_contract.py diff_holdings.py etl/daily_diff_flow.py tests/test_tool_registry.py