### PR TITLE
Add Postgres alert integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -e ".[dev]"
       - name: Run Postgres chain integration tests
-        run: pytest tests/test_chain_postgres_integration.py -v
+        run: pytest tests/test_chain_postgres_integration.py tests/test_alert_postgres_integration.py -v
 
   golden:
     name: Golden offline gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           cache: pip
       - name: Install test dependencies
         run: python -m pip install -e ".[dev]"
-      - name: Run Postgres chain integration tests
+      - name: Run Postgres chain and alert integration tests
         run: pytest tests/test_chain_postgres_integration.py tests/test_alert_postgres_integration.py -v
 
   golden:

--- a/tests/test_alert_postgres_integration.py
+++ b/tests/test_alert_postgres_integration.py
@@ -192,16 +192,26 @@ def _fired_alert(pg_conn: PgAlertFixture) -> FiredAlert:
 
 
 def test_ensure_alert_tables_creates_postgres_tables(pg_conn: PgAlertFixture):
-    ensure_alert_tables(pg_conn.conn)
+    with pg_conn.conn.cursor() as cur:
+        cur.execute("SAVEPOINT alert_table_contract")
+        cur.execute("DROP TABLE IF EXISTS alert_history")
+        cur.execute("DROP TABLE IF EXISTS alert_rules")
 
-    rows = pg_conn.conn.execute("""
-        SELECT table_name
-          FROM information_schema.tables
-         WHERE table_schema = 'public'
-           AND table_name IN ('alert_rules', 'alert_history')
-        """).fetchall()
+    try:
+        ensure_alert_tables(pg_conn.conn)
 
-    assert {row[0] for row in rows} == {"alert_rules", "alert_history"}
+        rows = pg_conn.conn.execute("""
+            SELECT table_name
+              FROM information_schema.tables
+             WHERE table_schema = 'public'
+               AND table_name IN ('alert_rules', 'alert_history')
+            """).fetchall()
+
+        assert {row[0] for row in rows} == {"alert_rules", "alert_history"}
+    finally:
+        with pg_conn.conn.cursor() as cur:
+            cur.execute("ROLLBACK TO SAVEPOINT alert_table_contract")
+            cur.execute("RELEASE SAVEPOINT alert_table_contract")
 
 
 def test_insert_pending_and_record_delivery_postgres(pg_conn: PgAlertFixture):

--- a/tests/test_alert_postgres_integration.py
+++ b/tests/test_alert_postgres_integration.py
@@ -194,14 +194,12 @@ def _fired_alert(pg_conn: PgAlertFixture) -> FiredAlert:
 def test_ensure_alert_tables_creates_postgres_tables(pg_conn: PgAlertFixture):
     ensure_alert_tables(pg_conn.conn)
 
-    rows = pg_conn.conn.execute(
-        """
+    rows = pg_conn.conn.execute("""
         SELECT table_name
           FROM information_schema.tables
          WHERE table_schema = 'public'
            AND table_name IN ('alert_rules', 'alert_history')
-        """
-    ).fetchall()
+        """).fetchall()
 
     assert {row[0] for row in rows} == {"alert_rules", "alert_history"}
 

--- a/tests/test_alert_postgres_integration.py
+++ b/tests/test_alert_postgres_integration.py
@@ -1,0 +1,278 @@
+"""Postgres-backed integration tests for alert persistence and dispatch paths.
+
+Set ``MGRDB_PG_TEST_URL`` to run these against a live Postgres database:
+
+    MGRDB_PG_TEST_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+        pytest tests/test_alert_postgres_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from alerts.channels import DeliveryResult, NotificationChannel
+from alerts.db import (
+    ensure_alert_tables,
+    fetch_rule_by_id,
+    insert_pending_alert,
+    record_delivery_error,
+    record_delivery_success,
+    rule_from_row,
+)
+from alerts.integration import (
+    build_new_filing_event,
+    evaluate_and_record_new_filing_alerts,
+    fire_alerts_for_event,
+)
+from alerts.models import FiredAlert
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_SQL = ROOT / "schema.sql"
+
+
+class PgAlertFixture:
+    def __init__(self, conn: Any, *, manager_id: int, rule_id: int) -> None:
+        self.conn = conn
+        self.manager_id = manager_id
+        self.rule_id = rule_id
+
+
+class MockStreamlitChannel(NotificationChannel):
+    channel_name = "streamlit"
+
+    async def deliver(self, alert: FiredAlert) -> DeliveryResult:
+        return DeliveryResult(success=True, channel=self.channel_name, skipped=False)
+
+
+@pytest.fixture(scope="module")
+def psycopg_module():
+    return pytest.importorskip("psycopg")
+
+
+@pytest.fixture(scope="module")
+def pg_url() -> str:
+    url = os.environ.get("MGRDB_PG_TEST_URL")
+    if not url:
+        pytest.skip("MGRDB_PG_TEST_URL not set; skipping Postgres alert integration tests")
+    return url
+
+
+@pytest.fixture(scope="module")
+def pg_conn(pg_url: str, psycopg_module) -> Generator[PgAlertFixture, None, None]:
+    with psycopg_module.connect(pg_url, autocommit=False) as conn:
+        _reset_public_schema(conn)
+        _apply_schema_sql(conn)
+        fixture = _seed_alert_fixtures(conn)
+        yield fixture
+
+
+def _split_sql_statements(sql: str) -> list[str]:
+    stmts: list[str] = []
+    buf: list[str] = []
+    in_dollar_quote = False
+    dollar_tag = ""
+    i = 0
+    n = len(sql)
+
+    while i < n:
+        ch = sql[i]
+        if not in_dollar_quote:
+            if ch == "-" and i + 1 < n and sql[i + 1] == "-":
+                while i < n and sql[i] != "\n":
+                    i += 1
+                continue
+            if ch == "$":
+                j = i + 1
+                while j < n and sql[j] != "$":
+                    j += 1
+                if j < n:
+                    tag = sql[i : j + 1]
+                    in_dollar_quote = True
+                    dollar_tag = tag
+                    buf.append(tag)
+                    i = j + 1
+                    continue
+            if ch == ";":
+                buf.append(";")
+                stmt = "".join(buf).strip()
+                if stmt:
+                    stmts.append(stmt)
+                buf = []
+                i += 1
+                continue
+        else:
+            if sql[i : i + len(dollar_tag)] == dollar_tag:
+                buf.append(dollar_tag)
+                i += len(dollar_tag)
+                in_dollar_quote = False
+                dollar_tag = ""
+                continue
+
+        buf.append(ch)
+        i += 1
+
+    remaining = "".join(buf).strip()
+    if remaining:
+        stmts.append(remaining)
+    return stmts
+
+
+def _reset_public_schema(conn: Any) -> None:
+    with conn.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS public CASCADE")
+        cur.execute("CREATE SCHEMA public")
+        cur.execute("GRANT ALL ON SCHEMA public TO public")
+    conn.commit()
+
+
+def _apply_schema_sql(conn: Any) -> None:
+    for idx, stmt in enumerate(_split_sql_statements(SCHEMA_SQL.read_text()), 1):
+        try:
+            with conn.cursor() as cur:
+                cur.execute(stmt)
+        except Exception as exc:
+            conn.rollback()
+            preview = stmt if len(stmt) <= 400 else stmt[:400] + "..."
+            pytest.fail(
+                f"schema.sql failed at statement {idx}: {type(exc).__name__}: {exc}\n{preview}"
+            )
+    conn.commit()
+
+
+def _seed_alert_fixtures(conn: Any) -> PgAlertFixture:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO managers(name, cik) VALUES (%s, %s) RETURNING manager_id",
+            ("Elliott", "0001791786"),
+        )
+        manager_id = int(cur.fetchone()[0])
+
+    ensure_alert_tables(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO alert_rules(
+                name, event_type, condition_json, channels, enabled, manager_id, created_by
+            ) VALUES (%s, %s, %s::jsonb, %s, %s, %s, %s)
+            RETURNING rule_id
+            """,
+            (
+                "New Filing Rule",
+                "new_filing",
+                '{"any_new_filing":true}',
+                ["streamlit"],
+                True,
+                manager_id,
+                "pytest",
+            ),
+        )
+        rule_id = int(cur.fetchone()[0])
+    conn.commit()
+    return PgAlertFixture(conn=conn, manager_id=manager_id, rule_id=rule_id)
+
+
+def _fired_alert(pg_conn: PgAlertFixture) -> FiredAlert:
+    row = fetch_rule_by_id(pg_conn.conn, pg_conn.rule_id)
+    assert row is not None
+    return FiredAlert(
+        rule=rule_from_row(row),
+        event=build_new_filing_event(
+            filing_id=1,
+            manager_id=pg_conn.manager_id,
+            filing_type="13F-HR",
+            filed_date="2026-04-15",
+        ),
+        channels=["streamlit"],
+    )
+
+
+def test_ensure_alert_tables_creates_postgres_tables(pg_conn: PgAlertFixture):
+    ensure_alert_tables(pg_conn.conn)
+
+    rows = pg_conn.conn.execute(
+        """
+        SELECT table_name
+          FROM information_schema.tables
+         WHERE table_schema = 'public'
+           AND table_name IN ('alert_rules', 'alert_history')
+        """
+    ).fetchall()
+
+    assert {row[0] for row in rows} == {"alert_rules", "alert_history"}
+
+
+def test_insert_pending_and_record_delivery_postgres(pg_conn: PgAlertFixture):
+    alert_id = insert_pending_alert(pg_conn.conn, _fired_alert(pg_conn))
+
+    record_delivery_success(pg_conn.conn, alert_id, "streamlit")
+    record_delivery_error(pg_conn.conn, alert_id, "slack", "webhook unavailable")
+
+    row = pg_conn.conn.execute(
+        """
+        SELECT delivered_channels, delivery_errors
+          FROM alert_history
+         WHERE alert_id = %s
+        """,
+        (alert_id,),
+    ).fetchone()
+
+    assert row is not None
+    assert "streamlit" in row[0]
+    assert row[1]["slack"] == "webhook unavailable"
+
+
+def test_evaluate_and_record_new_filing_alerts_postgres(pg_conn: PgAlertFixture):
+    alert_ids = evaluate_and_record_new_filing_alerts(
+        pg_conn.conn,
+        filing_id=1,
+        manager_id=pg_conn.manager_id,
+        filing_type="13F-HR",
+        filed_date="2026-04-15",
+    )
+
+    assert alert_ids
+    row = pg_conn.conn.execute(
+        """
+        SELECT rule_id, event_type, payload_json
+          FROM alert_history
+         WHERE alert_id = %s
+        """,
+        (alert_ids[0],),
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == pg_conn.rule_id
+    assert row[1] == "new_filing"
+    assert row[2]["type"] == "13F-HR"
+
+
+@pytest.mark.asyncio
+async def test_fire_alerts_for_event_records_streamlit_channel(pg_conn: PgAlertFixture):
+    alert_ids = await fire_alerts_for_event(
+        pg_conn.conn,
+        build_new_filing_event(
+            filing_id=1,
+            manager_id=pg_conn.manager_id,
+            filing_type="13F-HR",
+            filed_date="2026-04-15",
+        ),
+        channels={"streamlit": MockStreamlitChannel()},
+    )
+
+    assert alert_ids
+    row = pg_conn.conn.execute(
+        """
+        SELECT delivered_channels
+          FROM alert_history
+         WHERE alert_id = %s
+        """,
+        (alert_ids[0],),
+    ).fetchone()
+
+    assert row is not None
+    assert "streamlit" in row[0]

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,18 @@
+## 2026-06-11T03:14Z - opener (codex) issue #1147
+
+- Repo: `stranske/Manager-Database`
+- Issue: `#1147` (`Add Postgres-backed integration test for alert dispatch path and wire to postgres-integration CI job`)
+- Branch: `codex/issue-1147-alert-postgres`
+- State: implementation in progress; new Postgres alert integration tests and CI collection update staged for PR.
+- Changes: added `tests/test_alert_postgres_integration.py` covering Postgres alert table DDL, pending alert insert, delivery success/error persistence, new-filing evaluation, and streamlit dispatch; added the new test file to the existing `postgres-integration` CI job.
+- Validation:
+  - `pytest tests/test_alert_integration.py -q` passed (5).
+  - `pytest tests/test_alert_postgres_integration.py -v` collected 4 tests and skipped locally because `MGRDB_PG_TEST_URL` was unset.
+  - `rg "test_alert_postgres_integration" .github/workflows/ci.yml` returned the updated CI command.
+  - `git diff --check` passed.
+  - `python -m ruff check tests/test_alert_postgres_integration.py` passed.
+  - Attempted live local Postgres validation with Docker, but the Docker daemon socket `/Users/teacher/.orbstack/run/docker.sock` was unavailable; CI's Postgres service is expected to run these tests non-skipped.
+
 ## 2026-06-11T01:16Z - opener (codex) issue #1145
 
 - Repo: `stranske/Manager-Database`

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -2,8 +2,9 @@
 
 - Repo: `stranske/Manager-Database`
 - Issue: `#1147` (`Add Postgres-backed integration test for alert dispatch path and wire to postgres-integration CI job`)
+- PR: `#1148` (`Add Postgres alert integration coverage`)
 - Branch: `codex/issue-1147-alert-postgres`
-- State: implementation in progress; new Postgres alert integration tests and CI collection update staged for PR.
+- State: ready-for-review PR opened; waiting for keepalive/Gate.
 - Changes: added `tests/test_alert_postgres_integration.py` covering Postgres alert table DDL, pending alert insert, delivery success/error persistence, new-filing evaluation, and streamlit dispatch; added the new test file to the existing `postgres-integration` CI job.
 - Validation:
   - `pytest tests/test_alert_integration.py -q` passed (5).
@@ -12,6 +13,7 @@
   - `git diff --check` passed.
   - `python -m ruff check tests/test_alert_postgres_integration.py` passed.
   - Attempted live local Postgres validation with Docker, but the Docker daemon socket `/Users/teacher/.orbstack/run/docker.sock` was unavailable; CI's Postgres service is expected to run these tests non-skipped.
+  - PR #1148 verified non-draft with labels `agent:codex`, `agents:keepalive`, `autofix`, `agent:retry`, `repo-review-approved`, and `priority:normal`; cap-health reported it as `draining` with active Gate evidence.
 
 ## 2026-06-11T01:16Z - opener (codex) issue #1145
 


### PR DESCRIPTION
Closes #1147

## Summary
- Add Postgres-backed alert integration tests for alert table DDL, pending alert inserts, delivery success/error persistence, new-filing evaluation, and streamlit dispatch.
- Wire the new alert Postgres test file into the existing `postgres-integration` CI job alongside the chain integration suite.
- Record the opener lane state for issue #1147 in `workloop-state.md`.

## Validation
- `pytest tests/test_alert_integration.py -q` passed (5).
- `pytest tests/test_alert_postgres_integration.py -v` collected 4 tests and skipped locally because `MGRDB_PG_TEST_URL` is unset.
- `python -m ruff check tests/test_alert_postgres_integration.py` passed.
- `rg "test_alert_postgres_integration" .github/workflows/ci.yml` returns the updated CI command.
- `git diff --check origin/main...HEAD` passed.

## Notes
- Attempted local live Postgres validation with Docker, but the Docker daemon socket `/Users/teacher/.orbstack/run/docker.sock` was unavailable. The CI `postgres-integration` job sets `MGRDB_PG_TEST_URL` and should run the new tests non-skipped against its Postgres service.
