### PR TITLE
Add one-command internal/local launch for the analyst UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,21 @@
-.PHONY: db-migrate db-seed
+.PHONY: db-migrate db-seed app app-smoke
 
 db-migrate:
 	python -m alembic upgrade head
 
 db-seed:
 	python scripts/seed_managers.py
+
+# Launch the Streamlit analyst UI shell on :8501 for internal/local use.
+# Matches the docker-compose `ui` service CMD (ui/Dockerfile). The UI is a
+# thin HTTP client of the API on :8000 — point API_BASE_URL/CHAT_API_URL at a
+# running `api` (e.g. `docker compose up db api`) to render live data. Auth is
+# bypassed locally when UI_USERNAME/UI_PASSWORD are unset (ui/__init__.py).
+app:
+	streamlit run ui/app.py --server.port=8501 --server.headless=true
+
+# Launch the UI and assert it answers 200 on :8501, then tear it down.
+# Exercises scripts/readiness_smoke.py::check_ui against the `make app` path
+# without bringing up the full Docker stack.
+app-smoke:
+	python scripts/readiness_smoke.py --launch-ui

--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -81,6 +81,42 @@ Feel free to open issues or pull requests as you iterate.
    streamlit run ui/app.py
    ```
 
+   ### Run the UI locally (no full Docker stack)
+
+   For internal/local browsing you don't need to hand-orchestrate Postgres +
+   MinIO + uvicorn. A single command launches the multipage analyst shell on
+   `:8501` (the exact command the docker-compose `ui` service uses):
+
+   ```bash
+   make app
+   # or, after `pip install -e .`:
+   mgrdb-app
+   ```
+
+   This stays inside the org perimeter — the UI runs as a local/internal
+   process; **do not** publish it to Streamlit Community Cloud with real
+   manager data.
+
+   - **API target.** The UI is a thin HTTP client of the API on `:8000`; it
+     cannot render live data without a reachable API (`ui/alerts.py` reads
+     `API_BASE_URL`, `ui/research.py` reads `CHAT_API_URL`, both defaulting to
+     `http://localhost:8000`). The lightest internal path is to bring up just
+     the `api` + `db` compose services, then run `make app`:
+     ```bash
+     docker compose up -d db api
+     API_BASE_URL=http://localhost:8000 CHAT_API_URL=http://localhost:8000 make app
+     ```
+     Point `API_BASE_URL`/`CHAT_API_URL` at any already-running API target for
+     UI-only mode.
+   - **Auth is bypassed locally.** When `UI_USERNAME`/`UI_PASSWORD` are unset,
+     `ui/__init__.py` skips `streamlit_authenticator` (logging a dev-mode
+     warning) and treats the session as authenticated. Leave both unset for
+     local/internal mode; keep them **set** in production.
+   - **Smoke-test the launch path.** `make app-smoke` (i.e.
+     `python scripts/readiness_smoke.py --launch-ui`) launches the UI via the
+     same command and asserts it answers `200` on `:8501`, then tears it down —
+     without bringing up the full stack.
+
 5. You can still run individual pages directly if needed:
    ```bash
    streamlit run ui/daily_report.py

--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -98,16 +98,17 @@ Feel free to open issues or pull requests as you iterate.
    manager data.
 
    - **API target.** The UI is a thin HTTP client of the API on `:8000`; it
-     cannot render live data without a reachable API (`ui/alerts.py` reads
-     `API_BASE_URL`, `ui/research.py` reads `CHAT_API_URL`, both defaulting to
-     `http://localhost:8000`). The lightest internal path is to bring up just
-     the `api` + `db` compose services, then run `make app`:
+     cannot render live data without a reachable API. `ui/alerts.py` reads the
+     API root from `API_BASE_URL` (default `http://localhost:8000`), while
+     `ui/research.py` posts directly to `CHAT_API_URL` (default
+     `http://localhost:8000/api/chat`). The lightest internal path is to bring
+     up just the `api` + `db` compose services, then run `make app`:
      ```bash
      docker compose up -d db api
-     API_BASE_URL=http://localhost:8000 CHAT_API_URL=http://localhost:8000 make app
+     API_BASE_URL=http://localhost:8000 CHAT_API_URL=http://localhost:8000/api/chat make app
      ```
-     Point `API_BASE_URL`/`CHAT_API_URL` at any already-running API target for
-     UI-only mode.
+     Point `API_BASE_URL` at any already-running API root and `CHAT_API_URL` at
+     that API's chat endpoint for UI-only mode.
    - **Auth is bypassed locally.** When `UI_USERNAME`/`UI_PASSWORD` are unset,
      `ui/__init__.py` skips `streamlit_authenticator` (logging a dev-mode
      warning) and treats the session as authenticated. Leave both unset for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dependencies = [
     "langsmith>=0.7.30,<1.0",
 ]
 
+[project.scripts]
+# Internal/local launch for the analyst UI shell (see ui/launch.py and `make app`).
+mgrdb-app = "ui.launch:main"
+
 [project.optional-dependencies]
 app = []
 dev = [

--- a/scripts/readiness_smoke.py
+++ b/scripts/readiness_smoke.py
@@ -172,6 +172,30 @@ def check_ui(base_url: str, timeout_s: float) -> None:
     _retry_until_ready("Streamlit UI", timeout_s, _probe)
 
 
+def launch_and_probe_ui(ui_url: str, timeout_s: float) -> int:
+    """Launch the analyst UI via the `make app` path and assert it answers 200.
+
+    Spawns the exact Streamlit command used by `make app` / the `mgrdb-app`
+    console script (``ui.launch.ui_launch_command``), runs the existing
+    ``check_ui`` probe until the shell responds 200 on ``:8501``, then tears
+    the process down. This exercises the local launch path without bringing up
+    the full Docker stack (no Postgres/MinIO/uvicorn).
+    """
+    from ui.launch import ui_launch_command
+
+    proc = subprocess.Popen(ui_launch_command())
+    try:
+        check_ui(ui_url, timeout_s)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    return 0
+
+
 def run(
     base_url: str,
     ui_url: str,
@@ -232,7 +256,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="Skip the Streamlit UI probe (for headless CI that does not start the UI).",
     )
+    parser.add_argument(
+        "--launch-ui",
+        action="store_true",
+        help=(
+            "Launch the analyst UI via the `make app` path and assert it answers "
+            "200 on :8501, then tear it down. Skips the full-stack/API probes."
+        ),
+    )
     args = parser.parse_args(argv)
+    if args.launch_ui:
+        try:
+            launch_and_probe_ui(args.ui_url, args.timeout)
+        except ReadinessError as exc:
+            print(f"readiness smoke FAILED: {exc}", file=sys.stderr)
+            return 1
+        except httpx.HTTPError as exc:
+            print(f"readiness smoke FAILED (transport): {exc}", file=sys.stderr)
+            return 1
+        print(f"readiness smoke OK (ui launch path, ui={args.ui_url})")
+        return 0
     run_kwargs: dict[str, Any] = {
         "clean_stack": not args.skip_stack_start,
         "compose_file": args.compose_file,

--- a/tests/test_readiness_smoke.py
+++ b/tests/test_readiness_smoke.py
@@ -352,3 +352,99 @@ def test_skip_ui_flag_bypasses_ui_probe(monkeypatch):
         readiness_smoke.main(["--skip-stack-start", "--skip-ui", "--base-url", "http://test"]) == 0
     )
     assert calls == ["seed:docker-compose.yml:False"]
+
+
+class _FakeProc:
+    def __init__(self, events: list[object]) -> None:
+        self._events = events
+
+    def terminate(self) -> None:
+        self._events.append("terminate")
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._events.append(f"wait:{timeout}")
+        return 0
+
+    def kill(self) -> None:  # pragma: no cover - only on terminate timeout
+        self._events.append("kill")
+
+
+def test_launch_and_probe_ui_spawns_make_app_command_and_tears_down(monkeypatch):
+    events: list[object] = []
+
+    def fake_popen(cmd, **kwargs):
+        events.append(("popen", tuple(cmd)))
+        return _FakeProc(events)
+
+    monkeypatch.setattr(readiness_smoke.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        readiness_smoke,
+        "check_ui",
+        lambda ui_url, timeout_s: events.append(f"ui:{ui_url}:{timeout_s}"),
+    )
+
+    assert readiness_smoke.launch_and_probe_ui("http://localhost:8501", 1.0) == 0
+
+    popen_calls = [e for e in events if isinstance(e, tuple) and e[0] == "popen"]
+    assert len(popen_calls) == 1
+    cmd = popen_calls[0][1]
+    # Exact `make app` / docker-compose `ui` CMD.
+    assert cmd == (
+        "streamlit",
+        "run",
+        "ui/app.py",
+        "--server.port=8501",
+        "--server.headless=true",
+    )
+    assert "ui:http://localhost:8501:1.0" in events
+    assert "terminate" in events
+
+
+def test_launch_and_probe_ui_terminates_when_probe_fails(monkeypatch):
+    events: list[object] = []
+
+    monkeypatch.setattr(
+        readiness_smoke.subprocess, "Popen", lambda cmd, **kwargs: _FakeProc(events)
+    )
+
+    def boom(ui_url: str, timeout_s: float) -> None:
+        raise readiness_smoke.ReadinessError("ui never came up")
+
+    monkeypatch.setattr(readiness_smoke, "check_ui", boom)
+
+    with pytest.raises(readiness_smoke.ReadinessError):
+        readiness_smoke.launch_and_probe_ui("http://localhost:8501", 1.0)
+    # Process is still torn down on failure.
+    assert "terminate" in events
+
+
+def test_main_launch_ui_routes_to_launch_path_and_skips_run(monkeypatch, capsys):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        readiness_smoke,
+        "launch_and_probe_ui",
+        lambda ui_url, timeout_s: calls.append(f"launch:{ui_url}:{timeout_s}") or 0,
+    )
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("run() must not be called with --launch-ui")
+
+    monkeypatch.setattr(readiness_smoke, "run", fail_run)
+
+    assert readiness_smoke.main(["--launch-ui"]) == 0
+    assert calls == [
+        f"launch:{readiness_smoke.DEFAULT_UI_BASE}:{readiness_smoke.DEFAULT_TIMEOUT_S}"
+    ]
+    out = capsys.readouterr().out
+    assert "readiness smoke OK (ui launch path" in out
+
+
+def test_main_launch_ui_reports_failure(monkeypatch, capsys):
+    def boom(ui_url: str, timeout_s: float) -> int:
+        raise readiness_smoke.ReadinessError("ui never came up")
+
+    monkeypatch.setattr(readiness_smoke, "launch_and_probe_ui", boom)
+    assert readiness_smoke.main(["--launch-ui"]) == 1
+    err = capsys.readouterr().err
+    assert "FAILED" in err
+    assert "ui never came up" in err

--- a/tests/test_ui_launch.py
+++ b/tests/test_ui_launch.py
@@ -1,0 +1,38 @@
+"""Tests for the internal/local UI launcher (`make app` / `mgrdb-app`)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ui import launch
+
+
+def test_ui_launch_command_matches_compose_cmd():
+    # Must match ui/Dockerfile CMD and the Makefile `app` target verbatim.
+    assert launch.ui_launch_command() == [
+        "streamlit",
+        "run",
+        "ui/app.py",
+        "--server.port=8501",
+        "--server.headless=true",
+    ]
+
+
+def test_ui_launch_command_honors_port():
+    assert "--server.port=9000" in launch.ui_launch_command(port=9000)
+
+
+def test_main_invokes_streamlit_via_subprocess(monkeypatch):
+    seen: dict[str, list[str]] = {}
+
+    def fake_call(cmd):
+        seen["cmd"] = cmd
+        return 0
+
+    monkeypatch.setattr(launch.subprocess, "call", fake_call)
+    assert launch.main() == 0
+    assert seen["cmd"][0] == "streamlit"
+    assert seen["cmd"][2] == "ui/app.py"

--- a/ui/launch.py
+++ b/ui/launch.py
@@ -5,9 +5,10 @@ Runs the exact command the docker-compose ``ui`` service uses
 script, and the container all start the Streamlit multipage shell the same
 way. This is the lightweight internal/local launch path: it does **not**
 bring up Postgres/MinIO/uvicorn, so the UI renders against whatever API
-target ``API_BASE_URL``/``CHAT_API_URL`` point at (defaulting to
-``http://localhost:8000``). The UI cannot render live data without a
-reachable API on ``:8000``.
+targets ``API_BASE_URL`` and ``CHAT_API_URL`` point at. ``API_BASE_URL``
+defaults to ``http://localhost:8000``; ``CHAT_API_URL`` is a direct endpoint
+and defaults to ``http://localhost:8000/api/chat``. The UI cannot render live
+data without a reachable API on ``:8000``.
 
 Auth is bypassed automatically when ``UI_USERNAME``/``UI_PASSWORD`` are
 unset (see ``ui/__init__.py``), which is the intended local/internal mode;

--- a/ui/launch.py
+++ b/ui/launch.py
@@ -1,0 +1,43 @@
+"""Console-script launcher for the Manager-Database analyst UI.
+
+Runs the exact command the docker-compose ``ui`` service uses
+(``ui/Dockerfile`` ``CMD``) so ``make app``, the ``mgrdb-app`` console
+script, and the container all start the Streamlit multipage shell the same
+way. This is the lightweight internal/local launch path: it does **not**
+bring up Postgres/MinIO/uvicorn, so the UI renders against whatever API
+target ``API_BASE_URL``/``CHAT_API_URL`` point at (defaulting to
+``http://localhost:8000``). The UI cannot render live data without a
+reachable API on ``:8000``.
+
+Auth is bypassed automatically when ``UI_USERNAME``/``UI_PASSWORD`` are
+unset (see ``ui/__init__.py``), which is the intended local/internal mode;
+production keeps those credentials set.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+UI_APP_PATH = "ui/app.py"
+DEFAULT_UI_PORT = 8501
+
+
+def ui_launch_command(port: int = DEFAULT_UI_PORT) -> list[str]:
+    """Return the Streamlit launch command, matching ``ui/Dockerfile`` ``CMD``."""
+    return [
+        "streamlit",
+        "run",
+        UI_APP_PATH,
+        f"--server.port={port}",
+        "--server.headless=true",
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Launch the analyst UI shell on ``:8501`` for internal/local use."""
+    return subprocess.call(ui_launch_command())
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1093.

## What
A single documented command launches the Streamlit analyst UI shell on `:8501` for internal/local use, without hand-orchestrating Postgres + MinIO + uvicorn.

- **`make app`** — runs `streamlit run ui/app.py --server.port=8501 --server.headless=true`, matching the docker-compose `ui` service CMD (`ui/Dockerfile`) verbatim.
- **`mgrdb-app`** console script (`[project.scripts]` → `ui.launch:main`) — same launch via `ui/launch.py`, which defines the launch command once so the Makefile target, console script, and container stay in lockstep.
- **`make app-smoke`** (`python scripts/readiness_smoke.py --launch-ui`) — spawns the UI via that exact command and asserts it answers **200 on `:8501`** using the existing `check_ui` probe, then tears the process down. No full Docker stack required.
- **`README_bootstrap.md`** gains a "Run the UI locally (no full Docker stack)" subsection documenting the single command, the API-target env vars (`API_BASE_URL`/`CHAT_API_URL`, default `http://localhost:8000`), the local auth bypass when `UI_USERNAME`/`UI_PASSWORD` are unset (`ui/__init__.py`), and the smoke gate.

## Non-goals honored
- Docker compose stack untouched (kept for full ingest/Postgres/MinIO).
- No external SaaS / Streamlit Community Cloud publishing — internal/local only.
- No new UI pages, no API changes, no new auth (reuses the existing dev-mode bypass).

## Acceptance evidence
- **Smoke gate (real launch):** `make app-smoke` →
  ```
  readiness smoke OK (ui launch path, ui=http://localhost:8501)
  ```
  Streamlit really launched on `:8501`, returned 200, was torn down (`Stopping...`), and the port was released.
- **Tests:** `pytest tests/test_readiness_smoke.py tests/test_ui_launch.py` → **19 passed**. New tests cover the launch command matching the compose CMD, the `--launch-ui` routing, and teardown-on-failure.
- **`mgrdb-app` entry point** resolves to `ui.launch:main` after `pip install -e .`.
- `ruff check` clean; `mypy ui/launch.py scripts/readiness_smoke.py` → no issues; `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)