### PR TITLE
Align API rate-limit guideline scope

### DIFF
--- a/docs/api_design_guidelines.md
+++ b/docs/api_design_guidelines.md
@@ -8,6 +8,7 @@ specific endpoint documents a different requirement.
 
 ## Rate limiting
 
-All API endpoints are subject to rate limiting to ensure fair usage and system
-stability. For detailed information about rate limits, handling 429 responses,
-and best practices, see [API Rate Limiting](api_rate_limiting.md).
+Rate limiting applies to the chat write paths documented in
+[API Rate Limiting](api_rate_limiting.md). Other endpoints are currently
+unlimited unless they explicitly delegate to the chat rate limiter in
+`api/chat.py`.

--- a/tests/test_rate_limit_contract.py
+++ b/tests/test_rate_limit_contract.py
@@ -169,3 +169,14 @@ def test_rate_limit_document_matches_shipped_header_contract():
     assert "POST /api/chat/query" in doc
     assert "POST /api/chat/search" in doc
     assert "POST /api/chat/feedback" in doc
+
+
+def test_api_design_guidelines_do_not_claim_global_rate_limiting():
+    doc = (REPO_ROOT / "docs/api_design_guidelines.md").read_text(encoding="utf-8")
+    normalized_doc = doc.lower()
+
+    assert "all api endpoints are subject to rate limit" not in normalized_doc, (
+        "api_design_guidelines.md must delegate rate-limit scope to "
+        "api_rate_limiting.md instead of claiming all endpoints are limited."
+    )
+    assert "api_rate_limiting.md" in doc

--- a/tests/test_rate_limit_contract.py
+++ b/tests/test_rate_limit_contract.py
@@ -174,8 +174,16 @@ def test_rate_limit_document_matches_shipped_header_contract():
 def test_api_design_guidelines_do_not_claim_global_rate_limiting():
     doc = (REPO_ROOT / "docs/api_design_guidelines.md").read_text(encoding="utf-8")
     normalized_doc = doc.lower()
+    forbidden_global_claims = [
+        "all api endpoints are subject to rate limit",
+        "all api endpoints are rate limited",
+        "all endpoints are subject to rate limit",
+        "all endpoints are rate limited",
+        "every api endpoint is rate limited",
+        "every endpoint is rate limited",
+    ]
 
-    assert "all api endpoints are subject to rate limit" not in normalized_doc, (
+    assert not any(claim in normalized_doc for claim in forbidden_global_claims), (
         "api_design_guidelines.md must delegate rate-limit scope to "
         "api_rate_limiting.md instead of claiming all endpoints are limited."
     )

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,0 +1,14 @@
+## 2026-06-11T01:16Z - opener (codex) issue #1145
+
+- Repo: `stranske/Manager-Database`
+- Issue: `#1145` (`Align API design guidelines with the shipped chat-only rate limiter`)
+- PR: `#1146` (`Align API rate-limit guideline scope`)
+- Branch: `codex/issue-1145-rate-limit-guidelines`
+- State: ready-for-review PR opened; waiting for keepalive/Gate.
+- Changes: scoped `docs/api_design_guidelines.md` rate-limit language to the chat write paths documented in `api_rate_limiting.md`; added `test_api_design_guidelines_do_not_claim_global_rate_limiting`.
+- Validation:
+  - `pytest tests/test_rate_limit_contract.py::test_api_design_guidelines_do_not_claim_global_rate_limiting -q` passed.
+  - Deliberate break restored the old all-endpoints sentence; the new test failed with `AssertionError: api_design_guidelines.md must delegate rate-limit scope to api_rate_limiting.md instead of claiming all endpoints are limited.`
+  - Restored corrected docs and `pytest tests/test_rate_limit_contract.py -q` passed (14).
+  - `rg -i "all.*endpoint.*rate limit" docs/api_design_guidelines.md` returned no matches.
+  - `git diff --check` passed.


### PR DESCRIPTION
Closes #1145

## Summary
- scope `docs/api_design_guidelines.md` rate-limit guidance to the shipped chat write-path limiter
- add a regression assertion so the design guideline cannot silently return to an all-endpoints rate-limit claim
- record opener lane state in `workloop-state.md`

## Validation
- `pytest tests/test_rate_limit_contract.py::test_api_design_guidelines_do_not_claim_global_rate_limiting -q`
- deliberate break: temporarily restored the old all-endpoints sentence; the new test failed with `AssertionError: api_design_guidelines.md must delegate rate-limit scope to api_rate_limiting.md instead of claiming all endpoints are limited.`; restored corrected text
- `pytest tests/test_rate_limit_contract.py -q`
- `rg -i "all.*endpoint.*rate limit" docs/api_design_guidelines.md` returned no matches
- `git diff --check`
