### PR TITLE
Add database snapshot restore contract

### DIFF
--- a/.github/workflows/database-snapshot.yml
+++ b/.github/workflows/database-snapshot.yml
@@ -1,0 +1,31 @@
+name: Database Snapshot
+
+on:
+  schedule:
+    - cron: "15 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  postgres-snapshot:
+    runs-on: ubuntu-latest
+    env:
+      DB_SNAPSHOT_DATABASE_URL: ${{ secrets.DB_SNAPSHOT_DATABASE_URL }}
+      DB_SNAPSHOT_S3_URI: ${{ secrets.DB_SNAPSHOT_S3_URI }}
+      DB_SNAPSHOT_KMS_KEY_ID: ${{ secrets.DB_SNAPSHOT_KMS_KEY_ID }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install backup clients
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client awscli
+      - name: Validate backup contract without production credentials
+        env:
+          DB_SNAPSHOT_DATABASE_URL: postgresql://snapshot:snapshot@example.invalid:5432/manager
+          DB_SNAPSHOT_S3_URI: s3://manager-db-backups/dry-run
+        run: python scripts/db_snapshot_restore.py backup --dry-run
+      - name: Run encrypted Postgres snapshot
+        if: ${{ env.DB_SNAPSHOT_DATABASE_URL != '' && env.DB_SNAPSHOT_S3_URI != '' }}
+        run: python scripts/db_snapshot_restore.py backup

--- a/docs/deploy/INTERNAL_HOSTING.md
+++ b/docs/deploy/INTERNAL_HOSTING.md
@@ -123,3 +123,10 @@ With this setup, Postgres, MinIO, and the API stay **inside the org perimeter**.
 No proprietary data is sent to external SaaS or to an unauthorized LLM: chat is
 either disabled (`LLM_ZONE=disabled`) or bound only to an org-authorized,
 no-train endpoint.
+
+## Backup and restore
+
+Postgres deployments must also configure the nightly encrypted snapshot workflow
+described in `docs/runbooks/database-backup-restore.md`. Capture one successful
+snapshot workflow run and one restore dry-run before treating a hosted instance
+as recoverable.

--- a/docs/runbooks/database-backup-restore.md
+++ b/docs/runbooks/database-backup-restore.md
@@ -1,0 +1,67 @@
+# Database Backup And Restore Runbook
+
+Manager-Database stores the production data plane in Postgres. Nightly snapshots
+must be written to an encrypted object-store bucket and restore steps must be
+validated before any deployment is considered recoverable.
+
+## Snapshot Contract
+
+- Cadence: nightly at 05:15 UTC via `.github/workflows/database-snapshot.yml`.
+- Source: `DB_SNAPSHOT_DATABASE_URL`, falling back to `DB_URL` for local runs.
+- Destination: `DB_SNAPSHOT_S3_URI`, for example `s3://manager-db-backups/prod`.
+- Encryption: `aws s3 cp` uses `--sse aws:kms` when
+  `DB_SNAPSHOT_KMS_KEY_ID` is set, otherwise `--sse AES256`.
+- Format: `pg_dump --format=custom --no-owner --no-privileges`.
+- Retention target: 35 days unless the bucket lifecycle policy is stricter.
+
+The workflow always runs a dry-run contract check without credentials. It only
+executes the live backup step when both `DB_SNAPSHOT_DATABASE_URL` and
+`DB_SNAPSHOT_S3_URI` are configured as repository secrets.
+
+## Operator Backup Command
+
+```bash
+export DB_SNAPSHOT_DATABASE_URL="postgresql://..."
+export DB_SNAPSHOT_S3_URI="s3://manager-db-backups/prod"
+export DB_SNAPSHOT_KMS_KEY_ID="alias/manager-db-backups"  # optional
+
+python scripts/db_snapshot_restore.py backup --dry-run
+python scripts/db_snapshot_restore.py backup
+```
+
+The dry run prints a masked JSON plan and does not call `pg_dump` or `aws`.
+
+## Restore Drill
+
+Restore into a disposable database first. Do not point the restore command at
+production until the owner has confirmed the target database may be replaced.
+
+```bash
+export DB_RESTORE_DATABASE_URL="postgresql://..."
+
+python scripts/db_snapshot_restore.py restore \
+  --snapshot-uri "s3://manager-db-backups/prod/manager-database-20260611T051500Z.dump" \
+  --dry-run
+
+python scripts/db_snapshot_restore.py restore \
+  --snapshot-uri "s3://manager-db-backups/prod/manager-database-20260611T051500Z.dump"
+```
+
+The restore command downloads the snapshot and runs
+`pg_restore --clean --if-exists --no-owner` against the target database.
+
+## Required Secrets
+
+| Secret | Purpose |
+| --- | --- |
+| `DB_SNAPSHOT_DATABASE_URL` | Source Postgres database for nightly snapshots. |
+| `DB_SNAPSHOT_S3_URI` | Encrypted object-store destination prefix. |
+| `DB_SNAPSHOT_KMS_KEY_ID` | Optional KMS key or alias for bucket encryption. |
+| AWS credentials | Standard GitHub Actions AWS environment or OIDC role. |
+
+## Recovery Evidence
+
+For each production deployment, keep the latest successful workflow run and one
+restore dry-run output in the deployment notes. A quarterly restore drill should
+restore the newest snapshot into a disposable database and run the Postgres
+schema idempotence verifier plus the `/health/detailed` smoke.

--- a/scripts/db_snapshot_restore.py
+++ b/scripts/db_snapshot_restore.py
@@ -40,10 +40,14 @@ def mask_database_url(database_url: str) -> str:
         return database_url
 
     _, host = parsed.netloc.rsplit("@", 1)
-    return urlunsplit((parsed.scheme, f"***:***@{host}", parsed.path, parsed.query, parsed.fragment))
+    return urlunsplit(
+        (parsed.scheme, f"***:***@{host}", parsed.path, parsed.query, parsed.fragment)
+    )
 
 
-def snapshot_uri(bucket_uri: str, *, now: dt.datetime | None = None, prefix: str = DEFAULT_PREFIX) -> str:
+def snapshot_uri(
+    bucket_uri: str, *, now: dt.datetime | None = None, prefix: str = DEFAULT_PREFIX
+) -> str:
     timestamp = (now or _utc_now()).strftime("%Y%m%dT%H%M%SZ")
     return f"{bucket_uri.rstrip('/')}/{prefix}-{timestamp}.dump"
 
@@ -136,7 +140,9 @@ def _run_backup(database_url: str, bucket_uri: str, kms_key_id: str | None) -> N
 def _run_restore(database_url: str, snapshot: str) -> None:
     with tempfile.TemporaryDirectory(prefix="mgrdb-restore-") as tmpdir:
         snapshot_path = Path(tmpdir) / Path(snapshot).name
-        subprocess.run(["aws", "s3", "cp", snapshot, str(snapshot_path), "--only-show-errors"], check=True)
+        subprocess.run(
+            ["aws", "s3", "cp", snapshot, str(snapshot_path), "--only-show-errors"], check=True
+        )
         subprocess.run(
             [
                 "pg_restore",
@@ -163,14 +169,20 @@ def main(argv: list[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     backup = subparsers.add_parser("backup", help="Create a Postgres snapshot and upload it to S3")
-    backup.add_argument("--dry-run", action="store_true", help="Print the backup plan without executing it")
+    backup.add_argument(
+        "--dry-run", action="store_true", help="Print the backup plan without executing it"
+    )
     backup.add_argument("--database-url-env", default="DB_SNAPSHOT_DATABASE_URL")
     backup.add_argument("--bucket-uri", default=os.getenv("DB_SNAPSHOT_S3_URI"))
     backup.add_argument("--retention-days", type=int, default=DEFAULT_RETENTION_DAYS)
     backup.add_argument("--kms-key-id", default=os.getenv("DB_SNAPSHOT_KMS_KEY_ID"))
 
-    restore = subparsers.add_parser("restore", help="Restore a Postgres database from an S3 snapshot")
-    restore.add_argument("--dry-run", action="store_true", help="Print the restore plan without executing it")
+    restore = subparsers.add_parser(
+        "restore", help="Restore a Postgres database from an S3 snapshot"
+    )
+    restore.add_argument(
+        "--dry-run", action="store_true", help="Print the restore plan without executing it"
+    )
     restore.add_argument("--database-url-env", default="DB_RESTORE_DATABASE_URL")
     restore.add_argument("--snapshot-uri", required=True)
 

--- a/scripts/db_snapshot_restore.py
+++ b/scripts/db_snapshot_restore.py
@@ -1,0 +1,205 @@
+"""Postgres snapshot and restore helper for Manager-Database deployments.
+
+The default dry-run mode is intentionally credential-free so CI can validate the
+backup contract without touching production databases or object storage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+DEFAULT_PREFIX = "manager-database"
+DEFAULT_RETENTION_DAYS = 35
+
+
+@dataclass(frozen=True)
+class BackupPlan:
+    action: str
+    database_url: str
+    snapshot_uri: str
+    retention_days: int
+    encrypted: bool
+    commands: list[list[str]]
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0)
+
+
+def mask_database_url(database_url: str) -> str:
+    parsed = urlsplit(database_url)
+    if "@" not in parsed.netloc:
+        return database_url
+
+    _, host = parsed.netloc.rsplit("@", 1)
+    return urlunsplit((parsed.scheme, f"***:***@{host}", parsed.path, parsed.query, parsed.fragment))
+
+
+def snapshot_uri(bucket_uri: str, *, now: dt.datetime | None = None, prefix: str = DEFAULT_PREFIX) -> str:
+    timestamp = (now or _utc_now()).strftime("%Y%m%dT%H%M%SZ")
+    return f"{bucket_uri.rstrip('/')}/{prefix}-{timestamp}.dump"
+
+
+def build_backup_plan(
+    *,
+    database_url: str,
+    bucket_uri: str,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+    kms_key_id: str | None = None,
+    now: dt.datetime | None = None,
+) -> BackupPlan:
+    uri = snapshot_uri(bucket_uri, now=now)
+    pg_dump = [
+        "pg_dump",
+        "--format=custom",
+        "--no-owner",
+        "--no-privileges",
+        "--dbname",
+        mask_database_url(database_url),
+    ]
+    s3_cp = ["aws", "s3", "cp", "<local-snapshot>", uri, "--only-show-errors"]
+    if kms_key_id:
+        s3_cp.extend(["--sse", "aws:kms", "--sse-kms-key-id", "<kms-key-id>"])
+    else:
+        s3_cp.extend(["--sse", "AES256"])
+
+    return BackupPlan(
+        action="backup",
+        database_url=mask_database_url(database_url),
+        snapshot_uri=uri,
+        retention_days=retention_days,
+        encrypted=True,
+        commands=[pg_dump, s3_cp],
+    )
+
+
+def build_restore_plan(*, database_url: str, snapshot: str) -> BackupPlan:
+    return BackupPlan(
+        action="restore",
+        database_url=mask_database_url(database_url),
+        snapshot_uri=snapshot,
+        retention_days=0,
+        encrypted=True,
+        commands=[
+            ["aws", "s3", "cp", snapshot, "<local-snapshot>", "--only-show-errors"],
+            [
+                "pg_restore",
+                "--clean",
+                "--if-exists",
+                "--no-owner",
+                "--dbname",
+                mask_database_url(database_url),
+                "<local-snapshot>",
+            ],
+        ],
+    )
+
+
+def _print_plan(plan: BackupPlan) -> None:
+    print(json.dumps(asdict(plan), indent=2, sort_keys=True))
+
+
+def _run_backup(database_url: str, bucket_uri: str, kms_key_id: str | None) -> None:
+    destination = snapshot_uri(bucket_uri)
+    with tempfile.TemporaryDirectory(prefix="mgrdb-snapshot-") as tmpdir:
+        snapshot_path = Path(tmpdir) / Path(destination).name
+        subprocess.run(
+            [
+                "pg_dump",
+                "--format=custom",
+                "--no-owner",
+                "--no-privileges",
+                "--file",
+                str(snapshot_path),
+                "--dbname",
+                database_url,
+            ],
+            check=True,
+        )
+        cmd = ["aws", "s3", "cp", str(snapshot_path), destination, "--only-show-errors"]
+        if kms_key_id:
+            cmd.extend(["--sse", "aws:kms", "--sse-kms-key-id", kms_key_id])
+        else:
+            cmd.extend(["--sse", "AES256"])
+        subprocess.run(cmd, check=True)
+    print(destination)
+
+
+def _run_restore(database_url: str, snapshot: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="mgrdb-restore-") as tmpdir:
+        snapshot_path = Path(tmpdir) / Path(snapshot).name
+        subprocess.run(["aws", "s3", "cp", snapshot, str(snapshot_path), "--only-show-errors"], check=True)
+        subprocess.run(
+            [
+                "pg_restore",
+                "--clean",
+                "--if-exists",
+                "--no-owner",
+                "--dbname",
+                database_url,
+                str(snapshot_path),
+            ],
+            check=True,
+        )
+
+
+def _database_url(env_name: str) -> str:
+    value = os.getenv(env_name) or os.getenv("DB_URL")
+    if not value:
+        raise SystemExit(f"{env_name} or DB_URL is required")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    backup = subparsers.add_parser("backup", help="Create a Postgres snapshot and upload it to S3")
+    backup.add_argument("--dry-run", action="store_true", help="Print the backup plan without executing it")
+    backup.add_argument("--database-url-env", default="DB_SNAPSHOT_DATABASE_URL")
+    backup.add_argument("--bucket-uri", default=os.getenv("DB_SNAPSHOT_S3_URI"))
+    backup.add_argument("--retention-days", type=int, default=DEFAULT_RETENTION_DAYS)
+    backup.add_argument("--kms-key-id", default=os.getenv("DB_SNAPSHOT_KMS_KEY_ID"))
+
+    restore = subparsers.add_parser("restore", help="Restore a Postgres database from an S3 snapshot")
+    restore.add_argument("--dry-run", action="store_true", help="Print the restore plan without executing it")
+    restore.add_argument("--database-url-env", default="DB_RESTORE_DATABASE_URL")
+    restore.add_argument("--snapshot-uri", required=True)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "backup":
+        if not args.bucket_uri:
+            raise SystemExit("DB_SNAPSHOT_S3_URI or --bucket-uri is required")
+        database_url = _database_url(args.database_url_env)
+        plan = build_backup_plan(
+            database_url=database_url,
+            bucket_uri=args.bucket_uri,
+            retention_days=args.retention_days,
+            kms_key_id=args.kms_key_id,
+        )
+        if args.dry_run:
+            _print_plan(plan)
+            return 0
+        _run_backup(database_url, args.bucket_uri, args.kms_key_id)
+        return 0
+
+    database_url = _database_url(args.database_url_env)
+    plan = build_restore_plan(database_url=database_url, snapshot=args.snapshot_uri)
+    if args.dry_run:
+        _print_plan(plan)
+        return 0
+    _run_restore(database_url, args.snapshot_uri)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_db_snapshot_restore.py
+++ b/tests/test_db_snapshot_restore.py
@@ -1,0 +1,93 @@
+import datetime as dt
+import json
+import subprocess
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from scripts import db_snapshot_restore
+
+
+def test_backup_plan_masks_credentials_and_uses_encrypted_snapshot():
+    plan = db_snapshot_restore.build_backup_plan(
+        database_url="postgresql://manager:secret@db.internal:5432/manager",
+        bucket_uri="s3://manager-db-backups/prod",
+        kms_key_id="alias/manager-db",
+        now=dt.datetime(2026, 6, 11, 5, 15, tzinfo=dt.UTC),
+    )
+
+    assert plan.snapshot_uri == "s3://manager-db-backups/prod/manager-database-20260611T051500Z.dump"
+    assert plan.database_url == "postgresql://***:***@db.internal:5432/manager"
+    assert plan.encrypted is True
+    assert "--format=custom" in plan.commands[0]
+    assert "--sse" in plan.commands[1]
+    assert "aws:kms" in plan.commands[1]
+    assert "secret" not in json.dumps(plan.commands)
+
+
+def test_backup_dry_run_does_not_execute_clients(monkeypatch, capsys):
+    calls: list[list[str]] = []
+    monkeypatch.setenv("DB_SNAPSHOT_DATABASE_URL", "postgresql://user:pw@db:5432/manager")
+    monkeypatch.setenv("DB_SNAPSHOT_S3_URI", "s3://manager-db-backups/prod")
+    monkeypatch.setattr(subprocess, "run", lambda command, **_: calls.append(command))
+
+    assert db_snapshot_restore.main(["backup", "--dry-run"]) == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["action"] == "backup"
+    assert output["database_url"] == "postgresql://***:***@db:5432/manager"
+    assert output["snapshot_uri"].startswith("s3://manager-db-backups/prod/manager-database-")
+    assert calls == []
+
+
+def test_restore_dry_run_plans_pg_restore_without_clients(monkeypatch, capsys):
+    calls: list[list[str]] = []
+    monkeypatch.setenv("DB_RESTORE_DATABASE_URL", "postgresql://restore:pw@db:5432/restore")
+    monkeypatch.setattr(subprocess, "run", lambda command, **_: calls.append(command))
+
+    assert (
+        db_snapshot_restore.main(
+            [
+                "restore",
+                "--snapshot-uri",
+                "s3://manager-db-backups/prod/manager-database-20260611T051500Z.dump",
+                "--dry-run",
+            ]
+        )
+        == 0
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["action"] == "restore"
+    assert output["commands"][1][0] == "pg_restore"
+    assert "--clean" in output["commands"][1]
+    assert calls == []
+
+
+def test_backup_requires_bucket_uri(monkeypatch):
+    monkeypatch.setenv("DB_SNAPSHOT_DATABASE_URL", "postgresql://user:pw@db:5432/manager")
+    monkeypatch.delenv("DB_SNAPSHOT_S3_URI", raising=False)
+
+    with pytest.raises(SystemExit, match="DB_SNAPSHOT_S3_URI"):
+        db_snapshot_restore.main(["backup", "--dry-run"])
+
+
+def test_database_snapshot_workflow_runs_dry_run_and_conditional_live_backup():
+    workflow = yaml.safe_load(open(".github/workflows/database-snapshot.yml", encoding="utf-8"))
+    triggers = workflow[True]
+    job = workflow["jobs"]["postgres-snapshot"]
+    steps = job["steps"]
+
+    assert triggers["schedule"] == [{"cron": "15 5 * * *"}]
+    assert triggers["workflow_dispatch"] is None
+    assert job["env"]["DB_SNAPSHOT_DATABASE_URL"] == "${{ secrets.DB_SNAPSHOT_DATABASE_URL }}"
+    assert any(
+        step.get("run") == "python scripts/db_snapshot_restore.py backup --dry-run"
+        for step in steps
+    )
+
+    live_step = next(
+        step for step in steps if step.get("name") == "Run encrypted Postgres snapshot"
+    )
+    assert "DB_SNAPSHOT_DATABASE_URL" in live_step["if"]
+    assert live_step["run"] == "python scripts/db_snapshot_restore.py backup"

--- a/tests/test_db_snapshot_restore.py
+++ b/tests/test_db_snapshot_restore.py
@@ -16,7 +16,9 @@ def test_backup_plan_masks_credentials_and_uses_encrypted_snapshot():
         now=dt.datetime(2026, 6, 11, 5, 15, tzinfo=dt.UTC),
     )
 
-    assert plan.snapshot_uri == "s3://manager-db-backups/prod/manager-database-20260611T051500Z.dump"
+    assert (
+        plan.snapshot_uri == "s3://manager-db-backups/prod/manager-database-20260611T051500Z.dump"
+    )
     assert plan.database_url == "postgresql://***:***@db.internal:5432/manager"
     assert plan.encrypted is True
     assert "--format=custom" in plan.commands[0]

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,17 @@
+## 2026-06-11T05:02Z - opener (codex) issue #1150
+
+- Repo: `stranske/Manager-Database`
+- Issue: `#1150` (`Add nightly database snapshot and restore-provisioning contract`)
+- Branch: `codex/issue-1150-db-snapshot-restore`
+- Worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/manager-db-1150-db-snapshot-restore`
+- State: implemented backup/restore script, scheduled workflow, runbook, internal hosting cross-link, and dry-run tests.
+- Validation:
+  - `python -m pytest tests/test_db_snapshot_restore.py -q` passed (5; existing FastAPI/LangSmith deprecation warnings only).
+  - Deliberate-break gate: temporarily removed the workflow `backup --dry-run` command and `test_database_snapshot_workflow_runs_dry_run_and_conditional_live_backup` failed on the missing dry-run assertion; restored the command.
+  - `python -m ruff check scripts/db_snapshot_restore.py tests/test_db_snapshot_restore.py` passed.
+  - `git diff --check` passed.
+  - `DB_SNAPSHOT_DATABASE_URL=postgresql://user:pw@db:5432/manager DB_SNAPSHOT_S3_URI=s3://manager-db-backups/prod python scripts/db_snapshot_restore.py backup --dry-run` printed a masked plan with encrypted S3 upload.
+
 ## 2026-06-11T03:14Z - opener (codex) issue #1147
 
 - Repo: `stranske/Manager-Database`


### PR DESCRIPTION
Closes #1150

## Summary
- add `scripts/db_snapshot_restore.py` with backup and restore dry-run planning plus live `pg_dump`/`pg_restore` execution paths
- add a scheduled/manual Database Snapshot workflow that validates the dry-run contract and runs encrypted S3 snapshots when secrets exist
- document backup/restore operations in `docs/runbooks/database-backup-restore.md` and link it from internal hosting guidance

## Validation
- `python -m pytest tests/test_db_snapshot_restore.py -q`
- deliberate-break gate: temporarily removed the workflow `backup --dry-run` command and confirmed `test_database_snapshot_workflow_runs_dry_run_and_conditional_live_backup` failed on the missing dry-run assertion; restored the command
- `python -m ruff check scripts/db_snapshot_restore.py tests/test_db_snapshot_restore.py`
- `git diff --check origin/main...HEAD`
- `DB_SNAPSHOT_DATABASE_URL=postgresql://user:pw@db:5432/manager DB_SNAPSHOT_S3_URI=s3://manager-db-backups/prod python scripts/db_snapshot_restore.py backup --dry-run`
