### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -264,7 +264,7 @@ def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
     return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
 
 
-def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
+def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
     try:
         with config_file.open("rb") as fh:
             data = tomllib.load(fh)
@@ -272,13 +272,13 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
         return False
 
     if not isinstance(data, dict):
-        return False
+        return None
     tool = data.get("tool")
     if not isinstance(tool, dict):
-        return False
+        return None
     pytest_config = tool.get("pytest")
     if not isinstance(pytest_config, dict):
-        return False
+        return False if "pytest" in tool else None
     if _pythonpath_has_tests(pytest_config.get("pythonpath", [])):
         return True
     pytest_options = pytest_config.get("ini_options")
@@ -289,7 +289,7 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
 
 
 def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ...]) -> bool:
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     try:
         read_files = config.read(config_file, encoding="utf-8")
     except (configparser.Error, OSError, UnicodeDecodeError):
@@ -298,9 +298,13 @@ def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ..
         return False
 
     for section_name in section_names:
-        if config.has_option(section_name, "pythonpath") and _pythonpath_has_tests(
-            config.get(section_name, "pythonpath")
-        ):
+        if not config.has_option(section_name, "pythonpath"):
+            continue
+        try:
+            pythonpath = config.get(section_name, "pythonpath", raw=True)
+        except configparser.Error:
+            return False
+        if _pythonpath_has_tests(pythonpath):
             return True
 
     return False
@@ -319,7 +323,9 @@ def _tests_dir_on_pythonpath() -> bool:
 
     pyproject = _resolve_config_path(PYPROJECT_FILE)
     if pyproject.exists():
-        return _tests_dir_on_pyproject_pythonpath(pyproject)
+        pyproject_result = _tests_dir_on_pyproject_pythonpath(pyproject)
+        if pyproject_result is not None:
+            return pyproject_result
 
     for config_file, section_names in PYTEST_FALLBACK_INI_CONFIGS:
         resolved_config = _resolve_config_path(config_file)


### PR DESCRIPTION
## Sync Summary

### Files Updated
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow

### Files Skipped
- .github/workflows/pr-00-gate.yml: Maintains a fully custom Gate workflow; never overwrite (replaces the hard-coded custom_gate_repos list in maint-68).
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `2a89714b84903864def14a373de040147089c63d`
**Template hash:** `8338e66945ca`
**Sync branch:** `sync/workflows-8338e66945ca`
**Consumer repo:** `stranske/Manager-Database`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Manager-Database","source_repository":"stranske/Workflows","source_sha":"2a89714b84903864def14a373de040147089c63d","template_hash":"8338e66945ca","sync_branch":"sync/workflows-8338e66945ca","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"26860136598","run_attempt":"1","changes_count":1} -->