### PR TITLE
Adopt offline design-system theme

### DIFF
--- a/tests/test_wasm_no_external_cdn.py
+++ b/tests/test_wasm_no_external_cdn.py
@@ -11,7 +11,7 @@ DESIGN_SYSTEM_DIR = WEB_DIR / "design-system"
 PYODIDE_VENDOR = WEB_DIR / "vendor" / "pyodide" / "v0.27.3" / "full"
 STLITE_WHEELS = WEB_DIR / "vendor" / "stlite" / "browser-0.80.4" / "build" / "wheels"
 
-EXTERNAL_URL = re.compile(r"https?://", re.IGNORECASE)
+EXTERNAL_URL = re.compile(r"^(?:https?:)?//", re.IGNORECASE)
 MODULE_IMPORT_URL = re.compile(
     r"""(?:import\s+(?:[^'"]+\s+from\s+)?|import\s*\()\s*["'](?P<url>https?://[^"']+)["']\)?""",
     re.IGNORECASE,
@@ -105,7 +105,14 @@ def test_wasm_index_links_local_design_system_styles() -> None:
 
     assert "./design-system/tokens.css" in stylesheet_refs
     assert "./design-system/components.css" in stylesheet_refs
-    assert '<body class="ds theme-air">' in html
+    body_match = re.search(
+        r"<body\b[^>]*\bclass=['\"]([^'\"]+)['\"]",
+        html,
+        re.IGNORECASE,
+    )
+    assert body_match is not None
+    body_classes = set(body_match.group(1).split())
+    assert {"ds", "theme-air"}.issubset(body_classes)
     assert all(not EXTERNAL_URL.search(ref) for ref in stylesheet_refs)
 
     _assert_non_empty_file(DESIGN_SYSTEM_DIR / "tokens.css", label="design-system tokens")

--- a/tests/test_wasm_no_external_cdn.py
+++ b/tests/test_wasm_no_external_cdn.py
@@ -7,6 +7,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WEB_DIR = REPO_ROOT / "web"
 INDEX_HTML = WEB_DIR / "index.html"
+DESIGN_SYSTEM_DIR = WEB_DIR / "design-system"
 PYODIDE_VENDOR = WEB_DIR / "vendor" / "pyodide" / "v0.27.3" / "full"
 STLITE_WHEELS = WEB_DIR / "vendor" / "stlite" / "browser-0.80.4" / "build" / "wheels"
 
@@ -94,6 +95,23 @@ def test_wasm_index_has_no_external_cdn_or_runtime_urls() -> None:
     assert external_tags == [], (
         "web/index.html must not load scripts or stylesheets from external http(s) URLs: "
         f"{external_tags}"
+    )
+
+
+def test_wasm_index_links_local_design_system_styles() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    refs = _runtime_references()
+    stylesheet_refs = [value for location, value in refs if location == "link[href]"]
+
+    assert "./design-system/tokens.css" in stylesheet_refs
+    assert "./design-system/components.css" in stylesheet_refs
+    assert '<body class="ds theme-air">' in html
+    assert all(not EXTERNAL_URL.search(ref) for ref in stylesheet_refs)
+
+    _assert_non_empty_file(DESIGN_SYSTEM_DIR / "tokens.css", label="design-system tokens")
+    _assert_non_empty_file(
+        DESIGN_SYSTEM_DIR / "components.css",
+        label="design-system components",
     )
 
 

--- a/web/design-system/components.css
+++ b/web/design-system/components.css
@@ -1,0 +1,99 @@
+/* components.css — component layer. Token-driven and theme-AGNOSTIC.
+ * Requires tokens.css + a theme class (.theme-air | .theme-paper) on an ancestor.
+ * Everything is scoped under .ds so it never leaks into a host app's own styles.
+ */
+.ds { color:var(--text); font-family:var(--font-body); font-size:var(--fs-base); line-height:1.5; background:var(--bg); }
+.ds *, .ds *::before, .ds *::after { box-sizing:border-box; }
+.ds h3 { font-family:var(--font-heading); font-weight:var(--heading-weight); margin:0 0 var(--space-3); font-size:15px; letter-spacing:-.005em; }
+.ds .sub { color:var(--muted); font-size:var(--fs-sm); margin:calc(-1 * var(--space-2)) 0 var(--space-3); }
+
+.ds .panel { background:var(--surface); border:var(--card-border); border-radius:var(--radius); box-shadow:var(--shadow); padding:var(--card-pad); margin-bottom:var(--space-4); }
+
+.ds .appbar { display:flex; align-items:center; gap:var(--space-4); padding:var(--control-pad-y) var(--card-pad); background:var(--surface); border:var(--card-border); border-radius:var(--radius); box-shadow:var(--shadow); margin-bottom:var(--space-4); }
+.ds .appbar .brand { font-family:var(--font-heading); font-weight:700; font-size:15px; }
+.ds .appbar nav { display:flex; gap:var(--space-1); flex-wrap:wrap; }
+.ds .appbar nav a { font-size:var(--fs-sm); text-decoration:none; color:var(--muted); padding:5px 10px; border-radius:var(--radius-sm); cursor:pointer; }
+.ds .appbar nav a.active { color:var(--accent); background:var(--accent-weak); font-weight:600; }
+.ds .appbar .spacer { flex:1; }
+
+.ds .kpis { display:flex; flex-wrap:wrap; gap:var(--space-3); margin-bottom:var(--space-4); }
+.ds .kpi { flex:1; min-width:150px; background:var(--surface); border:var(--card-border); border-radius:var(--radius); box-shadow:var(--shadow); padding:var(--space-3) var(--space-4); }
+.ds .kpi .label { font-size:var(--fs-sm); color:var(--muted); }
+.ds .kpi .val { font-size:var(--kpi-size); font-weight:700; letter-spacing:-.02em; margin-top:4px; font-family:var(--font-heading); }
+.ds .kpi .delta { font-size:var(--fs-sm); font-weight:600; margin-top:2px; }
+.ds .up { color:var(--pos); }  .ds .down { color:var(--neg); }
+
+.ds .grid2 { display:grid; grid-template-columns:1.3fr 1fr; gap:var(--space-4); }
+@media (max-width:720px){ .ds .grid2 { grid-template-columns:1fr; } }
+
+.ds table { width:100%; border-collapse:collapse; font-size:var(--fs-sm); }
+.ds thead th { text-align:left; color:var(--muted); font-weight:600; font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.04em; padding:var(--row-pad-y) var(--row-pad-x); border-bottom:1px solid var(--border); }
+.ds tbody td { padding:var(--row-pad-y) var(--row-pad-x); border-bottom:1px solid var(--row-border); }
+.ds tbody tr:nth-child(even) { background:var(--zebra); }
+.ds td.num, .ds th.num { text-align:right; font-variant-numeric:tabular-nums; }
+
+.ds .field { margin-bottom:var(--space-3); }
+.ds label { display:block; font-size:var(--fs-sm); font-weight:600; margin-bottom:5px; }
+.ds label .help { font-weight:400; color:var(--muted); }
+.ds .q { display:inline-flex; width:15px; height:15px; border-radius:50%; border:1px solid var(--border); color:var(--muted); font-size:10px; align-items:center; justify-content:center; vertical-align:1px; margin-left:5px; cursor:help; }
+.ds input[type=text], .ds select { width:100%; font:inherit; font-size:var(--fs-base); padding:var(--control-pad-y) var(--control-pad-x); color:var(--text); background:var(--input-bg); border:1px solid var(--border); border-radius:var(--input-radius); }
+.ds input[type=range] { width:100%; accent-color:var(--accent); }
+.ds a:focus-visible, .ds button:focus-visible, .ds input:focus-visible, .ds select:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+
+.ds .btns { display:flex; flex-wrap:wrap; gap:var(--space-2); margin-top:var(--space-1); }
+.ds button { font:inherit; font-size:var(--fs-sm); font-weight:600; padding:var(--control-pad-y) 15px; border-radius:var(--btn-radius); cursor:pointer; border:1px solid transparent; }
+.ds .b-primary { background:var(--btn-primary-bg); color:var(--btn-primary-contrast); border-color:var(--btn-primary-bg); }
+.ds .b-secondary { background:var(--surface); color:var(--text); border:1px solid var(--border); }
+.ds .b-ghost { background:transparent; color:var(--accent); }
+.ds .b-danger { background:transparent; color:var(--neg); border:1px solid var(--neg-border); }
+.ds button[disabled] { opacity:.45; cursor:not-allowed; }
+
+.ds .callout { display:flex; gap:10px; padding:11px 13px; border-radius:var(--radius); background:var(--accent-weak); border:1px solid var(--accent-line); font-size:var(--fs-sm); }
+.ds .callout .ic { color:var(--accent); font-weight:700; }
+.ds .empty { text-align:center; color:var(--muted); border:1px dashed var(--border); border-radius:var(--radius); padding:20px; font-size:var(--fs-sm); }
+.ds .chart { color:var(--accent); display:block; }
+
+/* ============================================================================
+ *  PRESENTATION-STATE PATTERNS (added 2026-06-22 from the cross-fleet UX-Review
+ *  baseline). These standardize the recurring failure classes: empty/dead-end
+ *  views, raw errors, dev/diagnostic leaks, and unavailable features.
+ *  See PRESENTATION_PATTERNS.md for the rule behind each + per-app-type usage.
+ * ========================================================================== */
+
+/* notice — the ONE container for user-facing messages. Never render a raw
+ * exception / internal field name / filename / CLI flag; translate to a human
+ * message + remediation and put it here. Variants by semantics. */
+.ds .notice { display:flex; gap:10px; align-items:flex-start; padding:11px 13px; border-radius:var(--radius); font-size:var(--fs-sm); border:1px solid var(--border); background:var(--panel); }
+.ds .notice .ic { font-weight:700; flex:none; line-height:1.4; }
+.ds .notice .body { flex:1; }
+.ds .notice .body strong { display:block; margin-bottom:2px; }
+.ds .notice .body .act { margin-top:6px; }                 /* remediation link/button slot */
+.ds .notice--info  { background:var(--info-weak);  border-color:var(--accent-line); }
+.ds .notice--info  .ic { color:var(--info); }
+.ds .notice--warn  { background:var(--warn-weak);  border-color:var(--warn); }
+.ds .notice--warn  .ic { color:var(--warn); }
+.ds .notice--error { background:var(--neg-weak);   border-color:var(--neg-border); }
+.ds .notice--error .ic { color:var(--neg); }
+.ds .notice--ok    { background:var(--pos-weak);   border-color:var(--pos); }
+.ds .notice--ok    .ic { color:var(--pos); }
+
+/* empty-state — for "no data yet" surfaces. ALWAYS a title + one-line reason +
+ * a next-action; NEVER a bare prompt sitting above already-rendered results,
+ * and NEVER an internal filename/path. */
+.ds .empty-state { text-align:center; border:1px dashed var(--border); border-radius:var(--radius); padding:28px 20px; }
+.ds .empty-state .es-icon { font-size:22px; opacity:.6; }
+.ds .empty-state .es-title { font-family:var(--font-heading); font-weight:var(--heading-weight); font-size:15px; margin:8px 0 4px; }
+.ds .empty-state .es-desc { color:var(--muted); font-size:var(--fs-sm); max-width:42ch; margin:0 auto 12px; }
+.ds .empty-state .es-cta { display:inline-flex; gap:8px; }
+
+/* badge — small availability/status marker (e.g. "multi-period only",
+ * "needs setup") so a tab/control states its applicability up front. */
+.ds .badge { display:inline-block; font-size:var(--fs-xs); font-weight:600; padding:1px 7px; border-radius:999px; background:var(--panel); color:var(--muted); border:1px solid var(--border); vertical-align:middle; }
+.ds .badge--muted { opacity:.8; }
+
+/* skeleton — loading placeholder so a pending surface never looks empty/broken. */
+.ds .skeleton { background:linear-gradient(90deg,var(--panel) 25%,var(--border) 37%,var(--panel) 63%); background-size:400% 100%; border-radius:var(--radius-sm); animation:ds-shimmer 1.3s ease infinite; min-height:14px; }
+@keyframes ds-shimmer { 0%{background-position:100% 0} 100%{background-position:0 0} }
+@media (prefers-reduced-motion: reduce) {
+  .ds .skeleton { animation:none; background:var(--panel); }
+}

--- a/web/design-system/tokens.css
+++ b/web/design-system/tokens.css
@@ -1,0 +1,76 @@
+/* tokens.css — shared design-system tokens.
+ *
+ * One set of variable NAMES; two THEMES supply the values (.theme-air, .theme-paper);
+ * an orthogonal DENSITY axis (.density-compact) tightens spacing for data-dense screens
+ * WITHOUT changing the theme's identity.
+ *
+ * Apply on a root element:
+ *   <body class="theme-air">                     work / outward-facing (default)
+ *   <body class="theme-air density-compact">     dense data screens (e.g. Trend tables)
+ *   <body class="theme-paper">                   friendlier apps (Reader, LMS)
+ *
+ * Per-app customization: override any token in an app stylesheet loaded AFTER this file
+ * (e.g. redefine --accent). Never fork components.css.
+ */
+
+:root {
+  /* ---- spacing / density: comfortable (default) ---- */
+  --space-1: 4px;  --space-2: 8px;  --space-3: 12px;  --space-4: 16px;  --space-6: 24px;
+  --card-pad: 18px;
+  --control-pad-y: 8px;  --control-pad-x: 10px;
+  --row-pad-y: 9px;      --row-pad-x: 10px;
+  --fs-base: 14px;  --fs-sm: 12.5px;  --fs-xs: 11.5px;
+  --kpi-size: 26px;
+
+  /* ---- shape (a theme may override) ---- */
+  --radius: 10px;  --radius-sm: 8px;  --btn-radius: 8px;  --input-radius: 8px;
+
+  /* ---- type ---- */
+  --font-body: system-ui, -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif;
+  --font-heading: var(--font-body);
+  --heading-weight: 700;
+}
+
+/* ---- density axis (orthogonal to theme) ---- */
+.density-compact {
+  --space-3: 8px;  --space-4: 10px;  --space-6: 14px;
+  --card-pad: 12px;
+  --control-pad-y: 6px;  --control-pad-x: 8px;
+  --row-pad-y: 6px;      --row-pad-x: 8px;
+  --fs-base: 13px;  --fs-sm: 12px;
+  --kpi-size: 22px;
+}
+
+/* ===== THEME: Ink & Air — default, outward-facing work ===== */
+.theme-air {
+  --bg:#ffffff;  --surface:#ffffff;  --panel:#fafafa;
+  --text:#0a0a0a;  --muted:#737373;
+  --border:#ececec;  --row-border:#f2f2f2;  --zebra:transparent;
+  --input-bg:#ffffff;
+  --accent:#4f46e5;  --accent-contrast:#ffffff;  --accent-weak:#f4f3ff;  --accent-line:#e7e5fb;
+  --btn-primary-bg:#0a0a0a;  --btn-primary-contrast:#ffffff;   /* ink buttons, indigo highlights */
+  --pos:#047857;  --neg:#dc2626;  --neg-border:#f2cccc;
+  /* ---- notice/state semantics (errors, warnings, info, empty) ---- */
+  --warn:#b45309;  --info:#4f46e5;
+  --pos-weak:#ecfdf5;  --neg-weak:#fef2f2;  --warn-weak:#fffbeb;  --info-weak:var(--accent-weak);
+  --card-border: none;  --shadow: none;                        /* borderless, whitespace-led */
+  --heading-weight:700;
+}
+
+/* ===== THEME: Warm Paper — friendlier apps ===== */
+.theme-paper {
+  --bg:#faf7f1;  --surface:#fffdf9;  --panel:#f3efe7;
+  --text:#2b2622;  --muted:#857a6c;
+  --border:#e4ddcf;  --row-border:#efe9dd;  --zebra:#fbf8f1;
+  --input-bg:#fffdf9;
+  --accent:#a85a34;  --accent-contrast:#ffffff;  --accent-weak:#f6ece4;  --accent-line:#e9d4c4;
+  --btn-primary-bg: var(--accent);  --btn-primary-contrast:#ffffff;
+  --pos:#5a7d2f;  --neg:#a3402e;  --neg-border:#e3c3bb;
+  /* ---- notice/state semantics ---- */
+  --warn:#9a6a16;  --info:var(--accent);
+  --pos-weak:#eef3e6;  --neg-weak:#f6e9e6;  --warn-weak:#f7efe1;  --info-weak:var(--accent-weak);
+  --card-border: 1px solid var(--border);  --shadow: 0 1px 2px rgba(80,60,30,.06);
+  --radius:8px;  --radius-sm:7px;  --btn-radius:7px;  --input-radius:7px;
+  --font-heading: "Georgia", "Times New Roman", serif;
+  --heading-weight:600;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Manager-Database Offline Demo</title>
+    <link rel="stylesheet" href="./design-system/tokens.css" />
+    <link rel="stylesheet" href="./design-system/components.css" />
     <script type="module">
       import { mount } from "./vendor/stlite/browser-0.80.4/build/stlite.js";
 
@@ -63,7 +65,7 @@
       );
     </script>
   </head>
-  <body>
+  <body class="ds theme-air">
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Copies shared design-system token/component CSS into the offline web bundle under `web/design-system/`.
- Links the local stylesheets from `web/index.html` and applies `ds theme-air` to the app root.
- Extends the offline no-external gate to assert local stylesheet links, body theme classes, and non-empty local CSS assets.

Closes #1236

## Validation
- `UV_CACHE_DIR=/tmp/manager-1236-uv-cache uv run pytest tests/test_wasm_no_external_cdn.py -q --no-cov`
- `UV_CACHE_DIR=/tmp/manager-1236-uv-cache uv run ruff check tests/test_wasm_no_external_cdn.py`
- `UV_CACHE_DIR=/tmp/manager-1236-uv-cache uv run ruff format --check tests/test_wasm_no_external_cdn.py`
- `git diff --check`
- Deliberate break: temporarily removed the `./design-system/components.css` link; `tests/test_wasm_no_external_cdn.py::test_wasm_index_links_local_design_system_styles` failed on the missing link assertion; restored and reran green.

## Notes
- #1220 is closed with offline boot evidence, so this follow-up implements the previously blocked theme adoption scope. Full browser zero-request visual proof should be completed by CI/owner environment if required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in design system theming to the web app for consistent styling.
  * Introduced shared design tokens and a component-level stylesheet with UI primitives (layouts, forms, notices, badges, empty states, skeletons).
  * Added multiple theme options plus a compact density mode for tighter spacing.

* **Bug Fixes**
  * Updated the app to load design system styles locally (no external stylesheet URLs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->