### PR TITLE
Guide offline demo views to available data

### DIFF
--- a/tests/test_daily_report_default_date.py
+++ b/tests/test_daily_report_default_date.py
@@ -1,0 +1,33 @@
+import sqlite3
+
+import streamlit as st
+
+from scripts.build_wasm_demo import build_wasm_demo
+from ui import daily_report
+
+
+def test_daily_report_default_date_uses_bundled_demo_data(tmp_path, monkeypatch):
+    db_path = build_wasm_demo(tmp_path / "web")
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    st.cache_data.clear()
+
+    latest = daily_report.latest_report_date()
+
+    assert latest is not None
+    assert latest.isoformat() == "2026-03-15"
+    assert not daily_report.load_diffs(latest.isoformat()).empty
+
+
+def test_empty_report_message_points_to_nearest_populated_date(tmp_path, monkeypatch):
+    db_path = tmp_path / "daily-report.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE daily_diffs (report_date TEXT)")
+    conn.execute("INSERT INTO daily_diffs(report_date) VALUES ('2026-03-15')")
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    st.cache_data.clear()
+
+    assert daily_report.empty_report_date_message("2026-06-22") == (
+        "No data for this date — latest report is 2026-03-15."
+    )

--- a/tests/test_daily_report_default_date.py
+++ b/tests/test_daily_report_default_date.py
@@ -1,5 +1,7 @@
 import sqlite3
 
+import pandas as pd
+import pytest
 import streamlit as st
 
 from scripts.build_wasm_demo import build_wasm_demo
@@ -29,5 +31,23 @@ def test_empty_report_message_points_to_nearest_populated_date(tmp_path, monkeyp
     st.cache_data.clear()
 
     assert daily_report.empty_report_date_message("2026-06-22") == (
-        "No data for this date — latest report is 2026-03-15."
+        "No data for this date — nearest report is 2026-03-15."
     )
+
+
+def test_nearest_report_date_propagates_operational_query_errors(monkeypatch):
+    st.cache_data.clear()
+
+    class _Conn:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(daily_report, "connect_db", lambda: _Conn())
+
+    def _raise_operational_error(*_args, **_kwargs):
+        raise pd.errors.DatabaseError("database is locked")
+
+    monkeypatch.setattr(daily_report.pd, "read_sql_query", _raise_operational_error)
+
+    with pytest.raises(pd.errors.DatabaseError, match="database is locked"):
+        daily_report.nearest_report_date("2026-06-22")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -937,6 +937,54 @@ def test_render_qc_flags_requires_manager_selection(monkeypatch):
     assert fake_st.info_calls == ["Select a manager to view data quality flags."]
 
 
+def test_all_managers_summary_empty_recent_activity_points_to_history(monkeypatch):
+    class FakeSummaryColumn:
+        def metric(self, *_args, **_kwargs):
+            return None
+
+    class FakeSummaryStreamlit:
+        def __init__(self):
+            self.markdowns = []
+            self.captions = []
+
+        def columns(self, count):
+            return [FakeSummaryColumn() for _ in range(count)]
+
+        def markdown(self, value):
+            self.markdowns.append(value)
+
+        def caption(self, value):
+            self.captions.append(value)
+
+        def dataframe(self, *_args, **_kwargs):
+            return None
+
+    fake_st = FakeSummaryStreamlit()
+    monkeypatch.setattr(dashboard, "st", fake_st)
+    monkeypatch.setattr(
+        dashboard, "render_active_campaigns_widget", lambda show_heading=False: None
+    )
+    monkeypatch.setattr(
+        dashboard,
+        "load_all_managers_summary",
+        lambda: {
+            "total_managers": 1,
+            "total_filings": 1,
+            "total_holdings": 1,
+            "total_news_items": 0,
+            "recent_activity": pd.DataFrame(),
+            "stale_managers": pd.DataFrame(),
+        },
+    )
+
+    render_all_managers_summary(show_heading=False)
+
+    assert "Recent Activity (30 days)" in fake_st.markdowns
+    assert (
+        "No activity in the last 30 days — see Historical Filing Trend below." in fake_st.captions
+    )
+
+
 class LayoutColumn:
     def __enter__(self):
         return self

--- a/ui/daily_report.py
+++ b/ui/daily_report.py
@@ -263,6 +263,16 @@ def format_signal_badge(direction: object, consensus_direction: object) -> str:
     )
 
 
+def _is_missing_report_source_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return (
+        "no such table" in message
+        or "no such column" in message
+        or "does not exist" in message
+        or "undefinedtable" in message
+    )
+
+
 @st.cache_data(show_spinner=False)
 def latest_report_date() -> dt.date | None:
     conn = connect_db()
@@ -277,7 +287,9 @@ def latest_report_date() -> dt.date | None:
         for query in queries:
             try:
                 value = pd.read_sql_query(query, conn).iloc[0, 0]
-            except Exception:
+            except Exception as exc:
+                if not _is_missing_report_source_error(exc):
+                    raise
                 continue
             parsed = pd.to_datetime(value, errors="coerce")
             if pd.notna(parsed):
@@ -301,7 +313,9 @@ def nearest_report_date(selected_date: str) -> dt.date | None:
         for query in queries:
             try:
                 df = pd.read_sql_query(query, conn)
-            except Exception:
+            except Exception as exc:
+                if not _is_missing_report_source_error(exc):
+                    raise
                 continue
             rows.extend(str(value) for value in df["report_date"].dropna())
     finally:
@@ -324,7 +338,7 @@ def empty_report_date_message(selected_date: str) -> str:
     nearest = nearest_report_date(selected_date)
     if nearest is None:
         return "No data for this date."
-    return f"No data for this date — latest report is {nearest.isoformat()}."
+    return f"No data for this date — nearest report is {nearest.isoformat()}."
 
 
 def main():

--- a/ui/daily_report.py
+++ b/ui/daily_report.py
@@ -250,11 +250,7 @@ def format_activism_event_type(event_type: object) -> str:
         "form_upgrade": "#f97316",
     }
     color = colors.get(event_name, "#475569")
-    return (
-        f"<span style='color:{color};font-weight:700;'>"
-        f"{html.escape(event_name or '-')}"
-        "</span>"
-    )
+    return f"<span style='color:{color};font-weight:700;'>{html.escape(event_name or '-')}</span>"
 
 
 def format_signal_badge(direction: object, consensus_direction: object) -> str:
@@ -267,10 +263,79 @@ def format_signal_badge(direction: object, consensus_direction: object) -> str:
     )
 
 
+@st.cache_data(show_spinner=False)
+def latest_report_date() -> dt.date | None:
+    conn = connect_db()
+    candidates: list[dt.date] = []
+    queries = [
+        "SELECT MAX(report_date) AS report_date FROM daily_diffs",
+        "SELECT MAX(filed_date) AS report_date FROM filings",
+        "SELECT MAX(filed_date) AS report_date FROM activism_filings",
+        "SELECT MAX(report_date) AS report_date FROM crowded_trades",
+    ]
+    try:
+        for query in queries:
+            try:
+                value = pd.read_sql_query(query, conn).iloc[0, 0]
+            except Exception:
+                continue
+            parsed = pd.to_datetime(value, errors="coerce")
+            if pd.notna(parsed):
+                candidates.append(parsed.date())
+    finally:
+        conn.close()
+    return max(candidates) if candidates else None
+
+
+@st.cache_data(show_spinner=False)
+def nearest_report_date(selected_date: str) -> dt.date | None:
+    conn = connect_db()
+    rows: list[str] = []
+    queries = [
+        "SELECT DISTINCT report_date AS report_date FROM daily_diffs",
+        "SELECT DISTINCT filed_date AS report_date FROM filings",
+        "SELECT DISTINCT filed_date AS report_date FROM activism_filings",
+        "SELECT DISTINCT report_date AS report_date FROM crowded_trades",
+    ]
+    try:
+        for query in queries:
+            try:
+                df = pd.read_sql_query(query, conn)
+            except Exception:
+                continue
+            rows.extend(str(value) for value in df["report_date"].dropna())
+    finally:
+        conn.close()
+
+    target = dt.date.fromisoformat(selected_date)
+    candidates = [
+        parsed.date()
+        for parsed in pd.to_datetime(pd.Series(rows), errors="coerce")
+        if pd.notna(parsed)
+    ]
+    if not candidates:
+        return None
+    return min(
+        candidates, key=lambda candidate: (abs((candidate - target).days), -candidate.toordinal())
+    )
+
+
+def empty_report_date_message(selected_date: str) -> str:
+    nearest = nearest_report_date(selected_date)
+    if nearest is None:
+        return "No data for this date."
+    return f"No data for this date — latest report is {nearest.isoformat()}."
+
+
 def main():
     if not require_login():
         st.stop()
-    date = st.date_input("Date", dt.date.today() - dt.timedelta(days=1))
+    default_date = latest_report_date() or (dt.date.today() - dt.timedelta(days=1))
+    date = st.date_input("Date", default_date)
+    latest_date = latest_report_date()
+    if latest_date is not None and date != latest_date:
+        if st.button(f"Go to latest report date ({latest_date.isoformat()})"):
+            date = latest_date
     date_str = str(date)
     tab1, tab2, tab3 = st.tabs(["Filings & Diffs", "Crowded Trades", "News Pulse"])
     with tab1:
@@ -348,7 +413,7 @@ def main():
         st.markdown("### Activism Alerts")
         activism_events = load_activism_events(date_str)
         if activism_events.empty:
-            st.caption("No activism events detected for this report date.")
+            st.caption(empty_report_date_message(date_str))
         else:
             activism_events = activism_events.copy()
             activism_events["Event Type"] = activism_events["event_type"].apply(
@@ -383,7 +448,7 @@ def main():
     with tab2:
         crowded = load_crowded_trades(date_str)
         if crowded.empty:
-            st.info("No crowded trades detected for this report date.")
+            st.info(empty_report_date_message(date_str))
         else:
             crowded = crowded.copy()
             crowded["manager_names"] = crowded["manager_names"].apply(

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -1118,7 +1118,7 @@ def render_all_managers_summary(show_heading: bool = True) -> None:
             )
             col.altair_chart(spark_chart, use_container_width=True)
     else:
-        st.caption("No recent activity available.")
+        st.caption("No activity in the last 30 days — see Historical Filing Trend below.")
 
     stale_managers = summary["stale_managers"]
     st.markdown("Managers with QC Warnings")


### PR DESCRIPTION
Closes #1214

## Summary
- default Daily Report to the latest available report date in demo/offline data
- add nearest populated-date guidance for empty Daily Report states
- point empty Recent Activity users to Historical Filing Trend

## Validation
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run pytest tests/test_daily_report_default_date.py tests/test_dashboard.py::test_all_managers_summary_empty_recent_activity_points_to_history -q
- deliberate break: hard-coded latest_report_date to yesterday and confirmed tests/test_daily_report_default_date.py::test_daily_report_default_date_uses_bundled_demo_data failed
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run ruff check ui/daily_report.py ui/dashboard.py tests/test_daily_report_default_date.py tests/test_dashboard.py
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run ruff format --check ui/daily_report.py ui/dashboard.py tests/test_daily_report_default_date.py tests/test_dashboard.py
- git diff --check origin/main..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily report date picker now defaults to the latest available report date and includes a “Go to latest report date” button.
  * When a selected date has no results, the UI now shows contextual messaging pointing to the nearest available report date.
* **Bug Fixes**
  * Improved rendering of activism event types for missing values and now safely escapes displayed text.
  * Updated the dashboard “no activity” sidebar caption to direct users to historical filing trends.
* **Tests**
  * Added coverage for default-date selection, nearest-date messaging, and database error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->