### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
     "langchain-anthropic>=0.3,<2.0",
     "langsmith>=0.7.30,<1.0",
     "types-PyYAML",
-    "coverage==7.14.1",
+    "coverage==7.14.2",
     "referencing",
     "PyYAML",
     "fakeredis",

--- a/requirements.lock
+++ b/requirements.lock
@@ -100,7 +100,7 @@ colorama==0.4.6
     #   typer
 coolname==5.0.0
     # via prefect
-coverage==7.14.1
+coverage==7.14.2
     # via
     #   manager-database (pyproject.toml)
     #   pytest-cov

--- a/tests/route_helpers.py
+++ b/tests/route_helpers.py
@@ -1,0 +1,6 @@
+from collections.abc import Iterable
+from typing import Any
+
+
+def route_paths(routes: Iterable[Any]) -> set[str]:
+    return {path for route in routes if isinstance(path := getattr(route, "path", None), str)}

--- a/tests/test_activism_api.py
+++ b/tests/test_activism_api.py
@@ -9,6 +9,7 @@ import httpx
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from api.chat import app
+from tests.route_helpers import route_paths
 
 
 async def _request(path: str, params: dict | None = None):
@@ -183,14 +184,13 @@ def test_activism_router_is_registered(tmp_path, monkeypatch):
     _seed_db(db_path)
     monkeypatch.setenv("DB_PATH", str(db_path))
 
-    route_paths = {route.path for route in app.routes}
     expected_paths = {
         "/api/activism/filings",
         "/api/activism/events",
         "/api/activism/timeline/{manager_id}",
         "/api/activism/active-campaigns",
     }
-    assert expected_paths.issubset(route_paths)
+    assert expected_paths.issubset(route_paths(app.routes))
 
     openapi = app.openapi()
     for path in expected_paths:

--- a/tests/test_alerts_api.py
+++ b/tests/test_alerts_api.py
@@ -9,6 +9,7 @@ import httpx
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from api.chat import app
+from tests.route_helpers import route_paths
 
 
 async def _request(method: str, path: str, **kwargs):
@@ -24,7 +25,6 @@ async def _request(method: str, path: str, **kwargs):
 
 
 def test_alerts_router_is_registered():
-    route_paths = {route.path for route in app.routes}
     expected_paths = {
         "/api/alerts/rules",
         "/api/alerts/rules/{rule_id}",
@@ -33,7 +33,7 @@ def test_alerts_router_is_registered():
         "/api/alerts/history/{alert_id}/acknowledge",
         "/api/alerts/history/acknowledge-all",
     }
-    assert expected_paths.issubset(route_paths)
+    assert expected_paths.issubset(route_paths(app.routes))
 
     openapi = app.openapi()
     for path in expected_paths:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,6 +13,7 @@ from fastapi.encoders import jsonable_encoder
 
 import api.chat as chat_api_module
 from api.search import SearchResult, universal_search
+from tests.route_helpers import route_paths
 from ui.search import (
     _count_results_by_entity_type,
     _entity_badge_html,
@@ -368,8 +369,7 @@ def test_api_search_endpoint_returns_results(tmp_path: Path, monkeypatch):
 
 
 def test_api_search_route_is_registered():
-    paths = {route.path for route in chat_api_module.app.routes}
-    assert "/api/search" in paths
+    assert "/api/search" in route_paths(chat_api_module.app.routes)
 
 
 def test_api_search_endpoint_filters_entity_type(tmp_path: Path, monkeypatch):

--- a/tests/test_signals_api.py
+++ b/tests/test_signals_api.py
@@ -9,6 +9,7 @@ import httpx
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from api.chat import app
+from tests.route_helpers import route_paths
 
 
 async def _request(path: str, params: dict[str, Any] | None = None):
@@ -185,13 +186,12 @@ def test_signals_router_is_registered(tmp_path, monkeypatch):
     _seed_db(db_path)
     monkeypatch.setenv("DB_PATH", str(db_path))
 
-    route_paths = {route.path for route in app.routes}
     expected_paths = {
         "/api/signals/crowded",
         "/api/signals/contrarian",
         "/api/signals/conviction/{manager_id}",
     }
-    assert expected_paths.issubset(route_paths)
+    assert expected_paths.issubset(route_paths(app.routes))
 
     openapi = app.openapi()
     for path in expected_paths:


### PR DESCRIPTION
Automated follow-up to the Maint52 dev-tool sync wave.

The original Maint52 PR also changed `.github/workflows/autofix-versions.env`, but that env pin has already landed on `main` via the focused coverage env sync. This replacement starts from current `main` and keeps the remaining canonical coverage pin updates in `pyproject.toml` and `requirements.lock`.

Supersedes the conflicting `deps/sync-dev-versions-d45bcd3be592` PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency `coverage` to version 7.14.2.

* **Tests**
  * Added testing utilities and refactored API route tests to use a shared helper function, improving code maintainability and reducing duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->