### PR TITLE
Follow up dev auth warning verifier failure

### DIFF
--- a/tests/test_ui_auth.py
+++ b/tests/test_ui_auth.py
@@ -120,9 +120,7 @@ def test_require_login_skips_auth_when_credentials_missing(monkeypatch):
 
     assert ui.require_login() is True
     assert fake_st.session_state["auth"] is True
-    assert fake_st.warning_messages == [
-        "UI_USERNAME/UI_PASSWORD not set; skipping authentication in dev mode."
-    ]
+    assert fake_st.warning_messages == []
 
 
 def test_require_login_skips_auth_when_password_blank(monkeypatch):
@@ -134,6 +132,4 @@ def test_require_login_skips_auth_when_password_blank(monkeypatch):
 
     assert ui.require_login() is True
     assert fake_st.session_state["auth"] is True
-    assert fake_st.warning_messages == [
-        "UI_USERNAME/UI_PASSWORD not set; skipping authentication in dev mode."
-    ]
+    assert fake_st.warning_messages == []

--- a/tests/test_ui_auth_dev_mode.py
+++ b/tests/test_ui_auth_dev_mode.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+class FakeStreamlit:
+    def __init__(self) -> None:
+        self.session_state: dict[str, bool] = {}
+        self.warning_messages: list[str] = []
+
+    def warning(self, message: str) -> None:
+        self.warning_messages.append(message)
+
+
+def _load_ui_module():
+    return importlib.reload(importlib.import_module("ui"))
+
+
+def test_missing_ui_credentials_do_not_render_main_warning(monkeypatch) -> None:
+    ui = _load_ui_module()
+    fake_st = FakeStreamlit()
+    monkeypatch.delenv("UI_USERNAME", raising=False)
+    monkeypatch.delenv("UI_PASSWORD", raising=False)
+    monkeypatch.setattr(ui, "st", fake_st)
+
+    assert ui.require_login() is True
+    assert fake_st.session_state["auth"] is True
+    assert fake_st.warning_messages == []

--- a/tests/test_ui_auth_dev_mode.py
+++ b/tests/test_ui_auth_dev_mode.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import logging
 import sys
 from pathlib import Path
 
@@ -21,16 +20,18 @@ def _load_ui_module():
     return importlib.reload(importlib.import_module("ui"))
 
 
-def test_missing_ui_credentials_do_not_render_main_warning(monkeypatch, caplog) -> None:
+def test_missing_ui_credentials_do_not_render_main_warning(monkeypatch) -> None:
     ui = _load_ui_module()
     fake_st = FakeStreamlit()
+    info_messages: list[str] = []
     monkeypatch.delenv("UI_USERNAME", raising=False)
     monkeypatch.delenv("UI_PASSWORD", raising=False)
     monkeypatch.setattr(ui, "st", fake_st)
-    logging.disable(logging.NOTSET)
-    caplog.set_level(logging.INFO, logger=ui.logger.name)
+    monkeypatch.setattr(ui.logger, "info", info_messages.append)
 
     assert ui.require_login() is True
     assert fake_st.session_state["auth"] is True
     assert fake_st.warning_messages == []
-    assert "UI_USERNAME/UI_PASSWORD not set; skipping authentication in dev mode." in caplog.text
+    assert info_messages == [
+        "UI_USERNAME/UI_PASSWORD not set; skipping authentication in dev mode."
+    ]

--- a/tests/test_ui_auth_dev_mode.py
+++ b/tests/test_ui_auth_dev_mode.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 from pathlib import Path
 
@@ -20,13 +21,15 @@ def _load_ui_module():
     return importlib.reload(importlib.import_module("ui"))
 
 
-def test_missing_ui_credentials_do_not_render_main_warning(monkeypatch) -> None:
+def test_missing_ui_credentials_do_not_render_main_warning(monkeypatch, caplog) -> None:
     ui = _load_ui_module()
     fake_st = FakeStreamlit()
     monkeypatch.delenv("UI_USERNAME", raising=False)
     monkeypatch.delenv("UI_PASSWORD", raising=False)
     monkeypatch.setattr(ui, "st", fake_st)
+    caplog.set_level(logging.INFO, logger="ui")
 
     assert ui.require_login() is True
     assert fake_st.session_state["auth"] is True
     assert fake_st.warning_messages == []
+    assert "UI_USERNAME/UI_PASSWORD not set; skipping authentication in dev mode." in caplog.text

--- a/tests/test_ui_auth_dev_mode.py
+++ b/tests/test_ui_auth_dev_mode.py
@@ -27,7 +27,8 @@ def test_missing_ui_credentials_do_not_render_main_warning(monkeypatch, caplog) 
     monkeypatch.delenv("UI_USERNAME", raising=False)
     monkeypatch.delenv("UI_PASSWORD", raising=False)
     monkeypatch.setattr(ui, "st", fake_st)
-    caplog.set_level(logging.INFO, logger="ui")
+    logging.disable(logging.NOTSET)
+    caplog.set_level(logging.INFO, logger=ui.logger.name)
 
     assert ui.require_login() is True
     assert fake_st.session_state["auth"] is True

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 
 import streamlit as st
@@ -10,6 +11,8 @@ try:
     import streamlit_authenticator as stauth
 except ImportError:  # pragma: no cover - optional UI dependency
     stauth = None
+
+logger = logging.getLogger(__name__)
 
 
 def _get_env_credential(key: str) -> str | None:
@@ -25,7 +28,7 @@ def require_login() -> bool:
     username = _get_env_credential("UI_USERNAME")
     password = _get_env_credential("UI_PASSWORD")
     if not username or not password:
-        st.warning("UI_USERNAME/UI_PASSWORD not set; skipping authentication in dev mode.")
+        logger.info("UI_USERNAME/UI_PASSWORD not set; skipping authentication in dev mode.")
         st.session_state["auth"] = True
         return True
     if stauth is None:


### PR DESCRIPTION
## Summary
- move the missing UI auth credential dev-mode notice out of the Streamlit main page warning surface
- preserve local auth bypass behavior when UI_USERNAME/UI_PASSWORD are missing or blank
- add a regression test that fails if the main UI warning returns

## Validation
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run pytest tests/test_ui_auth.py tests/test_ui_auth_dev_mode.py -q --no-cov
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run ruff check ui/__init__.py tests/test_ui_auth.py tests/test_ui_auth_dev_mode.py
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run ruff format --check ui/__init__.py tests/test_ui_auth.py tests/test_ui_auth_dev_mode.py
- git diff --check
- deliberate-break: temporarily restored st.warning(...) and confirmed tests/test_ui_auth_dev_mode.py fails on the warning assertion

Refs #1215. Follow-up for verifier failure on #1222.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated development-mode authentication so missing credentials or a blank password no longer trigger user-facing warning messages, while authentication behavior remains consistent.

* **Tests**
  * Added coverage for development-mode authentication when UI credentials are unavailable.
  * Updated existing UI authentication tests to assert that no on-screen warnings are shown in these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->