### PR TITLE
Add app behavior baseline kit (api-snapshot: FastAPI managers endpoints)

### DIFF
--- a/.project_modules.txt
+++ b/.project_modules.txt
@@ -6,3 +6,11 @@ diff_holdings
 embeddings
 profiler
 _pg_fakes
+
+# app-baseline-kit ships the `baseline_kit` import (declared via the
+# app-baseline-kit git pin in pyproject [dev]); not a missing dependency.
+baseline_kit
+
+# tests/baseline/conftest.py is imported relatively ("from .conftest import ...");
+# the import scanner sees a bare `conftest` top-level name.
+conftest

--- a/docs/baseline-kit-dependency.md
+++ b/docs/baseline-kit-dependency.md
@@ -1,0 +1,64 @@
+# app-baseline-kit dependency
+
+Manager-Database uses **Pattern A** (the fleet default; see
+`stranske/Workflows/docs/guides/BASELINE_KIT_DEPENDENCY.md`).
+
+## What
+
+`app-baseline-kit` (the `baseline_kit` import) is declared **unpinned `@main`**
+in `pyproject.toml` `[project.optional-dependencies].dev`:
+
+```toml
+"app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit"
+```
+
+and is **excluded from `requirements.lock`** via:
+
+```toml
+[tool.uv.pip]
+no-emit-package = ["app-baseline-kit"]
+```
+
+`pytest-regressions>=2.8` (a transitive dependency of `app-baseline-kit`, used by
+the `data_regression` fixture the api-snapshot golden layer drives) is declared
+explicitly in `[dev]` so it is captured in the lock and the lock-presence test
+passes.
+
+## Why Pattern A (not B or vendoring)
+
+- **Build backend.** This repo uses the plain `setuptools.build_meta` backend,
+  which serializes a PEP 508 `name @ git+url` direct reference in extras metadata
+  cleanly. That rules out Pattern B (TPP's lock-only workaround exists only
+  because its custom `tp_build_backend` cannot serialize such metadata).
+- **CI install path.** CI calls the reusable
+  `stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main`, which
+  installs **both** `-r requirements.lock` **and** `-e ".[app,dev]"` in a single
+  `uv pip install`. The editable `[dev]` install resolves the `@main` URL, so
+  `baseline_kit` is installed at test time. Because the lock and the pyproject
+  URL are passed to the *same* `uv` invocation, the lock must **not** carry a
+  SHA-pinned `app-baseline-kit` URL — otherwise uv aborts on a cold-cache resolve
+  with *"Requirements contain conflicting URLs for package app-baseline-kit."*
+  `no-emit-package` keeps the package out of the lock, so the only URL uv sees is
+  the unpinned `@main` one. (This is the exact failure class Pension-Data hit and
+  fixed by adding `no-emit-package`.)
+- **Not vendoring.** The consumed surface is non-trivial (snapshot normalization,
+  directional engine, invariants, coverage manifest) and we want to track
+  Workflows `main` automatically while the package is unversioned, so vendoring
+  (Inv-Man-Intake's approach) is not warranted.
+
+## Knock-on changes
+
+- `tests/test_dependency_version_alignment.py` now subtracts the
+  `[tool.uv.pip].no-emit-package` names from the expected-in-lock set and treats
+  `name @ git+...` direct references as present-without-a-pinned-version (mirrors
+  Counter_Risk).
+- `.project_modules.txt` declares `baseline_kit` (the shipped import) and
+  `conftest` (the relative import the test-dependency scanner sees) as
+  first-party so `scripts/sync_test_dependencies.py --verify` does not flag them.
+
+## Tradeoff
+
+The exact baseline-kit commit used in CI is not recorded in the lock;
+reproducibility of *that one package* depends on Workflows `main` HEAD at install
+time. Acceptable while the package is unversioned; revisit once it is
+tagged/released.

--- a/docs/reports/baseline-coverage.md
+++ b/docs/reports/baseline-coverage.md
@@ -1,0 +1,14 @@
+# Manager-Database baseline coverage manifest (api-snapshot)
+
+- Input parameters: **6**
+- Exercised by a scenario: **6** (100.0%)
+- Observed read at runtime: **0**
+
+## Priority parameters
+
+- [x] `endpoint`
+- [x] `limit`
+- [x] `offset`
+- [x] `jurisdiction`
+- [x] `tag`
+- [x] `manager_id`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,25 @@ dev = [
     "referencing",
     "PyYAML",
     "fakeredis",
+    # Shared app-behavior baseline harness (api-snapshot kit under tests/baseline).
+    # Pattern A: unpinned @main, excluded from requirements.lock via the
+    # [tool.uv.pip] no-emit-package below. See docs/baseline-kit-dependency.md.
+    "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
+    # Transitive dep of app-baseline-kit; declared explicitly so the lock-presence
+    # test (tests/test_dependency_version_alignment.py) is satisfied.
+    "pytest-regressions>=2.8",
 ]
 
 [build-system]
 requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
+
+# Do not freeze a commit SHA for the monorepo app-baseline-kit package in
+# requirements.lock. Pattern A: the unpinned @main pyproject URL and the lock
+# must never disagree, or uv aborts on a cold-cache resolve with "conflicting
+# URLs for package app-baseline-kit". See docs/baseline-kit-dependency.md.
+[tool.uv.pip]
+no-emit-package = ["app-baseline-kit"]
 
 # Explicit package discovery for flat layout with multiple top-level packages
 [tool.setuptools.packages.find]

--- a/requirements.lock
+++ b/requirements.lock
@@ -396,12 +396,21 @@ pypdfium2==5.6.0
 pytest==9.0.3
     # via
     #   manager-database (pyproject.toml)
+    #   app-baseline-kit
     #   pytest-asyncio
     #   pytest-cov
+    #   pytest-datadir
+    #   pytest-regressions
 pytest-asyncio==1.3.0
     # via manager-database (pyproject.toml)
 pytest-cov==7.1.0
     # via manager-database (pyproject.toml)
+pytest-datadir==1.8.0
+    # via pytest-regressions
+pytest-regressions==2.11.0
+    # via
+    #   manager-database (pyproject.toml)
+    #   app-baseline-kit
 python-dateutil==2.9.0.post0
     # via
     #   botocore
@@ -429,10 +438,12 @@ pywin32==311 ; sys_platform == 'win32'
 pyyaml==6.0.3
     # via
     #   manager-database (pyproject.toml)
+    #   app-baseline-kit
     #   apprise
     #   langchain-core
     #   pre-commit
     #   prefect
+    #   pytest-regressions
     #   streamlit-authenticator
 readchar==4.2.1
     # via prefect
@@ -615,3 +626,6 @@ zipp==3.23.0
     # via importlib-metadata
 zstandard==0.25.0
     # via langsmith
+
+# The following packages were excluded from the output:
+# app-baseline-kit

--- a/tests/baseline/README.md
+++ b/tests/baseline/README.md
@@ -1,0 +1,105 @@
+# Manager-Database app behavior baseline kit (api-snapshot modality)
+
+Scenario-driven wiring / sensibility / regression tests built on the shared
+**`baseline_kit`** package. Only the app-specific pieces live here.
+
+> **This is the fleet's reference kit for the _api-snapshot_ modality.** The
+> rest of the fleet (Counter_Risk, TMP, PAEM, trip-planner, …) baselines a
+> *deterministic compute*: a pure function reduced to a flat metrics dict,
+> golden-mastered with `check_metrics` (numpy/pandas via `num_regression`).
+> Manager-Database is a **FastAPI service**, so its target surface is its HTTP
+> layer. The kit drives the `/managers` endpoints through a Starlette
+> `TestClient` against a **freshly seeded, deterministic sqlite DB** and
+> snapshots the JSON responses with `baseline_kit.check_snapshot`
+> (pytest-regressions' `data_regression`, YAML — **no numpy/pandas**).
+
+## Requires
+
+`baseline_kit` (the shared core, **v0.2.0+** — needs the `snapshot` helper) must
+be importable. It lives in `stranske/Workflows` under
+`packages/app-baseline-kit` and is declared in this repo's `pyproject.toml`
+`[project.optional-dependencies].dev` (Pattern A, unpinned `@main`):
+
+```bash
+pip install -e ".[app,dev]"   # how CI installs it (resolves the @main URL)
+```
+
+`pytest-regressions` is a transitive dependency of `app-baseline-kit`; it is also
+declared explicitly in `[dev]` so the lock-presence test stays satisfied. See
+[`docs/baseline-kit-dependency.md`](../../docs/baseline-kit-dependency.md) for
+the dependency-pattern justification.
+
+## Target surface
+
+The FastAPI `/managers` endpoints in `api/managers.py`, mounted on a **minimal**
+app (managers router only — the kit does not import `api.chat.app`, avoiding its
+boto3 / langsmith / prometheus import chain):
+
+| Endpoint | What it returns |
+|---|---|
+| `GET /managers` | paginated list (`limit`/`offset`) + `jurisdiction`/`tag` filters; `{items, total, limit, offset}` envelope |
+| `GET /managers/{id}` | a single manager (404 when absent) |
+| `GET /managers/stats` | universe aggregates (`total_managers`, `by_jurisdiction`, `by_tag`, `with_cik`, `with_lei`) |
+
+## How it stays deterministic
+
+`adapters.base.connect_db` reads `DB_PATH` from the environment per request and
+opens a plain `sqlite3` connection. The adapter seeds a **fresh** sqlite file
+(per-test `tmp_path`) from a committed, fixed seed variant, points `DB_PATH` at
+it, resets the in-process query cache, and calls the endpoint via `TestClient`.
+Same seed + same request ⇒ byte-identical JSON. The two volatile fields
+(`created_at` / `updated_at`) are both pinned in the seed *and* redacted by the
+golden layer, so they can never wobble.
+
+## Layout
+
+```
+adapter.py                # seed sqlite + TestClient -> (payload, flat metrics)  [the only app glue]
+catalog.yaml              # seed variants + endpoint/param scenarios + directional checks
+invariants.py             # structural + economic invariants -> baseline_kit.InvariantResult
+test_golden.py            # JSON-response snapshots via check_snapshot (redacts timestamps)
+test_directional.py       # metamorphic checks (filter narrows count, richer seed raises total...)
+test_invariants.py        # invariants on every scenario
+test_coverage_manifest.py # request-param coverage -> docs/reports/baseline-coverage.md
+test_golden/              # blessed YAML snapshots (one per scenario)
+```
+
+## Scenario model
+
+A *scenario* names an `endpoint` (`list` | `detail` | `stats`), a `seed` variant
+(`base` | `richer`), and the request knobs (`params` for list filters/paging, or
+`manager_id` for detail). Each scenario produces **both** a JSON payload (for
+snapshotting) and a flat `dict[str, float | int]` of reduced metrics (`count`,
+`total`, `total_managers`, `with_cik`, …) for invariants and directional checks.
+
+## Running
+
+```bash
+PYTHONHASHSEED=0 pytest tests/baseline/                          # full suite
+pytest tests/baseline/test_golden.py --force-regen               # re-bless after an intended change
+BASELINE_REFRESH_REPORT=1 pytest tests/baseline/test_coverage_manifest.py  # refresh report
+```
+
+After a `--force-regen`, **inspect** the updated YAML under `test_golden/`
+before committing.
+
+## Invariants enforced
+
+- **list:** `status==200`; `{items,total,limit,offset}` envelope; `items` is a
+  list; `count <= limit` and `count <= total`; ids are integers, unique, and
+  **sorted ascending** (`ORDER BY id` ⇒ stable ordering); names non-empty; the
+  per-scenario seeded `count`/`total` expectation holds.
+- **detail:** found ⇒ `status==200`, echoes the requested id, has a name and the
+  required fields; miss ⇒ `status==404`, `{"detail": …}`, no `manager_id`.
+- **stats:** `status==200`; `total_managers` equals the seeded row count and the
+  scenario expectation; `with_cik`/`with_lei` non-negative and `<= total`; every
+  breakdown key lowercased; each breakdown count in `[1, total]`.
+
+## Directional checks
+
+- a `jurisdiction` / `tag` filter **narrows** the count vs the unfiltered list;
+- combining two filters narrows **at least as much** as one;
+- pagination **caps** the page size below the full count but leaves `total`
+  **unchanged**;
+- a **richer** seed (more managers) **raises** the list count, the stats
+  `total_managers`, and (weakly) `with_cik`.

--- a/tests/baseline/__init__.py
+++ b/tests/baseline/__init__.py
@@ -1,0 +1,29 @@
+"""Manager-Database app behavior baseline kit (api-snapshot modality).
+
+Built on the shared ``baseline_kit`` package -- this directory contains only the
+app-specific pieces (adapter, catalog, invariant bounds, seed fixture). The
+generic harness (snapshot glue, directional engine, invariant assertion,
+coverage manifest) is imported from ``baseline_kit``, the same core the
+Counter_Risk / TMP / trip-planner kits use.
+
+**This is the fleet's reference kit for the api-snapshot modality.** The rest of
+the fleet baselines a *deterministic compute* (a pure function reduced to a flat
+metrics dict, golden-mastered with ``check_metrics``). Manager-Database is a
+FastAPI service, so its target surface is its HTTP layer: the kit exercises the
+``/managers`` endpoints through a Starlette ``TestClient`` against a freshly
+seeded, deterministic in-process sqlite database, and snapshots the JSON
+responses with ``baseline_kit.check_snapshot`` (YAML via pytest-regressions'
+``data_regression`` -- no numpy/pandas).
+
+Target surface (``api/managers.py`` routes, mounted on a minimal FastAPI app):
+
+  * ``GET /managers``        -- paginated list (``limit``/``offset``) with
+                                ``jurisdiction``/``tag`` filters.
+  * ``GET /managers/{id}``   -- single manager by id (404 when absent).
+  * ``GET /managers/stats``  -- universe aggregates (counts, by-jurisdiction,
+                                by-tag, with_cik, with_lei).
+
+The adapter returns BOTH the JSON payload (for snapshotting) and a flat
+``dict[str, float | int]`` of reduced metrics (for invariants and directional
+checks), so the same scenario drives all three layers.
+"""

--- a/tests/baseline/adapter.py
+++ b/tests/baseline/adapter.py
@@ -1,0 +1,259 @@
+"""App-specific adapter for the Manager-Database ``/managers`` HTTP surface.
+
+This is the ONLY app-specific glue the shared ``baseline_kit`` needs for the
+**api-snapshot** modality: a way to turn a scenario (an endpoint + query/path
+params, run against a named seed variant) into
+
+  * a JSON-able *payload* (``{"status_code": ..., "json": <body>}``) for golden
+    snapshotting via ``baseline_kit.check_snapshot``, and
+  * a flat ``dict[str, float | int]`` of reduced *metrics* for invariants and
+    directional ("metamorphic") checks.
+
+Everything else -- snapshot normalization, directional engine, invariant
+assertion, coverage manifest -- is generic and lives in ``baseline_kit``.
+
+Determinism
+-----------
+The app's data layer (``adapters.base.connect_db``) reads ``DB_PATH`` from the
+environment at call time and opens a plain ``sqlite3`` connection. We exploit
+that: each scenario seeds a *fresh* sqlite file (under a per-test temp dir) from
+a committed, fixed seed variant, points ``DB_PATH`` at it, resets the process
+cache backend, and drives the endpoint through a Starlette ``TestClient`` over a
+minimal FastAPI app that mounts only ``api.managers.router``. Same seed + same
+request => byte-identical JSON (modulo the volatile fields the golden layer
+redacts: ``created_at``/``updated_at``, which we also pin explicitly in the seed
+so they never wobble).
+
+We mount a *minimal* app rather than importing ``api.chat.app`` so the kit does
+not drag in boto3 / langsmith / prometheus just to snapshot three GET handlers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A fixed timestamp baked into every seeded row. The golden layer redacts
+# created_at/updated_at anyway, but pinning them keeps the raw DB deterministic
+# and makes invariant/debug output stable.
+SEED_TIMESTAMP = "2026-01-01T00:00:00Z"
+
+
+def _create_schema(conn: sqlite3.Connection) -> None:
+    """Create the managers table with the universe-import column superset.
+
+    This is the union of what ``_ensure_manager_table`` and
+    ``_ensure_universe_schema`` produce: the columns the ``/managers`` SELECTs
+    name explicitly (``... registry_ids, quality_flags, created_at, updated_at``)
+    plus the scalar ``jurisdiction`` fallback column ``GET /managers/stats``
+    reads. Seeding the full column set means the endpoints never have to ALTER
+    the table at request time, so the snapshot is what the read path produces
+    against a complete schema.
+    """
+    conn.execute("""
+        CREATE TABLE managers (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            cik TEXT,
+            lei TEXT,
+            jurisdiction TEXT,
+            aliases TEXT NOT NULL DEFAULT '[]',
+            jurisdictions TEXT NOT NULL DEFAULT '[]',
+            tags TEXT NOT NULL DEFAULT '[]',
+            registry_ids TEXT NOT NULL DEFAULT '{}',
+            quality_flags TEXT NOT NULL DEFAULT '[]',
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """)
+
+
+def _insert_seed_rows(conn: sqlite3.Connection, rows: list[dict[str, Any]]) -> None:
+    """Insert seed manager rows with explicit, deterministic ids and timestamps.
+
+    JSON columns (``aliases``/``jurisdictions``/``tags``/``registry_ids``) are
+    stored as JSON text, exactly as the production write path does, so the read
+    path's ``json_each``/``json.loads`` handling is exercised faithfully.
+    """
+    for row in rows:
+        conn.execute(
+            """
+            INSERT INTO managers
+                (id, name, cik, lei, jurisdiction, aliases, jurisdictions,
+                 tags, registry_ids, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                int(row["id"]),
+                str(row["name"]),
+                row.get("cik"),
+                row.get("lei"),
+                # jurisdiction (scalar fallback column) mirrors first jurisdiction.
+                (row.get("jurisdictions") or [None])[0],
+                json.dumps(list(row.get("aliases", []))),
+                json.dumps(list(row.get("jurisdictions", []))),
+                json.dumps(list(row.get("tags", []))),
+                json.dumps(dict(row.get("registry_ids", {}))),
+                SEED_TIMESTAMP,
+                SEED_TIMESTAMP,
+            ),
+        )
+    conn.commit()
+
+
+def seed_database(db_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Create + seed a fresh sqlite DB at ``db_path`` from ``rows``."""
+    if db_path.exists():
+        db_path.unlink()
+    conn = sqlite3.connect(str(db_path))
+    try:
+        _create_schema(conn)
+        _insert_seed_rows(conn, rows)
+    finally:
+        conn.close()
+
+
+@contextmanager
+def _seeded_client(db_path: Path):
+    """Yield a TestClient for a minimal managers-only app bound to ``db_path``.
+
+    Reads of ``DB_PATH`` happen inside ``connect_db`` per request, so setting the
+    env var around the client covers every endpoint call. The process cache
+    backend is reset so a prior scenario's cached query results (keyed partly on
+    the DB identity) can never leak into this one.
+    """
+    # Imported lazily so importing this module never pulls FastAPI/app deps until
+    # a scenario actually runs.
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.cache import reset_cache_backend, reset_cache_stats
+    from api.managers import router as managers_router
+
+    app = FastAPI()
+    app.include_router(managers_router)
+
+    prev_db_path = os.environ.get("DB_PATH")
+    prev_db_url = os.environ.get("DB_URL")
+    # DB_URL must be unset/non-postgres so connect_db falls through to sqlite.
+    os.environ.pop("DB_URL", None)
+    os.environ["DB_PATH"] = str(db_path)
+    reset_cache_backend()
+    reset_cache_stats()
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        reset_cache_backend()
+        reset_cache_stats()
+        if prev_db_path is None:
+            os.environ.pop("DB_PATH", None)
+        else:
+            os.environ["DB_PATH"] = prev_db_path
+        if prev_db_url is not None:
+            os.environ["DB_URL"] = prev_db_url
+
+
+def _build_request(scenario: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Translate a catalog scenario into (path, query-params).
+
+    Scenario shape:
+        endpoint: "list" | "detail" | "stats"
+        params:   {limit, offset, jurisdiction, tag}   # list filters
+        manager_id: int                                  # detail target
+    """
+    endpoint = scenario["endpoint"]
+    if endpoint == "list":
+        return "/managers", dict(scenario.get("params") or {})
+    if endpoint == "detail":
+        return f"/managers/{scenario['manager_id']}", {}
+    if endpoint == "stats":
+        return "/managers/stats", {}
+    raise ValueError(f"unknown endpoint {endpoint!r}")  # pragma: no cover - catalog typo guard
+
+
+def _list_metrics(body: dict[str, Any]) -> dict[str, float | int]:
+    """Reduce a list-endpoint body to flat scalar metrics."""
+    items = body.get("items", []) or []
+    names = [it.get("name", "") for it in items]
+    ids = [it.get("manager_id") for it in items]
+    return {
+        "count": len(items),
+        "total": int(body.get("total", 0)),
+        "limit": int(body.get("limit", 0)),
+        "offset": int(body.get("offset", 0)),
+        "distinct_ids": len(set(ids)),
+        "ids_sorted_ascending": int(ids == sorted(i for i in ids if i is not None)),
+        "names_nonempty": int(all(bool(n) for n in names)),
+        "items_with_cik": sum(1 for it in items if it.get("cik")),
+    }
+
+
+def _detail_metrics(status_code: int, body: dict[str, Any]) -> dict[str, float | int]:
+    """Reduce a detail-endpoint body to flat scalar metrics."""
+    found = int(status_code == 200 and "manager_id" in body)
+    return {
+        "found": found,
+        "has_name": int(bool(body.get("name"))) if found else 0,
+        "n_aliases": len(body.get("aliases", []) or []) if found else 0,
+        "n_jurisdictions": len(body.get("jurisdictions", []) or []) if found else 0,
+        "n_tags": len(body.get("tags", []) or []) if found else 0,
+    }
+
+
+def _stats_metrics(body: dict[str, Any]) -> dict[str, float | int]:
+    """Reduce a stats-endpoint body to flat scalar metrics."""
+    by_jur = body.get("by_jurisdiction", {}) or {}
+    by_tag = body.get("by_tag", {}) or {}
+    return {
+        "total_managers": int(body.get("total_managers", 0)),
+        "n_jurisdiction_keys": len(by_jur),
+        "n_tag_keys": len(by_tag),
+        "jurisdiction_count_sum": sum(int(v) for v in by_jur.values()),
+        "tag_count_sum": sum(int(v) for v in by_tag.values()),
+        "with_cik": int(body.get("with_cik", 0)),
+        "with_lei": int(body.get("with_lei", 0)),
+    }
+
+
+def reduce_metrics(scenario: dict[str, Any], payload: dict[str, Any]) -> dict[str, float | int]:
+    """Reduce a response payload to a flat metrics dict for the given endpoint."""
+    endpoint = scenario["endpoint"]
+    status_code = int(payload["status_code"])
+    body = payload["json"] if isinstance(payload["json"], dict) else {}
+    base: dict[str, float | int] = {"status_code": status_code}
+    if endpoint == "list":
+        base.update(_list_metrics(body))
+    elif endpoint == "detail":
+        base.update(_detail_metrics(status_code, body))
+    elif endpoint == "stats":
+        base.update(_stats_metrics(body))
+    return base
+
+
+def run_scenario(
+    scenario: dict[str, Any],
+    seed_rows: list[dict[str, Any]],
+    db_path: Path,
+) -> tuple[dict[str, Any], dict[str, float | int]]:
+    """Seed a fresh DB, call the scenario's endpoint, return (payload, metrics).
+
+    ``payload`` is ``{"status_code", "json"}`` (via ``response_to_payload``) for
+    snapshotting; ``metrics`` is a flat ``dict[str, float | int]`` for invariants
+    and directional checks.
+    """
+    from baseline_kit import response_to_payload
+
+    seed_database(db_path, seed_rows)
+    path, params = _build_request(scenario)
+    with _seeded_client(db_path) as client:
+        response = client.get(path, params=params)
+    payload = response_to_payload(response)
+    metrics = reduce_metrics(scenario, payload)
+    return payload, metrics

--- a/tests/baseline/catalog.yaml
+++ b/tests/baseline/catalog.yaml
@@ -1,0 +1,299 @@
+# Manager-Database scenario catalog -- api-snapshot modality.
+#
+# Surface: the FastAPI /managers HTTP endpoints (api/managers.py), driven through
+# a Starlette TestClient against a freshly seeded, deterministic sqlite DB.
+#
+# Unlike the deterministic-compute kits (Counter_Risk etc.), a "scenario" here is
+# an ENDPOINT + params run against a named SEED variant. Each scenario yields a
+# JSON payload (golden-snapshotted via baseline_kit.check_snapshot) and a flat
+# metrics dict (for invariants + directional checks).
+
+# ---------------------------------------------------------------------------
+# Seed variants. Each is a fixed, committed list of manager rows. ids are
+# explicit and contiguous so the autoincrement surface is deterministic. The
+# `base` variant deliberately mixes:
+#   * jurisdictions: us (3), uk (1), and one multi-jurisdiction (us+uk) record,
+#   * tags: activist / hedge-fund / quant overlaps so by_tag is non-trivial,
+#   * presence of cik (4 of 5) and lei (3 of 5) so with_cik/with_lei differ,
+#   * aliases of varying length.
+# `richer` = base + 3 additional us managers (strictly more rows), used by the
+# directional "more managers raises count / total" checks.
+# ---------------------------------------------------------------------------
+seeds:
+  base:
+    - id: 1
+      name: Elliott Investment Management L.P.
+      cik: "0001791786"
+      lei: "549300U3N12T57QLOU60"
+      aliases: ["Elliott Management"]
+      jurisdictions: ["us"]
+      tags: ["activist", "hedge-fund"]
+      registry_ids: {fca_frn: "122927"}
+    - id: 2
+      name: Bridgewater Associates
+      cik: "0001350694"
+      lei: "5493001Z7HC8XOLIRT54"
+      aliases: ["Bridgewater"]
+      jurisdictions: ["us"]
+      tags: ["hedge-fund", "quant"]
+      registry_ids: {}
+    - id: 3
+      name: TCI Fund Management
+      cik: "0001647251"
+      lei: null
+      aliases: []
+      jurisdictions: ["uk"]
+      tags: ["activist"]
+      registry_ids: {fca_frn: "190271"}
+    - id: 4
+      name: Pershing Square Capital Management
+      cik: "0001336528"
+      lei: "5493006FHHFR8FMRY713"
+      aliases: ["Pershing Square"]
+      jurisdictions: ["us", "uk"]
+      tags: ["activist", "hedge-fund"]
+      registry_ids: {}
+    - id: 5
+      name: Renaissance Technologies
+      cik: null
+      lei: null
+      aliases: ["RenTech", "Renaissance"]
+      jurisdictions: ["us"]
+      tags: ["quant", "hedge-fund"]
+      registry_ids: {}
+
+  richer:
+    # base + three additional us managers (count goes 5 -> 8).
+    - id: 1
+      name: Elliott Investment Management L.P.
+      cik: "0001791786"
+      lei: "549300U3N12T57QLOU60"
+      aliases: ["Elliott Management"]
+      jurisdictions: ["us"]
+      tags: ["activist", "hedge-fund"]
+      registry_ids: {fca_frn: "122927"}
+    - id: 2
+      name: Bridgewater Associates
+      cik: "0001350694"
+      lei: "5493001Z7HC8XOLIRT54"
+      aliases: ["Bridgewater"]
+      jurisdictions: ["us"]
+      tags: ["hedge-fund", "quant"]
+      registry_ids: {}
+    - id: 3
+      name: TCI Fund Management
+      cik: "0001647251"
+      lei: null
+      aliases: []
+      jurisdictions: ["uk"]
+      tags: ["activist"]
+      registry_ids: {fca_frn: "190271"}
+    - id: 4
+      name: Pershing Square Capital Management
+      cik: "0001336528"
+      lei: "5493006FHHFR8FMRY713"
+      aliases: ["Pershing Square"]
+      jurisdictions: ["us", "uk"]
+      tags: ["activist", "hedge-fund"]
+      registry_ids: {}
+    - id: 5
+      name: Renaissance Technologies
+      cik: null
+      lei: null
+      aliases: ["RenTech", "Renaissance"]
+      jurisdictions: ["us"]
+      tags: ["quant", "hedge-fund"]
+      registry_ids: {}
+    - id: 6
+      name: Citadel Advisors
+      cik: "0001423053"
+      lei: "549300V1ZTQHPDQEM927"
+      aliases: ["Citadel"]
+      jurisdictions: ["us"]
+      tags: ["hedge-fund"]
+      registry_ids: {}
+    - id: 7
+      name: Two Sigma Investments
+      cik: "0001179392"
+      lei: null
+      aliases: ["Two Sigma"]
+      jurisdictions: ["us"]
+      tags: ["quant", "hedge-fund"]
+      registry_ids: {}
+    - id: 8
+      name: Berkshire Hathaway
+      cik: "0001067983"
+      lei: "5493000C01ZX7D35SD85"
+      aliases: []
+      jurisdictions: ["us"]
+      tags: []
+      registry_ids: {}
+
+# ---------------------------------------------------------------------------
+# Scenarios. Each names an endpoint, a seed variant, and (for list/detail) the
+# request params/target. `expect.count`/`expect.total`/`expect.total_managers`
+# encode the hand-derived seeded expectation the invariants pin.
+# ---------------------------------------------------------------------------
+scenarios:
+  # --- GET /managers (list) ------------------------------------------------
+  - id: list_all_base
+    endpoint: list
+    seed: base
+    params: {}
+    expect: {count: 5, total: 5}
+
+  - id: list_filter_us
+    endpoint: list
+    seed: base
+    params: {jurisdiction: us}
+    # us: ids 1,2,4,5  (3 is uk-only) -> 4
+    expect: {count: 4, total: 4}
+
+  - id: list_filter_uk
+    endpoint: list
+    seed: base
+    params: {jurisdiction: uk}
+    # uk: ids 3,4 -> 2
+    expect: {count: 2, total: 2}
+
+  - id: list_filter_activist
+    endpoint: list
+    seed: base
+    params: {tag: activist}
+    # activist: ids 1,3,4 -> 3
+    expect: {count: 3, total: 3}
+
+  - id: list_filter_us_activist
+    endpoint: list
+    seed: base
+    params: {jurisdiction: us, tag: activist}
+    # us AND activist: ids 1,4 -> 2
+    expect: {count: 2, total: 2}
+
+  - id: list_paginated
+    endpoint: list
+    seed: base
+    params: {limit: 2, offset: 0}
+    # page of 2, but total still reflects all 5.
+    expect: {count: 2, total: 5}
+
+  - id: list_paginated_offset
+    endpoint: list
+    seed: base
+    params: {limit: 2, offset: 4}
+    # offset past the first 4 -> only id 5 remains on the page.
+    expect: {count: 1, total: 5}
+
+  - id: list_filter_no_match
+    endpoint: list
+    seed: base
+    params: {jurisdiction: jp}
+    # no jp managers -> empty page, total 0.
+    expect: {count: 0, total: 0}
+
+  - id: list_all_richer
+    endpoint: list
+    seed: richer
+    params: {limit: 100}
+    # richer seed has 8 managers (base + 3).
+    expect: {count: 8, total: 8}
+
+  # --- GET /managers/{id} (detail) ----------------------------------------
+  - id: detail_found
+    endpoint: detail
+    seed: base
+    manager_id: 4
+    expect: {found: 1}
+
+  - id: detail_missing
+    endpoint: detail
+    seed: base
+    manager_id: 9999
+    expect: {found: 0}
+
+  # --- GET /managers/stats -------------------------------------------------
+  - id: stats_base
+    endpoint: stats
+    seed: base
+    expect: {total_managers: 5}
+
+  - id: stats_richer
+    endpoint: stats
+    seed: richer
+    expect: {total_managers: 8}
+
+# ---------------------------------------------------------------------------
+# Directional ("metamorphic") checks: a metric of one scenario vs another.
+# direction is from baseline_kit.DIRECTIONS (left=scenario, right=control).
+# Each is grounded in the endpoint contract, not boilerplate.
+# ---------------------------------------------------------------------------
+directionals:
+  # A jurisdiction filter can only narrow (or equal) the unfiltered count.
+  - id: us_filter_narrows_count
+    scenario: list_filter_us
+    control: list_all_base
+    metric: count
+    direction: less_than
+    enforce: true
+  # A tag filter likewise narrows the count.
+  - id: activist_filter_narrows_count
+    scenario: list_filter_activist
+    control: list_all_base
+    metric: count
+    direction: less_than
+    enforce: true
+  # Combining two filters narrows at least as much as one filter alone.
+  - id: combined_filter_narrows_further
+    scenario: list_filter_us_activist
+    control: list_filter_activist
+    metric: count
+    direction: less_or_equal
+    enforce: true
+  # Pagination caps the returned page size below the full count...
+  - id: pagination_caps_page
+    scenario: list_paginated
+    control: list_all_base
+    metric: count
+    direction: less_than
+    enforce: true
+  # ...but does NOT change the reported total (total is filter-, not page-, sized).
+  - id: pagination_preserves_total
+    scenario: list_paginated
+    control: list_all_base
+    metric: total
+    direction: unchanged
+    enforce: true
+  # A richer seed (more managers) raises the unfiltered list count.
+  - id: richer_seed_raises_count
+    scenario: list_all_richer
+    control: list_all_base
+    metric: count
+    direction: greater_than
+    enforce: true
+  # ...and raises the stats total_managers.
+  - id: richer_seed_raises_total_managers
+    scenario: stats_richer
+    control: stats_base
+    metric: total_managers
+    direction: greater_than
+    enforce: true
+  # ...and can only raise (never lower) the with_cik count.
+  - id: richer_seed_raises_with_cik
+    scenario: stats_richer
+    control: stats_base
+    metric: with_cik
+    direction: greater_or_equal
+    enforce: true
+
+# ---------------------------------------------------------------------------
+# Coverage manifest: input-parameter space the kit must exercise. These are the
+# request knobs the /managers surface accepts; the manifest flags any priority
+# parameter no scenario touches.
+# ---------------------------------------------------------------------------
+priority_params:
+  - endpoint
+  - limit
+  - offset
+  - jurisdiction
+  - tag
+  - manager_id

--- a/tests/baseline/conftest.py
+++ b/tests/baseline/conftest.py
@@ -1,0 +1,61 @@
+"""Fixtures and catalog loading for the Manager-Database baseline kit.
+
+Provides:
+  * the loaded scenario ``catalog`` (via ``baseline_kit.load_catalog``),
+  * ``seed_rows_for(seed_name)`` -- a fresh copy of a committed seed variant,
+  * ``db_path`` -- a per-test fresh sqlite file path (the seed target),
+
+so each scenario runs against a freshly-seeded, deterministic in-process DB.
+"""
+
+from __future__ import annotations
+
+import copy
+import functools
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+CATALOG_PATH = HERE / "catalog.yaml"
+
+# Ensure the repo root is importable (mirrors pyproject `pythonpath = ["."]`),
+# so `api.managers` / `adapters.base` resolve under the baseline venv too.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@functools.lru_cache(maxsize=1)
+def _load_catalog_cached():
+    from baseline_kit import load_catalog
+
+    return load_catalog(CATALOG_PATH)
+
+
+def seed_rows_for(seed_name: str) -> list[dict]:
+    """Return a deep copy of a named seed variant from the catalog."""
+    seeds = _load_catalog_cached()["seeds"]
+    if seed_name not in seeds:
+        raise KeyError(f"unknown seed variant {seed_name!r}; known: {sorted(seeds)}")
+    return copy.deepcopy(seeds[seed_name])
+
+
+def scenarios() -> list[dict]:
+    return list(_load_catalog_cached()["scenarios"])
+
+
+def scenarios_by_id() -> dict[str, dict]:
+    return {s["id"]: s for s in scenarios()}
+
+
+@pytest.fixture(scope="session")
+def catalog():
+    return _load_catalog_cached()
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """A per-test fresh sqlite file path used as the seed target."""
+    return tmp_path / "baseline.db"

--- a/tests/baseline/invariants.py
+++ b/tests/baseline/invariants.py
@@ -1,0 +1,200 @@
+"""Structural + economic invariants on the /managers HTTP responses.
+
+These are properties that must hold for the seeded, deterministic universe --
+grounded in the endpoint contract (``api/managers.py`` + the response models in
+``api/models.py``), NOT generic placeholders:
+
+  * status_code is 200 for valid list/stats requests; detail is 200 when the id
+    exists and 404 when it does not.
+  * a list body is a ``{items, total, limit, offset}`` envelope; ``items`` is a
+    list; the per-scenario seeded ``count``/``total`` expectation holds.
+  * every returned manager has a non-empty ``name`` and an integer
+    ``manager_id``; ids on a page are unique and sorted ascending (the SELECT is
+    ``ORDER BY id``) -- ordering is therefore stable/deterministic.
+  * ``count`` never exceeds the requested ``limit`` nor the reported ``total``;
+    ``total`` is non-negative.
+  * detail: a found manager echoes the requested id; a miss returns
+    ``{"detail": ...}`` and no body fields.
+  * stats: ``total_managers`` matches the seeded expectation and equals the sum
+    over no single breakdown (a manager may carry several tags/jurisdictions, so
+    the breakdown sums are bounded BELOW by total, not equal); counts are
+    non-negative; ``with_cik``/``with_lei`` never exceed ``total_managers``;
+    every breakdown key is lowercased (the aggregator lowercases).
+
+The result type and assertion helper are shared
+(``baseline_kit.InvariantResult`` / ``assert_invariants``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from baseline_kit import InvariantResult
+
+from . import adapter
+from .conftest import seed_rows_for
+
+
+def _check_list(
+    scenario: dict[str, Any], status_code: int, body: dict[str, Any]
+) -> list[InvariantResult]:
+    results: list[InvariantResult] = []
+
+    def add(name: str, ok: bool, detail: str, severity: str = "error") -> None:
+        results.append(InvariantResult(name, bool(ok), severity, detail))
+
+    add("list.status_200", status_code == 200, f"status={status_code}")
+
+    is_envelope = all(k in body for k in ("items", "total", "limit", "offset"))
+    add("list.envelope_shape", is_envelope, f"keys={sorted(body)}")
+    if not is_envelope:
+        return results
+
+    items = body["items"]
+    total = body["total"]
+    limit = body["limit"]
+    offset = body["offset"]
+
+    add("list.items_is_list", isinstance(items, list), f"type={type(items).__name__}")
+    add("list.total_nonneg", isinstance(total, int) and total >= 0, f"total={total}")
+    add("list.limit_positive", isinstance(limit, int) and limit >= 1, f"limit={limit}")
+    add("list.offset_nonneg", isinstance(offset, int) and offset >= 0, f"offset={offset}")
+
+    ids = [it.get("manager_id") for it in items]
+    names = [it.get("name") for it in items]
+
+    add("list.count_le_limit", len(items) <= limit, f"count={len(items)} limit={limit}")
+    add("list.count_le_total", len(items) <= total, f"count={len(items)} total={total}")
+    add("list.ids_all_int", all(isinstance(i, int) for i in ids), f"ids={ids}")
+    add("list.ids_unique", len(set(ids)) == len(ids), f"ids={ids}")
+    add("list.ids_sorted_ascending", ids == sorted(ids), f"ids={ids}")
+    add("list.names_nonempty", all(bool(n) for n in names), f"names={names}")
+    add(
+        "list.quality_flags_is_list",
+        all(isinstance(it.get("quality_flags"), list) for it in items),
+        "quality_flags must be a list on every item",
+    )
+
+    expect = scenario.get("expect", {})
+    if "count" in expect:
+        add(
+            "list.count_matches_seed_expectation",
+            len(items) == expect["count"],
+            f"count={len(items)} expected={expect['count']}",
+        )
+    if "total" in expect:
+        add(
+            "list.total_matches_seed_expectation",
+            total == expect["total"],
+            f"total={total} expected={expect['total']}",
+        )
+    return results
+
+
+def _check_detail(
+    scenario: dict[str, Any], status_code: int, body: dict[str, Any]
+) -> list[InvariantResult]:
+    results: list[InvariantResult] = []
+
+    def add(name: str, ok: bool, detail: str, severity: str = "error") -> None:
+        results.append(InvariantResult(name, bool(ok), severity, detail))
+
+    expect_found = bool(scenario.get("expect", {}).get("found", 0))
+    if expect_found:
+        add("detail.status_200", status_code == 200, f"status={status_code}")
+        add("detail.echoes_id", body.get("manager_id") == scenario["manager_id"], f"body={body}")
+        add("detail.has_name", bool(body.get("name")), f"name={body.get('name')!r}")
+        add(
+            "detail.required_fields_present",
+            all(
+                k in body
+                for k in ("manager_id", "name", "aliases", "jurisdictions", "tags", "quality_flags")
+            ),
+            f"keys={sorted(body)}",
+        )
+        add(
+            "detail.quality_flags_is_list",
+            isinstance(body.get("quality_flags"), list),
+            f"quality_flags={body.get('quality_flags')!r}",
+        )
+    else:
+        add("detail.status_404", status_code == 404, f"status={status_code}")
+        add("detail.has_error_detail", "detail" in body, f"body={body}")
+        add("detail.no_manager_id", "manager_id" not in body, f"body={body}")
+    return results
+
+
+def _check_stats(
+    scenario: dict[str, Any],
+    status_code: int,
+    body: dict[str, Any],
+    n_seeded: int,
+) -> list[InvariantResult]:
+    results: list[InvariantResult] = []
+
+    def add(name: str, ok: bool, detail: str, severity: str = "error") -> None:
+        results.append(InvariantResult(name, bool(ok), severity, detail))
+
+    add("stats.status_200", status_code == 200, f"status={status_code}")
+
+    total = body.get("total_managers")
+    by_jur = body.get("by_jurisdiction", {}) or {}
+    by_tag = body.get("by_tag", {}) or {}
+    with_cik = body.get("with_cik", 0)
+    with_lei = body.get("with_lei", 0)
+
+    add("stats.total_is_int", isinstance(total, int) and total >= 0, f"total={total}")
+    add("stats.total_equals_seeded", total == n_seeded, f"total={total} seeded={n_seeded}")
+
+    expect = scenario.get("expect", {})
+    if "total_managers" in expect:
+        add(
+            "stats.total_matches_expectation",
+            total == expect["total_managers"],
+            f"total={total} expected={expect['total_managers']}",
+        )
+
+    add(
+        "stats.with_cik_nonneg", isinstance(with_cik, int) and with_cik >= 0, f"with_cik={with_cik}"
+    )
+    add(
+        "stats.with_lei_nonneg", isinstance(with_lei, int) and with_lei >= 0, f"with_lei={with_lei}"
+    )
+    add("stats.with_cik_le_total", with_cik <= (total or 0), f"with_cik={with_cik} total={total}")
+    add("stats.with_lei_le_total", with_lei <= (total or 0), f"with_lei={with_lei} total={total}")
+
+    # Each breakdown sum is >= total only if every manager has exactly one
+    # key; managers may carry several tags/jurisdictions, so the sum is bounded
+    # below by 0 and each per-key count is in [1, total]. A manager appears in a
+    # jurisdiction bucket at most once, so no single count can exceed total.
+    for label, breakdown in (("jurisdiction", by_jur), ("tag", by_tag)):
+        for key, cnt in breakdown.items():
+            add(
+                f"stats.{label}_key_lowercased",
+                key == key.lower(),
+                f"key={key!r}",
+            )
+            add(
+                f"stats.{label}_count_in_range[{key}]",
+                isinstance(cnt, int) and 1 <= cnt <= (total or 0),
+                f"{key}={cnt} total={total}",
+            )
+    return results
+
+
+def check_scenario(scenario: dict[str, Any], db_path: Path) -> list[InvariantResult]:
+    """Run every invariant against one scenario's response."""
+    seed_rows = seed_rows_for(scenario["seed"])
+    payload, _metrics = adapter.run_scenario(scenario, seed_rows, db_path)
+    status_code = int(payload["status_code"])
+    body = payload["json"] if isinstance(payload["json"], dict) else {}
+    endpoint = scenario["endpoint"]
+
+    if endpoint == "list":
+        return _check_list(scenario, status_code, body)
+    if endpoint == "detail":
+        return _check_detail(scenario, status_code, body)
+    if endpoint == "stats":
+        return _check_stats(scenario, status_code, body, n_seeded=len(seed_rows))
+    raise ValueError(f"unknown endpoint {endpoint!r}")  # pragma: no cover - catalog typo guard

--- a/tests/baseline/test_coverage_manifest.py
+++ b/tests/baseline/test_coverage_manifest.py
@@ -1,0 +1,68 @@
+"""Coverage manifest -- which request knobs the scenarios exercise; emit a report.
+
+Uses the generic ``baseline_kit.CoverageManifest``. For the api-snapshot
+modality the "input parameter" space is the request surface of the /managers
+endpoints: the chosen ``endpoint`` plus the query/path knobs (``limit``,
+``offset``, ``jurisdiction``, ``tag``, ``manager_id``). A parameter is "touched"
+when at least one scenario sets it (or, for ``endpoint``, exercises that value).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from baseline_kit import CoverageManifest, load_catalog
+
+from .conftest import CATALOG_PATH, REPO_ROOT
+
+REPORT_PATH = REPO_ROOT / "docs" / "reports" / "baseline-coverage.md"
+
+# The full request-parameter space the /managers surface accepts.
+_ALL_PARAMS = {"endpoint", "limit", "offset", "jurisdiction", "tag", "manager_id"}
+
+
+def _touched_params(catalog) -> set[str]:
+    touched: set[str] = set()
+    for scenario in catalog["scenarios"]:
+        touched.add("endpoint")  # every scenario picks an endpoint
+        for key in scenario.get("params") or {}:
+            touched.add(key)
+        if "manager_id" in scenario:
+            touched.add("manager_id")
+    return touched
+
+
+def _build_manifest() -> CoverageManifest:
+    catalog = load_catalog(CATALOG_PATH)
+    return CoverageManifest(
+        all_keys=set(_ALL_PARAMS),
+        touched_keys=_touched_params(catalog),
+        priority_params=list(catalog.get("priority_params", [])),
+        title="Manager-Database baseline coverage manifest (api-snapshot)",
+    )
+
+
+def test_no_unknown_catalog_params():
+    m = _build_manifest()
+    assert not m.unknown_catalog_keys, (
+        "Scenarios reference request params outside the documented surface: "
+        f"{sorted(m.unknown_catalog_keys)}"
+    )
+
+
+def test_priority_params_covered():
+    m = _build_manifest()
+    assert not m.priority_gaps, "Priority params with no scenario: " + ", ".join(m.priority_gaps)
+
+
+def test_emit_coverage_report(tmp_path: Path):
+    m = _build_manifest()
+    report_path = (
+        REPORT_PATH
+        if os.environ.get("BASELINE_REFRESH_REPORT") == "1"
+        else tmp_path / "baseline-coverage.md"
+    )
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(m.to_markdown())
+    assert report_path.exists()

--- a/tests/baseline/test_directional.py
+++ b/tests/baseline/test_directional.py
@@ -1,0 +1,51 @@
+"""Directional ("metamorphic") checks on reduced response metrics.
+
+Each catalog ``directionals`` entry asserts a relationship the endpoint contract
+guarantees, e.g. a filter narrows the count; pagination caps the page but
+preserves the total; a richer seed raises the count / stats total. The metric is
+pulled from the adapter's flat reduction of each scenario's response.
+"""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import evaluate_direction
+
+from . import adapter
+from .conftest import scenarios_by_id, seed_rows_for
+
+_CATALOG_SCENARIOS = scenarios_by_id()
+
+
+def _metric(scenario_id: str, key: str, db_path) -> float:
+    scenario = _CATALOG_SCENARIOS[scenario_id]
+    _payload, metrics = adapter.run_scenario(scenario, seed_rows_for(scenario["seed"]), db_path)
+    return float(metrics[key])
+
+
+def _load_directionals():
+    from baseline_kit import load_catalog
+
+    from .conftest import CATALOG_PATH
+
+    return load_catalog(CATALOG_PATH).get("directionals", [])
+
+
+_DIRECTIONALS = _load_directionals()
+
+
+@pytest.mark.parametrize("scen", _DIRECTIONALS, ids=[s["id"] for s in _DIRECTIONALS])
+def test_directional(scen, record_property, db_path):
+    metric = scen["metric"]
+    variant = _metric(scen["scenario"], metric, db_path)
+    control = _metric(scen["control"], metric, db_path)
+    holds = evaluate_direction(scen["direction"], variant, control)
+    msg = (
+        f"{scen['id']}: {metric} scenario={variant:.6g} "
+        f"{scen['direction']} control={control:.6g} -> {holds}"
+    )
+    record_property("directional", msg)
+    if scen.get("enforce"):
+        assert holds, "Contract-violating direction -- " + msg
+    elif not holds:
+        pytest.skip("[report-only] " + msg)

--- a/tests/baseline/test_golden.py
+++ b/tests/baseline/test_golden.py
@@ -1,0 +1,38 @@
+"""Golden snapshots of each scenario's JSON response (api-snapshot modality).
+
+Each scenario's normalized ``{"status_code", "json"}`` payload is snapshotted as
+YAML via ``baseline_kit.check_snapshot`` (pytest-regressions' ``data_regression``
+fixture -- no numpy/pandas). Volatile fields are redacted with the ``exclude``
+path syntax so the snapshots are stable run-to-run:
+
+  * ``created_at`` / ``updated_at`` -- bare-key redaction drops these timestamps
+    wherever they appear (top-level detail body or nested list items).
+
+The seeded ids are deliberately NOT redacted: the seed pins explicit contiguous
+ids, so they are deterministic and part of what we want to pin (ordering,
+pagination boundaries). The DB is freshly recreated per scenario, so ids never
+drift.
+
+Re-bless an intended change with ``--force-regen``, then INSPECT the updated
+YAML under ``test_golden/`` before committing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import check_snapshot
+
+from . import adapter
+from .conftest import scenarios, seed_rows_for
+
+_SCENARIOS = scenarios()
+
+# Volatile fields redacted from every snapshot (bare-key => any depth).
+_EXCLUDE = ("created_at", "updated_at")
+
+
+@pytest.mark.parametrize("scenario", _SCENARIOS, ids=[s["id"] for s in _SCENARIOS])
+def test_response_snapshot(scenario, data_regression, db_path):
+    seed_rows = seed_rows_for(scenario["seed"])
+    payload, _metrics = adapter.run_scenario(scenario, seed_rows, db_path)
+    check_snapshot(data_regression, payload, exclude=_EXCLUDE, basename=scenario["id"])

--- a/tests/baseline/test_golden/detail_found.yml
+++ b/tests/baseline/test_golden/detail_found.yml
@@ -1,0 +1,16 @@
+json:
+  aliases:
+  - Pershing Square
+  cik: 0001336528
+  jurisdictions:
+  - us
+  - uk
+  lei: 5493006FHHFR8FMRY713
+  manager_id: 4
+  name: Pershing Square Capital Management
+  quality_flags: []
+  registry_ids: {}
+  tags:
+  - activist
+  - hedge-fund
+status_code: 200

--- a/tests/baseline/test_golden/detail_missing.yml
+++ b/tests/baseline/test_golden/detail_missing.yml
@@ -1,0 +1,3 @@
+json:
+  detail: Manager not found
+status_code: 404

--- a/tests/baseline/test_golden/list_all_base.yml
+++ b/tests/baseline/test_golden/list_all_base.yml
@@ -1,0 +1,73 @@
+json:
+  items:
+  - aliases:
+    - Elliott Management
+    cik: 0001791786
+    jurisdictions:
+    - us
+    lei: 549300U3N12T57QLOU60
+    manager_id: 1
+    name: Elliott Investment Management L.P.
+    quality_flags: []
+    registry_ids:
+      fca_frn: '122927'
+    tags:
+    - activist
+    - hedge-fund
+  - aliases:
+    - Bridgewater
+    cik: 0001350694
+    jurisdictions:
+    - us
+    lei: 5493001Z7HC8XOLIRT54
+    manager_id: 2
+    name: Bridgewater Associates
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - hedge-fund
+    - quant
+  - aliases: []
+    cik: '0001647251'
+    jurisdictions:
+    - uk
+    lei: null
+    manager_id: 3
+    name: TCI Fund Management
+    quality_flags: []
+    registry_ids:
+      fca_frn: '190271'
+    tags:
+    - activist
+  - aliases:
+    - Pershing Square
+    cik: 0001336528
+    jurisdictions:
+    - us
+    - uk
+    lei: 5493006FHHFR8FMRY713
+    manager_id: 4
+    name: Pershing Square Capital Management
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - activist
+    - hedge-fund
+  - aliases:
+    - RenTech
+    - Renaissance
+    cik: null
+    jurisdictions:
+    - us
+    lei: null
+    manager_id: 5
+    name: Renaissance Technologies
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - quant
+    - hedge-fund
+  limit: 25
+  offset: 0
+  total: 5
+status_code: 200

--- a/tests/baseline/test_golden/list_all_richer.yml
+++ b/tests/baseline/test_golden/list_all_richer.yml
@@ -1,0 +1,108 @@
+json:
+  items:
+  - aliases:
+    - Elliott Management
+    cik: 0001791786
+    jurisdictions:
+    - us
+    lei: 549300U3N12T57QLOU60
+    manager_id: 1
+    name: Elliott Investment Management L.P.
+    quality_flags: []
+    registry_ids:
+      fca_frn: '122927'
+    tags:
+    - activist
+    - hedge-fund
+  - aliases:
+    - Bridgewater
+    cik: 0001350694
+    jurisdictions:
+    - us
+    lei: 5493001Z7HC8XOLIRT54
+    manager_id: 2
+    name: Bridgewater Associates
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - hedge-fund
+    - quant
+  - aliases: []
+    cik: '0001647251'
+    jurisdictions:
+    - uk
+    lei: null
+    manager_id: 3
+    name: TCI Fund Management
+    quality_flags: []
+    registry_ids:
+      fca_frn: '190271'
+    tags:
+    - activist
+  - aliases:
+    - Pershing Square
+    cik: 0001336528
+    jurisdictions:
+    - us
+    - uk
+    lei: 5493006FHHFR8FMRY713
+    manager_id: 4
+    name: Pershing Square Capital Management
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - activist
+    - hedge-fund
+  - aliases:
+    - RenTech
+    - Renaissance
+    cik: null
+    jurisdictions:
+    - us
+    lei: null
+    manager_id: 5
+    name: Renaissance Technologies
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - quant
+    - hedge-fund
+  - aliases:
+    - Citadel
+    cik: '0001423053'
+    jurisdictions:
+    - us
+    lei: 549300V1ZTQHPDQEM927
+    manager_id: 6
+    name: Citadel Advisors
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - hedge-fund
+  - aliases:
+    - Two Sigma
+    cik: 0001179392
+    jurisdictions:
+    - us
+    lei: null
+    manager_id: 7
+    name: Two Sigma Investments
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - quant
+    - hedge-fund
+  - aliases: []
+    cik: 0001067983
+    jurisdictions:
+    - us
+    lei: 5493000C01ZX7D35SD85
+    manager_id: 8
+    name: Berkshire Hathaway
+    quality_flags: []
+    registry_ids: {}
+    tags: []
+  limit: 100
+  offset: 0
+  total: 8
+status_code: 200

--- a/tests/baseline/test_golden/list_filter_activist.yml
+++ b/tests/baseline/test_golden/list_filter_activist.yml
@@ -1,0 +1,46 @@
+json:
+  items:
+  - aliases:
+    - Elliott Management
+    cik: 0001791786
+    jurisdictions:
+    - us
+    lei: 549300U3N12T57QLOU60
+    manager_id: 1
+    name: Elliott Investment Management L.P.
+    quality_flags: []
+    registry_ids:
+      fca_frn: '122927'
+    tags:
+    - activist
+    - hedge-fund
+  - aliases: []
+    cik: '0001647251'
+    jurisdictions:
+    - uk
+    lei: null
+    manager_id: 3
+    name: TCI Fund Management
+    quality_flags: []
+    registry_ids:
+      fca_frn: '190271'
+    tags:
+    - activist
+  - aliases:
+    - Pershing Square
+    cik: 0001336528
+    jurisdictions:
+    - us
+    - uk
+    lei: 5493006FHHFR8FMRY713
+    manager_id: 4
+    name: Pershing Square Capital Management
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - activist
+    - hedge-fund
+  limit: 25
+  offset: 0
+  total: 3
+status_code: 200

--- a/tests/baseline/test_golden/list_filter_no_match.yml
+++ b/tests/baseline/test_golden/list_filter_no_match.yml
@@ -1,0 +1,6 @@
+json:
+  items: []
+  limit: 25
+  offset: 0
+  total: 0
+status_code: 200

--- a/tests/baseline/test_golden/list_filter_uk.yml
+++ b/tests/baseline/test_golden/list_filter_uk.yml
@@ -1,0 +1,32 @@
+json:
+  items:
+  - aliases: []
+    cik: '0001647251'
+    jurisdictions:
+    - uk
+    lei: null
+    manager_id: 3
+    name: TCI Fund Management
+    quality_flags: []
+    registry_ids:
+      fca_frn: '190271'
+    tags:
+    - activist
+  - aliases:
+    - Pershing Square
+    cik: 0001336528
+    jurisdictions:
+    - us
+    - uk
+    lei: 5493006FHHFR8FMRY713
+    manager_id: 4
+    name: Pershing Square Capital Management
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - activist
+    - hedge-fund
+  limit: 25
+  offset: 0
+  total: 2
+status_code: 200

--- a/tests/baseline/test_golden/list_filter_us.yml
+++ b/tests/baseline/test_golden/list_filter_us.yml
@@ -1,0 +1,61 @@
+json:
+  items:
+  - aliases:
+    - Elliott Management
+    cik: 0001791786
+    jurisdictions:
+    - us
+    lei: 549300U3N12T57QLOU60
+    manager_id: 1
+    name: Elliott Investment Management L.P.
+    quality_flags: []
+    registry_ids:
+      fca_frn: '122927'
+    tags:
+    - activist
+    - hedge-fund
+  - aliases:
+    - Bridgewater
+    cik: 0001350694
+    jurisdictions:
+    - us
+    lei: 5493001Z7HC8XOLIRT54
+    manager_id: 2
+    name: Bridgewater Associates
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - hedge-fund
+    - quant
+  - aliases:
+    - Pershing Square
+    cik: 0001336528
+    jurisdictions:
+    - us
+    - uk
+    lei: 5493006FHHFR8FMRY713
+    manager_id: 4
+    name: Pershing Square Capital Management
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - activist
+    - hedge-fund
+  - aliases:
+    - RenTech
+    - Renaissance
+    cik: null
+    jurisdictions:
+    - us
+    lei: null
+    manager_id: 5
+    name: Renaissance Technologies
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - quant
+    - hedge-fund
+  limit: 25
+  offset: 0
+  total: 4
+status_code: 200

--- a/tests/baseline/test_golden/list_filter_us_activist.yml
+++ b/tests/baseline/test_golden/list_filter_us_activist.yml
@@ -1,0 +1,34 @@
+json:
+  items:
+  - aliases:
+    - Elliott Management
+    cik: 0001791786
+    jurisdictions:
+    - us
+    lei: 549300U3N12T57QLOU60
+    manager_id: 1
+    name: Elliott Investment Management L.P.
+    quality_flags: []
+    registry_ids:
+      fca_frn: '122927'
+    tags:
+    - activist
+    - hedge-fund
+  - aliases:
+    - Pershing Square
+    cik: 0001336528
+    jurisdictions:
+    - us
+    - uk
+    lei: 5493006FHHFR8FMRY713
+    manager_id: 4
+    name: Pershing Square Capital Management
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - activist
+    - hedge-fund
+  limit: 25
+  offset: 0
+  total: 2
+status_code: 200

--- a/tests/baseline/test_golden/list_paginated.yml
+++ b/tests/baseline/test_golden/list_paginated.yml
@@ -1,0 +1,33 @@
+json:
+  items:
+  - aliases:
+    - Elliott Management
+    cik: 0001791786
+    jurisdictions:
+    - us
+    lei: 549300U3N12T57QLOU60
+    manager_id: 1
+    name: Elliott Investment Management L.P.
+    quality_flags: []
+    registry_ids:
+      fca_frn: '122927'
+    tags:
+    - activist
+    - hedge-fund
+  - aliases:
+    - Bridgewater
+    cik: 0001350694
+    jurisdictions:
+    - us
+    lei: 5493001Z7HC8XOLIRT54
+    manager_id: 2
+    name: Bridgewater Associates
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - hedge-fund
+    - quant
+  limit: 2
+  offset: 0
+  total: 5
+status_code: 200

--- a/tests/baseline/test_golden/list_paginated_offset.yml
+++ b/tests/baseline/test_golden/list_paginated_offset.yml
@@ -1,0 +1,20 @@
+json:
+  items:
+  - aliases:
+    - RenTech
+    - Renaissance
+    cik: null
+    jurisdictions:
+    - us
+    lei: null
+    manager_id: 5
+    name: Renaissance Technologies
+    quality_flags: []
+    registry_ids: {}
+    tags:
+    - quant
+    - hedge-fund
+  limit: 2
+  offset: 4
+  total: 5
+status_code: 200

--- a/tests/baseline/test_golden/stats_base.yml
+++ b/tests/baseline/test_golden/stats_base.yml
@@ -1,0 +1,12 @@
+json:
+  by_jurisdiction:
+    uk: 2
+    us: 4
+  by_tag:
+    activist: 3
+    hedge-fund: 4
+    quant: 2
+  total_managers: 5
+  with_cik: 4
+  with_lei: 3
+status_code: 200

--- a/tests/baseline/test_golden/stats_richer.yml
+++ b/tests/baseline/test_golden/stats_richer.yml
@@ -1,0 +1,12 @@
+json:
+  by_jurisdiction:
+    uk: 2
+    us: 7
+  by_tag:
+    activist: 3
+    hedge-fund: 6
+    quant: 3
+  total_managers: 8
+  with_cik: 7
+  with_lei: 5
+status_code: 200

--- a/tests/baseline/test_invariants.py
+++ b/tests/baseline/test_invariants.py
@@ -1,0 +1,19 @@
+"""Structural + economic invariants on every catalog scenario's response."""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import assert_invariants
+
+from . import invariants
+from .conftest import scenarios
+
+_SCENARIOS = scenarios()
+
+
+@pytest.mark.parametrize("scenario", _SCENARIOS, ids=[s["id"] for s in _SCENARIOS])
+def test_scenario_invariants(scenario, db_path):
+    assert_invariants(
+        invariants.check_scenario(scenario, db_path),
+        context=scenario["id"],
+    )

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -10,6 +10,11 @@ _OPERATORS = ("==", ">=", "<=", "~=", "!=", ">", "<", "===")
 
 def _split_spec(raw: str) -> str:
     entry = raw.strip().strip(",").strip('"')
+    # Direct references ("name @ git+https://...") declare the package name before
+    # the " @ "; there is no version operator to split on.
+    if " @ " in entry:
+        name, _ = entry.split(" @ ", 1)
+        return name.strip().split("[")[0]
     for operator in _OPERATORS:
         if operator in entry:
             name, _ = entry.split(operator, 1)
@@ -24,6 +29,12 @@ def _load_lock_versions(path: Path) -> dict[str, str]:
         if not stripped or stripped.startswith("#"):
             continue
         if stripped.startswith("--"):
+            continue
+        # Direct references in the lock ("name @ git+https://...") have no pinned
+        # "==" version; record them so the presence check still passes.
+        if " @ " in stripped:
+            name, _ = stripped.split(" @ ", 1)
+            versions[name.strip().lower()] = "<direct-reference>"
             continue
         if "==" not in stripped:
             continue
@@ -43,6 +54,18 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
     for group in project.get("optional-dependencies", {}).values():
         for entry in group:
             declared.add(_split_spec(entry).lower())
+
+    # Packages intentionally excluded from the lock via uv's no-emit-package
+    # (monorepo deps consumed from an unpinned @main git URL, e.g.
+    # app-baseline-kit) are not expected to be pinned in requirements.lock.
+    no_emit = {
+        _split_spec(name).lower()
+        for name in pyproject.get("tool", {})
+        .get("uv", {})
+        .get("pip", {})
+        .get("no-emit-package", [])
+    }
+    declared -= no_emit
 
     lock_versions = _load_lock_versions(Path("requirements.lock"))
 


### PR DESCRIPTION
## Summary

Adds the fleet's first **api-snapshot** baseline kit under `tests/baseline/`, built on the shared `baseline_kit` **v0.2.0** snapshot helper. The rest of the fleet baselines a *deterministic compute* (flat metrics dict golden-mastered with `check_metrics`); Manager-Database is a **FastAPI service**, so this kit drives the `/managers` HTTP endpoints through a Starlette `TestClient` against a **freshly seeded, deterministic in-process sqlite DB** and snapshots the JSON responses with `baseline_kit.check_snapshot` (`data_regression` / YAML — no numpy/pandas).

This kit is intended as the **reference implementation for the api-snapshot modality**.

## Endpoints covered

Mounted on a *minimal* managers-only FastAPI app (avoids `api.chat.app`'s boto3/langsmith/prometheus import chain):

- `GET /managers` — list + `limit`/`offset` paging + `jurisdiction`/`tag` filters
- `GET /managers/{id}` — detail (200 found / 404 missing)
- `GET /managers/stats` — universe aggregates

## Layers (37 tests: 13 golden + 13 invariant + 8 directional + 3 coverage)

- **Golden snapshots** of each scenario's `{status_code, json}` payload; `created_at`/`updated_at` redacted via the `exclude` bare-key syntax (and pinned in the seed); seeded ids kept (deterministic, fresh DB per scenario).
- **Invariants**: status codes; list `{items,total,limit,offset}` envelope; `count <= limit` and `<= total`; ids integer/unique/**sorted ascending** (stable ordering); names non-empty; `quality_flags` is a list; per-scenario seeded `count`/`total`; stats `total_managers == seeded row count`; `with_cik`/`with_lei <= total`; breakdown keys lowercased + counts in `[1,total]`; detail echoes id / 404 has `detail`.
- **Directional**: filter narrows count; combined filter narrows further; pagination caps the page but preserves `total`; richer seed raises count / `total_managers` / `with_cik`.
- **Coverage manifest** → `docs/reports/baseline-coverage.md` (6/6 request params, 100%).

## Dependency pattern: A (fleet default)

`app-baseline-kit @ git+...#subdirectory=...` (unpinned `@main`) in `pyproject` `[dev]` + `[tool.uv.pip] no-emit-package` excluding it from `requirements.lock`. CI installs `-r requirements.lock` **and** `-e .[app,dev]` in a single `uv pip install`, so a SHA-pinned lock URL would conflict on a cold resolve — `no-emit` removes that. `pytest-regressions>=2.8` declared explicitly (lock-presence). Rationale in `docs/baseline-kit-dependency.md`. Cold resolve verified clean (no "conflicting URLs"); `app-baseline-kit==0.2.0` with `check_snapshot` confirmed installed from `@main`.

## Local verification

- `PYTHONHASHSEED=0 pytest tests/baseline` → **37 passed**, deterministic across repeated runs.
- `tests/test_manager_universe_api.py` + `tests/baseline` together → **44 passed** (no regression).
- `tests/test_dependency_version_alignment.py` → pass; `scripts/sync_test_dependencies.py --verify` → clean.
- `ruff check` + `ruff format --check` + `black --check` (py312) → clean.

## Notes for review

- **Not marked ready** — for your review.
- One observation surfaced (not a bug): every manager payload includes a `quality_flags: []` field that is populated by the read path; the kit pins it and adds a `quality_flags is a list` invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)