### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.14
+RUFF_VERSION=0.15.17
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0
-PYTEST_VERSION=9.0.3
+PYTEST_VERSION=9.1.0
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.14.0
+COVERAGE_VERSION=7.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,11 @@ mgrdb-app = "ui.launch:main"
 [project.optional-dependencies]
 app = []
 dev = [
-    "pytest==9.0.3",
+    "pytest>=9.1.0",
     "pytest-asyncio",
     "pytest-cov==7.1.0",
     "black>=26.5.1",
-    "ruff>=0.15.14",
+    "ruff>=0.15.17",
     "pre-commit",
     "mypy>=2.1.0",
     "langchain>=1.2,<2.0",
@@ -52,7 +52,7 @@ dev = [
     "langchain-anthropic>=0.3,<2.0",
     "langsmith>=0.7.30,<1.0",
     "types-PyYAML",
-    "coverage>=7.14.0",
+    "coverage>=7.14.1",
     "referencing",
     "PyYAML",
     "fakeredis",

--- a/requirements.lock
+++ b/requirements.lock
@@ -94,7 +94,7 @@ colorama==0.4.6
     #   tqdm
 coolname==2.2.0
     # via prefect
-coverage==7.14.0
+coverage==7.14.1
     # via
     #   manager-database (pyproject.toml)
     #   pytest-cov
@@ -393,7 +393,7 @@ pyjwt==2.10.1
     # via streamlit-authenticator
 pypdfium2==5.6.0
     # via pdfplumber
-pytest==9.0.3
+pytest==9.1.0
     # via
     #   manager-database (pyproject.toml)
     #   app-baseline-kit
@@ -489,7 +489,7 @@ ruamel-yaml==0.19.1
     # via prefect
 ruamel-yaml-clib==0.2.15 ; platform_python_implementation == 'CPython'
     # via prefect
-ruff==0.15.14
+ruff==0.15.17
     # via manager-database (pyproject.toml)
 s3transfer==0.16.0
     # via boto3


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 6 version updates:
  - ruff: >=0.15.14 -> >=0.15.17
  - pytest: ==9.0.3 -> >=9.1.0
  - coverage: >=7.14.0 -> >=7.14.1
  - requirements.lock:coverage: 7.14.0 -> ==7.14.1
  - requirements.lock:pytest: 9.0.3 -> ==9.1.0
  - requirements.lock:ruff: 0.15.14 -> ==0.15.17

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`