### PR TITLE
Add parser snapshot regression coverage

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,3 +20,5 @@ jobs:
         run: docker compose up -d
       - name: Run nightly tests
         run: pytest -m nightly -q
+      - name: Run parser snapshot regression tests
+        run: pytest -m nightly tests/test_parser_snapshot_regression.py -q

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Start services
         run: docker compose up -d
       - name: Run nightly tests
-        run: pytest -m nightly -q
+        run: pytest -m nightly -q --ignore=tests/test_parser_snapshot_regression.py
       - name: Run parser snapshot regression tests
         run: pytest -m nightly tests/test_parser_snapshot_regression.py -q

--- a/docs/runbooks/parser-regression-snapshots.md
+++ b/docs/runbooks/parser-regression-snapshots.md
@@ -1,0 +1,30 @@
+# Parser Regression Snapshots
+
+Manager-Database keeps retained filing snapshots under
+`tests/fixtures/filing_snapshots/` so parser changes can be checked without
+live EDGAR, Companies House, SEDAR, or other network calls.
+
+## Current Coverage
+
+- `tests/fixtures/filing_snapshots/edgar_13f_prior_snapshot.xml` is a redacted
+  EDGAR 13F XML snapshot used by
+  `tests/test_parser_snapshot_regression.py`.
+- `.github/workflows/nightly.yml` runs the parser snapshot regression test path
+  explicitly in the nightly lane.
+
+## Adding Snapshots
+
+1. Save snapshots in `tests/fixtures/filing_snapshots/` with a source and form
+   type in the filename, for example `edgar_13f_<case>.xml`.
+2. Keep the fixture small and deterministic. Include only the fields needed to
+   prove the parser contract.
+3. Redact manager names, issuer names, account identifiers, URLs, signatures,
+   emails, phone numbers, and any non-public notes before committing.
+4. Add or extend a parser regression test that reads the fixture from disk and
+   asserts the parsed structured rows.
+5. Mark the regression with `@pytest.mark.nightly` when it should run in the
+   nightly lane.
+
+The parser snapshot tests must not perform live network requests. Network-backed
+adapter coverage belongs in separate integration tests with explicit credentials
+or service fixtures.

--- a/tests/fixtures/filing_snapshots/edgar_13f_prior_snapshot.xml
+++ b/tests/fixtures/filing_snapshots/edgar_13f_prior_snapshot.xml
@@ -1,0 +1,32 @@
+<edgarSubmission>
+  <formData>
+    <coverPage>
+      <reportCalendarOrQuarter>2024-03-31</reportCalendarOrQuarter>
+      <filingManager>
+        <name>Example Investment Manager LP</name>
+      </filingManager>
+    </coverPage>
+    <informationTable>
+      <infoTable>
+        <nameOfIssuer>Example Corp</nameOfIssuer>
+        <titleOfClass>COM</titleOfClass>
+        <cusip>123456789</cusip>
+        <value>1000</value>
+        <shrsOrPrnAmt>
+          <sshPrnamt>100</sshPrnamt>
+          <sshPrnamtType>SH</sshPrnamtType>
+        </shrsOrPrnAmt>
+      </infoTable>
+      <infoTable>
+        <nameOfIssuer>Sample Holdings Inc</nameOfIssuer>
+        <titleOfClass>COM</titleOfClass>
+        <cusip>987654321</cusip>
+        <value>2500</value>
+        <shrsOrPrnAmt>
+          <sshPrnamt>45</sshPrnamt>
+          <sshPrnamtType>SH</sshPrnamtType>
+        </shrsOrPrnAmt>
+      </infoTable>
+    </informationTable>
+  </formData>
+</edgarSubmission>

--- a/tests/test_parser_snapshot_regression.py
+++ b/tests/test_parser_snapshot_regression.py
@@ -1,0 +1,30 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from adapters import edgar
+
+SNAPSHOT_DIR = Path(__file__).parent / "fixtures" / "filing_snapshots"
+
+
+@pytest.mark.nightly
+def test_edgar_parser_retained_prior_snapshot_fixture():
+    raw = (SNAPSHOT_DIR / "edgar_13f_prior_snapshot.xml").read_text()
+
+    rows = asyncio.run(edgar.parse(raw))
+
+    assert rows == [
+        {
+            "nameOfIssuer": "Example Corp",
+            "cusip": "123456789",
+            "value": 1000,
+            "sshPrnamt": 100,
+        },
+        {
+            "nameOfIssuer": "Sample Holdings Inc",
+            "cusip": "987654321",
+            "value": 2500,
+            "sshPrnamt": 45,
+        },
+    ]


### PR DESCRIPTION
Closes #1151

## Summary
- add a retained EDGAR 13F prior-snapshot fixture under tests/fixtures/filing_snapshots
- add a nightly-marked parser regression test that parses the retained fixture without network access
- wire the nightly workflow to explicitly collect the parser snapshot regression path and document fixture update/redaction steps

## Validation
- python -m pytest -m nightly tests/test_parser_snapshot_regression.py -q
- python -m ruff check tests/test_parser_snapshot_regression.py
- git diff --check origin/main...HEAD