### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -182,6 +182,19 @@ def _detect_local_project_modules() -> set[str]:
             elif item.suffix == ".py":
                 detected.add(item.stem)
 
+    tests_dir = Path("tests")
+    if tests_dir.is_dir():
+        for item in tests_dir.iterdir():
+            if item.name.startswith(".") or item.name == "__pycache__":
+                continue
+            if item.is_dir() and (item / "__init__.py").exists():
+                detected.add(item.name)
+            elif item.suffix == ".py":
+                if item.name == "conftest.py":
+                    detected.add("conftest")
+                elif not item.name.startswith("test_") and item.name != "__init__.py":
+                    detected.add(item.stem)
+
     return detected
 
 
@@ -281,7 +294,7 @@ def extract_imports_from_file(file_path: Path) -> set[str]:
             for alias in node.names:
                 module = alias.name.split(".")[0]
                 imports.add(module)
-        elif isinstance(node, ast.ImportFrom) and node.module:
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
             module = node.module.split(".")[0]
             imports.add(module)
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow

### Files Skipped
- .github/workflows/pr-00-gate.yml: Maintains a fully custom Gate workflow; never overwrite (replaces the hard-coded custom_gate_repos list in maint-68).
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `edca1176fcce7cbb661e8b639c6f891863d460af`
**Template hash:** `fac23e08582a`
**Sync branch:** `sync/workflows-fac23e08582a`
**Consumer repo:** `stranske/Manager-Database`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Manager-Database","source_repository":"stranske/Workflows","source_sha":"edca1176fcce7cbb661e8b639c6f891863d460af","template_hash":"fac23e08582a","sync_branch":"sync/workflows-fac23e08582a","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"26839060056","run_attempt":"1","changes_count":1} -->