### PR TITLE
Codex bootstrap for #1214

### DIFF
--- a/agents/codex-1214.md
+++ b/agents/codex-1214.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1214 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1214 -->

### Source Issue #1214: [MINOR] Offline demo opens on empty views — Daily Report date + Dashboard 'Recent Activity (30 days)' show no data; add jump-to-latest guidance

Base: main
Head: codex/issue-1214

Source: https://github.com/stranske/Manager-Database/issues/1214

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
In the offline stlite demo (`web/wasm_app.py`, bundled synthetic SQLite), two headline surfaces default to recent time windows that exclude the demo's data (dated 2026-03-15), so a first-time user lands on empty views with no guidance to where the data is. Observed live, 2026-06-22 (HEAD `c673705`).

Daily Report (`ui/daily_report.py:273`) defaults `date = st.date_input("Date", dt.date.today() - dt.timedelta(days=1))` to yesterday, which renders an empty report ("Managers w/ changes 0"; "No activism events detected for this report date." `:351`; "No crowded trades detected…" `:386`) and does not point the user to 2026-03-15, the date with data.

Dashboard "Recent Activity (30 days)" (`ui/dashboard.py:1096`, 30-day threshold `:324`) renders empty Filings/Holdings/News columns because the demo data is older than 30 days, so the headline widget reads as broken.

User-facing consequence: the bundled demo opens on empty Daily Report and empty Recent Activity. UX-Review panel: workflow/efficiency_trap sev3 + help_clarity/missing_help sev3, corrob 4/4 (offline build scored 6.0/10, gate FAIL).

#### Tasks
- [ ] Update the date picker default in `ui/daily_report.py:273` to query and use the maximum filing_date from the database instead of yesterday.
- [ ] Add a "Go to latest report date" button or link beside the date picker that sets the date to the most recent available data.
- [ ] Ensure the date picker default logic gracefully handles empty databases by falling back to yesterday when no filing dates exist.
- [ ] Create a helper function to query the nearest non-empty report date given a selected date with no data.
- [ ] Update the empty-state message at `ui/daily_report.py:351` to display the nearest populated date when no activism events exist.
- [ ] Update the empty-state message at `ui/daily_report.py:386` to display the nearest populated date when no crowded trades exist.
- [ ] Make the nearest-date suggestion in empty states clickable to navigate the user to that date.
- [ ] Update `ui/dashboard.py:1096` so when "Recent Activity (30 days)" is empty it shows a sub-caption directing users to where data exists, e.g. "Nothing in the last 30 days — see Historical Filing Trend below".
- [ ] Add a test fixture that loads the bundled demo database for use across daily report tests.
- [ ] Write a test in `tests/test_daily_report_default_date.py` that verifies the Daily Report default date resolves to a date with available filing data in the bundled demo database.
- [ ] Write a test in `tests/test_daily_report_default_date.py` that verifies empty-state messages display the nearest populated date when the selected date has no data.
- [ ] Test the regression by hard-coding the default back to `today - 1 day` without a nearest-date hint, confirm `tests/test_daily_report_default_date.py` fails, then revert.

#### Acceptance Criteria
- [ ] The Daily Report defaults to a date with available filing data when opened in the bundled demo (verified by checking that at least one manager change, activism event, or crowded trade is displayed).
- [ ] When a Daily Report date has no data, each empty-state message displays text matching the pattern 'No data for this date — latest report is YYYY-MM-DD' where the date is the most recent filing_date in the database.
- [ ] When the Recent Activity widget at `ui/dashboard.py:1096` returns zero results, it displays a message containing both 'last 30 days' and a reference to 'Historical Filing Trend' (case-insensitive).
- [ ] `tests/test_daily_report_default_date.py` exists and passes against the bundled demo DB.
- [ ] Reintroducing a `today - 1 day` default with no nearest-date hint causes `tests/test_daily_report_default_date.py` to fail.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

In the offline stlite demo (`web/wasm_app.py`, bundled synthetic SQLite), two headline surfaces default to recent time windows that exclude the demo's data (dated 2026-03-15), so a first-time user lands on empty views with no guidance to where the data is. Observed live, 2026-06-22 (HEAD `c673705`).

Daily Report (`ui/daily_report.py:273`) defaults `date = st.date_input("Date", dt.date.today() - dt.timedelta(days=1))` to yesterday, which renders an empty report ("Managers w/ changes 0"; "No activism events detected for this report date." `:351`; "No crowded trades detected…" `:386`) and does not point the user to 2026-03-15, the date with data.

Dashboard "Recent Activity (30 days)" (`ui/dashboard.py:1096`, 30-day threshold `:324`) renders empty Filings/Holdings/News columns because the demo data is older than 30 days, so the headline widget reads as broken.

User-facing consequence: the bundled demo opens on empty Daily Report and empty Recent Activity. UX-Review panel: workflow/efficiency_trap sev3 + help_clarity/missing_help sev3, corrob 4/4 (offline build scored 6.0/10, gate FAIL).

## Scope

Adjust demo defaults and empty-state guidance so the offline bundled demo points users to available data instead of opening on empty Daily Report and Recent Activity surfaces.

## Non-Goals

Do NOT change the seed/demo data or the 30-day window semantics for live use — adjust the demo defaults + empty-state guidance only.

## Tasks

- [ ] Update the date picker default in `ui/daily_report.py:273` to query and use the maximum filing_date from the database instead of yesterday.
- [ ] Add a "Go to latest report date" button or link beside the date picker that sets the date to the most recent available data.
- [ ] Ensure the date picker default logic gracefully handles empty databases by falling back to yesterday when no filing dates exist.
- [ ] Create a helper function to query the nearest non-empty report date given a selected date with no data.
- [ ] Update the empty-state message at `ui/daily_report.py:351` to display the nearest populated date when no activism events exist.
- [ ] Update the empty-state message at `ui/daily_report.py:386` to display the nearest populated date when no crowded trades exist.
- [ ] Make the nearest-date suggestion in empty states clickable to navigate the user to that date.
- [ ] Update `ui/dashboard.py:1096` so when "Recent Activity (30 days)" is empty it shows a sub-caption directing users to where data exists, e.g. "Nothing in the last 30 days — see Historical Filing Trend below".
- [ ] Add a test fixture that loads the bundled demo database for use across daily report tests.
- [ ] Write a test in `tests/test_daily_report_default_date.py` that verifies the Daily Report default date resolves to a date with available filing data in the bundled demo database.
- [ ] Write a test in `tests/test_daily_report_default_date.py` that verifies empty-state messages display the nearest populated date when the selected date has no data.
- [ ] Test the regression by hard-coding the default back to `today - 1 day` without a nearest-date hint, confirm `tests/test_daily_report_default_date.py` fails, then revert.

## Acceptance Criteria

- [ ] The Daily Report defaults to a date with available filing data when opened in the bundled demo (verified by checking that at least one manager change, activism event, or crowded trade is displayed).
- [ ] When a Daily Report date has no data, each empty-state message displays text matching the pattern 'No data for this date — latest report is YYYY-MM-DD' where the date is the most recent filing_date in the database.
- [ ] When the Recent Activity widget at `ui/dashboard.py:1096` returns zero results, it displays a message containing both 'last 30 days' and a reference to 'Historical Filing Trend' (case-insensitive).
- [ ] `tests/test_daily_report_default_date.py` exists and passes against the bundled demo DB.
- [ ] Reintroducing a `today - 1 day` default with no nearest-date hint causes `tests/test_daily_report_default_date.py` to fail.

## Implementation Notes

Surfaced by the UX Review (`Code/Orchestrator/ux_review.py`), 2026-06-22 — review_id `stranske/Manager-Database:uxreview:2026-06-22` (OFFLINE build), overall 6.0/10 (gate FAIL). Verified at the cited file:lines + live captures. Fix hints from the 4/4-corroborated panel.

<!-- issue-pr-context:formatted-body:v1 {"sha256":"3c5fc6fe2900ca2f97f6cbb27717ab7a41a9e1e94528da0fd0b8c1f4412c9559","workflows":["agents-auto-pilot","agents-issue-optimizer","agents-63-issue-intake","issue_formatter","issue_optimizer"]} -->



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal documentation file for issue tracking purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->