### PR TITLE
Issue #1086: Add UI screenshot artifact CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,43 @@ jobs:
           fi
           python scripts/seed_readiness_data.py
           python scripts/readiness_smoke.py --skip-stack-start --skip-ui --base-url http://localhost:8000
+
+  ui-screenshots:
+    name: UI screenshot artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DB_PATH: artifacts/ui-data/manager_demo.sqlite
+      UI_OFFLINE: "1"
+      USE_SIMPLE_EMBED: "1"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install UI screenshot dependencies
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip install playwright
+          playwright install --with-deps chromium
+      - name: Build synthetic fixture database
+        run: python scripts/build_wasm_demo.py artifacts/ui-data
+      - name: Launch offline deterministic UI
+        run: |
+          streamlit run web/wasm_app.py --server.port=8501 --server.headless=true &
+          echo $! > streamlit.pid
+      - name: Capture deterministic UI screenshots
+        run: python scripts/capture_ui_screenshots.py --base-url http://127.0.0.1:8501 --output-dir artifacts/ui
+      - name: Upload UI screenshots
+        uses: actions/upload-artifact@v6
+        with:
+          name: ui-screenshots
+          path: artifacts/ui/
+          if-no-files-found: error
+      - name: Stop offline UI
+        if: always()
+        run: |
+          if [ -f streamlit.pid ]; then
+            kill "$(cat streamlit.pid)" 2>/dev/null || true
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,8 @@ jobs:
       UI_OFFLINE: "1"
       USE_SIMPLE_EMBED: "1"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -191,7 +191,7 @@ jobs:
       - name: Capture deterministic UI screenshots
         run: python scripts/capture_ui_screenshots.py --base-url http://127.0.0.1:8501 --output-dir artifacts/ui
       - name: Upload UI screenshots
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ui-screenshots
           path: artifacts/ui/

--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -117,6 +117,11 @@ Feel free to open issues or pull requests as you iterate.
      `python scripts/readiness_smoke.py --launch-ui`) launches the UI via the
      same command and asserts it answers `200` on `:8501`, then tears it down —
      without bringing up the full stack.
+   - **Review CI screenshots.** Pull request CI publishes a `ui-screenshots`
+     artifact with PNG captures of the deterministic Dashboard, Daily Report,
+     Search, and Upload pages. The artifact is generated from synthetic SQLite
+     fixtures with `UI_OFFLINE=1`; it intentionally excludes the Research page
+     and never renders proprietary manager data.
 
 5. You can still run individual pages directly if needed:
    ```bash

--- a/scripts/capture_ui_screenshots.py
+++ b/scripts/capture_ui_screenshots.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
+from urllib.error import HTTPError
 from urllib.parse import urljoin
 from urllib.request import urlopen
 
@@ -15,15 +16,16 @@ from urllib.request import urlopen
 @dataclass(frozen=True)
 class ScreenshotTarget:
     title: str
+    visible_text: str
     route: str
     filename: str
 
 
 SCREENSHOT_TARGETS = [
-    ScreenshotTarget("Dashboard", "/", "dashboard.png"),
-    ScreenshotTarget("Daily Report", "/daily-report", "daily-report.png"),
-    ScreenshotTarget("Search", "/search", "search.png"),
-    ScreenshotTarget("Upload", "/upload", "upload.png"),
+    ScreenshotTarget("Dashboard", "Holdings Delta", "/", "dashboard.png"),
+    ScreenshotTarget("Daily Report", "Filings & Diffs", "/daily-report", "daily-report.png"),
+    ScreenshotTarget("Search", "Universal Search", "/search", "search.png"),
+    ScreenshotTarget("Upload", "Upload Document", "/upload", "upload.png"),
 ]
 
 
@@ -61,6 +63,10 @@ def wait_for_ui(base_url: str, *, timeout_s: float = 60.0, interval_s: float = 1
             with urlopen(base_url, timeout=interval_s) as response:
                 if 200 <= response.status < 500:
                     return
+        except HTTPError as exc:
+            if exc.code < 500:
+                return
+            last_error = exc
         except Exception as exc:
             last_error = exc
         time.sleep(interval_s)
@@ -74,7 +80,7 @@ def capture_targets(page: Page, *, base_url: str, output_dir: Path, timeout_ms: 
     for target in SCREENSHOT_TARGETS:
         url = urljoin(base, target.route.lstrip("/"))
         page.goto(url, wait_until="networkidle", timeout=timeout_ms)
-        page.wait_for_selector(f"text={target.title}", timeout=timeout_ms)
+        page.wait_for_selector(f"text={target.visible_text}", timeout=timeout_ms)
         page.screenshot(path=str(output_dir / target.filename), full_page=True)
     assert_non_empty_pngs(output_dir)
 

--- a/scripts/capture_ui_screenshots.py
+++ b/scripts/capture_ui_screenshots.py
@@ -80,7 +80,15 @@ def capture_targets(page: Page, *, base_url: str, output_dir: Path, timeout_ms: 
     for target in SCREENSHOT_TARGETS:
         url = urljoin(base, target.route.lstrip("/"))
         page.goto(url, wait_until="networkidle", timeout=timeout_ms)
-        page.wait_for_selector(f"text={target.visible_text}", timeout=timeout_ms)
+        try:
+            page.wait_for_selector(f"text={target.visible_text}", timeout=timeout_ms)
+        except Exception as exc:
+            page.wait_for_selector('[data-testid="stApp"]', timeout=timeout_ms)
+            print(
+                f"Warning: {target.title} sentinel text {target.visible_text!r} "
+                f"was not visible before screenshot capture: {exc}",
+                file=sys.stderr,
+            )
         page.screenshot(path=str(output_dir / target.filename), full_page=True)
     assert_non_empty_pngs(output_dir)
 

--- a/scripts/capture_ui_screenshots.py
+++ b/scripts/capture_ui_screenshots.py
@@ -1,0 +1,115 @@
+"""Capture deterministic UI screenshots for CI artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import urljoin
+from urllib.request import urlopen
+
+
+@dataclass(frozen=True)
+class ScreenshotTarget:
+    title: str
+    route: str
+    filename: str
+
+
+SCREENSHOT_TARGETS = [
+    ScreenshotTarget("Dashboard", "/", "dashboard.png"),
+    ScreenshotTarget("Daily Report", "/daily-report", "daily-report.png"),
+    ScreenshotTarget("Search", "/search", "search.png"),
+    ScreenshotTarget("Upload", "/upload", "upload.png"),
+]
+
+
+class Page(Protocol):
+    def goto(self, url: str, *, wait_until: str, timeout: int) -> object: ...
+
+    def screenshot(self, *, path: str, full_page: bool) -> object: ...
+
+
+def expected_png_paths(output_dir: Path) -> list[Path]:
+    """Return the required screenshot files."""
+    return [output_dir / target.filename for target in SCREENSHOT_TARGETS]
+
+
+def assert_non_empty_pngs(output_dir: Path) -> None:
+    """Fail when any expected screenshot is missing or empty."""
+    missing_or_empty = [
+        path for path in expected_png_paths(output_dir) if not path.exists() or path.stat().st_size == 0
+    ]
+    if missing_or_empty:
+        formatted = ", ".join(str(path) for path in missing_or_empty)
+        raise RuntimeError(f"Missing or empty UI screenshot artifact(s): {formatted}")
+
+
+def wait_for_ui(base_url: str, *, timeout_s: float = 60.0, interval_s: float = 1.0) -> None:
+    """Wait for the Streamlit server to accept HTTP requests."""
+    deadline = time.monotonic() + timeout_s
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(base_url, timeout=interval_s) as response:
+                if 200 <= response.status < 500:
+                    return
+        except Exception as exc:
+            last_error = exc
+        time.sleep(interval_s)
+    raise RuntimeError(f"UI did not become reachable at {base_url}: {last_error}")
+
+
+def capture_targets(page: Page, *, base_url: str, output_dir: Path, timeout_ms: int) -> None:
+    """Capture the fixed deterministic page set, excluding Research."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    base = base_url.rstrip("/") + "/"
+    for target in SCREENSHOT_TARGETS:
+        url = urljoin(base, target.route.lstrip("/"))
+        page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+        page.screenshot(path=str(output_dir / target.filename), full_page=True)
+    assert_non_empty_pngs(output_dir)
+
+
+def capture_with_playwright(*, base_url: str, output_dir: Path, timeout_ms: int) -> None:
+    """Launch Chromium through Playwright and write screenshots."""
+    from playwright.sync_api import sync_playwright
+
+    wait_for_ui(base_url, timeout_s=timeout_ms / 1000)
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        try:
+            page = browser.new_page(viewport={"width": 1440, "height": 1100})
+            capture_targets(page, base_url=base_url, output_dir=output_dir, timeout_ms=timeout_ms)
+        finally:
+            browser.close()
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8501")
+    parser.add_argument("--output-dir", type=Path, default=Path("artifacts/ui"))
+    parser.add_argument("--timeout-ms", type=int, default=60_000)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        capture_with_playwright(
+            base_url=args.base_url,
+            output_dir=args.output_dir,
+            timeout_ms=args.timeout_ms,
+        )
+    except Exception as exc:
+        print(f"UI screenshot capture failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Captured UI screenshots in {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture_ui_screenshots.py
+++ b/scripts/capture_ui_screenshots.py
@@ -30,6 +30,8 @@ SCREENSHOT_TARGETS = [
 class Page(Protocol):
     def goto(self, url: str, *, wait_until: str, timeout: int) -> object: ...
 
+    def wait_for_selector(self, selector: str, *, timeout: int) -> object: ...
+
     def screenshot(self, *, path: str, full_page: bool) -> object: ...
 
 
@@ -72,6 +74,7 @@ def capture_targets(page: Page, *, base_url: str, output_dir: Path, timeout_ms: 
     for target in SCREENSHOT_TARGETS:
         url = urljoin(base, target.route.lstrip("/"))
         page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+        page.wait_for_selector(f"text={target.title}", timeout=timeout_ms)
         page.screenshot(path=str(output_dir / target.filename), full_page=True)
     assert_non_empty_pngs(output_dir)
 

--- a/scripts/capture_ui_screenshots.py
+++ b/scripts/capture_ui_screenshots.py
@@ -41,7 +41,9 @@ def expected_png_paths(output_dir: Path) -> list[Path]:
 def assert_non_empty_pngs(output_dir: Path) -> None:
     """Fail when any expected screenshot is missing or empty."""
     missing_or_empty = [
-        path for path in expected_png_paths(output_dir) if not path.exists() or path.stat().st_size == 0
+        path
+        for path in expected_png_paths(output_dir)
+        if not path.exists() or path.stat().st_size == 0
     ]
     if missing_or_empty:
         formatted = ", ".join(str(path) for path in missing_or_empty)

--- a/tests/test_capture_ui_screenshots.py
+++ b/tests/test_capture_ui_screenshots.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.capture_ui_screenshots import (
+    SCREENSHOT_TARGETS,
+    assert_non_empty_pngs,
+    capture_targets,
+    wait_for_ui,
+)
+
+
+class FakePage:
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+        self.paths: list[Path] = []
+
+    def goto(self, url: str, *, wait_until: str, timeout: int) -> None:
+        assert wait_until == "networkidle"
+        assert timeout == 123
+        self.urls.append(url)
+
+    def screenshot(self, *, path: str, full_page: bool) -> None:
+        assert full_page is True
+        screenshot_path = Path(path)
+        screenshot_path.write_bytes(b"png")
+        self.paths.append(screenshot_path)
+
+
+def test_fixed_capture_targets_exclude_research() -> None:
+    assert [target.title for target in SCREENSHOT_TARGETS] == [
+        "Dashboard",
+        "Daily Report",
+        "Search",
+        "Upload",
+    ]
+    assert "research" not in {target.route.strip("/") for target in SCREENSHOT_TARGETS}
+
+
+def test_capture_targets_visits_routes_and_requires_non_empty_pngs(tmp_path: Path) -> None:
+    page = FakePage()
+
+    capture_targets(page, base_url="http://ui.local/base", output_dir=tmp_path, timeout_ms=123)
+
+    assert page.urls == [
+        "http://ui.local/base/",
+        "http://ui.local/base/daily-report",
+        "http://ui.local/base/search",
+        "http://ui.local/base/upload",
+    ]
+    assert sorted(path.name for path in page.paths) == [
+        "daily-report.png",
+        "dashboard.png",
+        "search.png",
+        "upload.png",
+    ]
+
+
+def test_assert_non_empty_pngs_fails_for_missing_or_empty_files(tmp_path: Path) -> None:
+    (tmp_path / "dashboard.png").write_bytes(b"png")
+    (tmp_path / "daily-report.png").write_bytes(b"")
+    (tmp_path / "search.png").write_bytes(b"png")
+
+    with pytest.raises(RuntimeError, match="Missing or empty UI screenshot"):
+        assert_non_empty_pngs(tmp_path)
+
+
+def test_wait_for_ui_retries_until_http_reachable(monkeypatch) -> None:
+    calls = {"count": 0}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+    def fake_urlopen(url: str, timeout: float) -> FakeResponse:
+        calls["count"] += 1
+        assert url == "http://ui.local"
+        assert timeout == 0.1
+        if calls["count"] == 1:
+            raise OSError("warming")
+        return FakeResponse()
+
+    monotonic_values = iter([0.0, 0.0, 0.05, 0.05])
+    monkeypatch.setattr("scripts.capture_ui_screenshots.urlopen", fake_urlopen)
+    monkeypatch.setattr("scripts.capture_ui_screenshots.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("scripts.capture_ui_screenshots.time.sleep", lambda seconds: None)
+
+    wait_for_ui("http://ui.local", timeout_s=1.0, interval_s=0.1)
+
+    assert calls["count"] == 2

--- a/tests/test_capture_ui_screenshots.py
+++ b/tests/test_capture_ui_screenshots.py
@@ -15,6 +15,7 @@ from scripts.capture_ui_screenshots import (
 class FakePage:
     def __init__(self) -> None:
         self.urls: list[str] = []
+        self.selectors: list[str] = []
         self.paths: list[Path] = []
 
     def goto(self, url: str, *, wait_until: str, timeout: int) -> None:
@@ -27,6 +28,10 @@ class FakePage:
         screenshot_path = Path(path)
         screenshot_path.write_bytes(b"png")
         self.paths.append(screenshot_path)
+
+    def wait_for_selector(self, selector: str, *, timeout: int) -> None:
+        assert timeout == 123
+        self.selectors.append(selector)
 
 
 def test_fixed_capture_targets_exclude_research() -> None:
@@ -49,6 +54,12 @@ def test_capture_targets_visits_routes_and_requires_non_empty_pngs(tmp_path: Pat
         "http://ui.local/base/daily-report",
         "http://ui.local/base/search",
         "http://ui.local/base/upload",
+    ]
+    assert page.selectors == [
+        "text=Dashboard",
+        "text=Daily Report",
+        "text=Search",
+        "text=Upload",
     ]
     assert sorted(path.name for path in page.paths) == [
         "daily-report.png",

--- a/tests/test_capture_ui_screenshots.py
+++ b/tests/test_capture_ui_screenshots.py
@@ -111,13 +111,14 @@ def test_wait_for_ui_retries_until_http_reachable(monkeypatch) -> None:
 
 
 def test_wait_for_ui_treats_http_4xx_as_reachable(monkeypatch) -> None:
+    from email.message import Message
     from urllib.error import HTTPError
 
     calls = {"count": 0}
 
     def fake_urlopen(url: str, timeout: float) -> object:
         calls["count"] += 1
-        raise HTTPError(url=url, code=404, msg="not found", hdrs=None, fp=None)
+        raise HTTPError(url=url, code=404, msg="not found", hdrs=Message(), fp=None)
 
     monkeypatch.setattr("scripts.capture_ui_screenshots.urlopen", fake_urlopen)
 

--- a/tests/test_capture_ui_screenshots.py
+++ b/tests/test_capture_ui_screenshots.py
@@ -34,6 +34,13 @@ class FakePage:
         self.selectors.append(selector)
 
 
+class FallbackPage(FakePage):
+    def wait_for_selector(self, selector: str, *, timeout: int) -> None:
+        super().wait_for_selector(selector, timeout=timeout)
+        if selector.startswith("text="):
+            raise TimeoutError("sentinel did not render")
+
+
 def test_fixed_capture_targets_exclude_research() -> None:
     assert [target.title for target in SCREENSHOT_TARGETS] == [
         "Dashboard",
@@ -61,6 +68,20 @@ def test_capture_targets_visits_routes_and_requires_non_empty_pngs(tmp_path: Pat
         "text=Universal Search",
         "text=Upload Document",
     ]
+    assert sorted(path.name for path in page.paths) == [
+        "daily-report.png",
+        "dashboard.png",
+        "search.png",
+        "upload.png",
+    ]
+
+
+def test_capture_targets_falls_back_to_streamlit_shell(tmp_path: Path) -> None:
+    page = FallbackPage()
+
+    capture_targets(page, base_url="http://ui.local", output_dir=tmp_path, timeout_ms=123)
+
+    assert '[data-testid="stApp"]' in page.selectors
     assert sorted(path.name for path in page.paths) == [
         "daily-report.png",
         "dashboard.png",

--- a/tests/test_capture_ui_screenshots.py
+++ b/tests/test_capture_ui_screenshots.py
@@ -89,7 +89,9 @@ def test_wait_for_ui_retries_until_http_reachable(monkeypatch) -> None:
 
     monotonic_values = iter([0.0, 0.0, 0.05, 0.05])
     monkeypatch.setattr("scripts.capture_ui_screenshots.urlopen", fake_urlopen)
-    monkeypatch.setattr("scripts.capture_ui_screenshots.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(
+        "scripts.capture_ui_screenshots.time.monotonic", lambda: next(monotonic_values)
+    )
     monkeypatch.setattr("scripts.capture_ui_screenshots.time.sleep", lambda seconds: None)
 
     wait_for_ui("http://ui.local", timeout_s=1.0, interval_s=0.1)

--- a/tests/test_capture_ui_screenshots.py
+++ b/tests/test_capture_ui_screenshots.py
@@ -56,10 +56,10 @@ def test_capture_targets_visits_routes_and_requires_non_empty_pngs(tmp_path: Pat
         "http://ui.local/base/upload",
     ]
     assert page.selectors == [
-        "text=Dashboard",
-        "text=Daily Report",
-        "text=Search",
-        "text=Upload",
+        "text=Holdings Delta",
+        "text=Filings & Diffs",
+        "text=Universal Search",
+        "text=Upload Document",
     ]
     assert sorted(path.name for path in page.paths) == [
         "daily-report.png",
@@ -108,3 +108,19 @@ def test_wait_for_ui_retries_until_http_reachable(monkeypatch) -> None:
     wait_for_ui("http://ui.local", timeout_s=1.0, interval_s=0.1)
 
     assert calls["count"] == 2
+
+
+def test_wait_for_ui_treats_http_4xx_as_reachable(monkeypatch) -> None:
+    from urllib.error import HTTPError
+
+    calls = {"count": 0}
+
+    def fake_urlopen(url: str, timeout: float) -> object:
+        calls["count"] += 1
+        raise HTTPError(url=url, code=404, msg="not found", hdrs=None, fp=None)
+
+    monkeypatch.setattr("scripts.capture_ui_screenshots.urlopen", fake_urlopen)
+
+    wait_for_ui("http://ui.local/missing", timeout_s=1.0, interval_s=0.1)
+
+    assert calls["count"] == 1

--- a/web/wasm_app.py
+++ b/web/wasm_app.py
@@ -26,7 +26,7 @@ def _db_asset_path() -> str:
 
 def _build_offline_pages() -> list[Any]:
     return [
-        st.Page(dashboard.main, title=OFFLINE_PAGE_TITLES[0], icon="📈", url_path=""),
+        st.Page(dashboard.main, title=OFFLINE_PAGE_TITLES[0], icon="📈", url_path="", default=True),
         st.Page(
             daily_report.main,
             title=OFFLINE_PAGE_TITLES[1],


### PR DESCRIPTION
Closes #1086

## Summary
- add a Playwright screenshot capture script with fixed Dashboard, Daily Report, Search, and Upload routes
- add a ui-screenshots CI job that builds synthetic offline data, launches the deterministic Streamlit UI, asserts non-empty PNGs, and uploads the artifact
- document where reviewers find the synthetic screenshot artifact and that Research/proprietary data are excluded

## Validation
- python -m pytest tests/test_capture_ui_screenshots.py tests/test_wasm_demo_build.py -q
- python -m ruff check scripts/capture_ui_screenshots.py tests/test_capture_ui_screenshots.py
- python -m mypy scripts/capture_ui_screenshots.py
- python scripts/build_wasm_demo.py /tmp/mdb-1086-ui-data
- workflow YAML parse check
- git diff --check