### PR TITLE
Codex bootstrap for #1262

### DIFF
--- a/agents/codex-1262.md
+++ b/agents/codex-1262.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1262 -->

--- a/api/_compat.py
+++ b/api/_compat.py
@@ -39,9 +39,9 @@ def offline_query(default: Any = None, *args: Any, **kwargs: Any) -> Any:
     return default
 
 
-def offline_api_imports() -> tuple[
-    type[OfflineAPIRouter], type[OfflineBaseModel], Callable[..., Any], Callable[..., Any]
-]:
+def offline_api_imports() -> (
+    tuple[type[OfflineAPIRouter], type[OfflineBaseModel], Callable[..., Any], Callable[..., Any]]
+):
     if os.getenv("UI_OFFLINE") != "1":
         raise ModuleNotFoundError("FastAPI/Pydantic fallbacks are only available with UI_OFFLINE=1")
     return OfflineAPIRouter, OfflineBaseModel, offline_field, offline_query

--- a/tests/test_ci_coverage_delta.py
+++ b/tests/test_ci_coverage_delta.py
@@ -9,7 +9,6 @@ import pytest
 
 from scripts import ci_coverage_delta
 
-
 _ENV_KEYS = (
     "COVERAGE_XML_PATH",
     "OUTPUT_PATH",

--- a/tests/test_ci_coverage_delta.py
+++ b/tests/test_ci_coverage_delta.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, tzinfo
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import ci_coverage_delta
+
+
+_ENV_KEYS = (
+    "COVERAGE_XML_PATH",
+    "OUTPUT_PATH",
+    "BASELINE_COVERAGE",
+    "ALERT_DROP",
+    "FAIL_ON_DROP",
+)
+
+
+@pytest.fixture
+def fixed_timestamp(monkeypatch: pytest.MonkeyPatch) -> str:
+    timestamp = datetime(2026, 6, 27, 12, 34, 56, 789123, tzinfo=UTC)
+
+    class FixedDateTime:
+        @classmethod
+        def now(cls, tz: tzinfo | None = None) -> datetime:
+            if tz is None:
+                return timestamp
+            return timestamp.astimezone(tz)
+
+    monkeypatch.setattr(
+        ci_coverage_delta,
+        "_dt",
+        SimpleNamespace(datetime=FixedDateTime, UTC=UTC),
+    )
+    return "2026-06-27T12:34:56Z"
+
+
+def _clear_coverage_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _write_coverage_xml(path: Path, line_rate: str) -> Path:
+    path.write_text(f'<coverage line-rate="{line_rate}"></coverage>\n', encoding="utf-8")
+    return path
+
+
+def test_extract_line_rate_reads_valid_cobertura_xml(tmp_path: Path) -> None:
+    xml_path = _write_coverage_xml(tmp_path / "coverage.xml", "0.876543")
+
+    assert ci_coverage_delta._extract_line_rate(xml_path) == pytest.approx(87.6543)
+
+
+@pytest.mark.parametrize(
+    (
+        "current",
+        "baseline",
+        "alert_drop",
+        "fail_on_drop",
+        "expected_payload",
+        "expected_should_fail",
+    ),
+    [
+        (
+            91.23456,
+            0.0,
+            1.25,
+            False,
+            {
+                "current": 91.2346,
+                "baseline": 0.0,
+                "delta": 91.2346,
+                "drop": 0.0,
+                "threshold": 1.25,
+                "status": "no-baseline",
+                "fail_on_drop": False,
+            },
+            False,
+        ),
+        (
+            99.87654,
+            99.12345,
+            1.0,
+            False,
+            {
+                "current": 99.8765,
+                "baseline": 99.1235,
+                "delta": 0.7531,
+                "drop": 0.0,
+                "threshold": 1.0,
+                "status": "ok",
+                "fail_on_drop": False,
+            },
+            False,
+        ),
+        (
+            94.87654,
+            97.12345,
+            2.0,
+            False,
+            {
+                "current": 94.8765,
+                "baseline": 97.1235,
+                "delta": -2.2469,
+                "drop": 2.2469,
+                "threshold": 2.0,
+                "status": "alert",
+                "fail_on_drop": False,
+            },
+            False,
+        ),
+        (
+            94.87654,
+            97.12345,
+            2.0,
+            True,
+            {
+                "current": 94.8765,
+                "baseline": 97.1235,
+                "delta": -2.2469,
+                "drop": 2.2469,
+                "threshold": 2.0,
+                "status": "fail",
+                "fail_on_drop": True,
+            },
+            True,
+        ),
+    ],
+)
+def test_build_payload_sets_status_and_rounded_values(
+    fixed_timestamp: str,
+    current: float,
+    baseline: float,
+    alert_drop: float,
+    fail_on_drop: bool,
+    expected_payload: dict[str, object],
+    expected_should_fail: bool,
+) -> None:
+    payload, should_fail = ci_coverage_delta._build_payload(
+        current,
+        baseline,
+        alert_drop,
+        fail_on_drop=fail_on_drop,
+    )
+
+    assert should_fail is expected_should_fail
+    assert payload == {"timestamp": fixed_timestamp, **expected_payload}
+
+
+def test_main_returns_failure_for_missing_coverage_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _clear_coverage_env(monkeypatch)
+    missing_xml = tmp_path / "missing.xml"
+    output_path = tmp_path / "coverage-delta.json"
+    monkeypatch.setenv("COVERAGE_XML_PATH", str(missing_xml))
+    monkeypatch.setenv("OUTPUT_PATH", str(output_path))
+
+    assert ci_coverage_delta.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == f"Coverage XML not found: {missing_xml}\n"
+    assert not output_path.exists()
+
+
+def test_main_writes_json_with_environment_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    fixed_timestamp: str,
+) -> None:
+    _clear_coverage_env(monkeypatch)
+    xml_path = _write_coverage_xml(tmp_path / "custom-coverage.xml", "0.900006")
+    output_path = tmp_path / "custom-delta.json"
+    monkeypatch.setenv("COVERAGE_XML_PATH", str(xml_path))
+    monkeypatch.setenv("OUTPUT_PATH", str(output_path))
+    monkeypatch.setenv("BASELINE_COVERAGE", "92.34567")
+    monkeypatch.setenv("ALERT_DROP", "1.5")
+    monkeypatch.setenv("FAIL_ON_DROP", "true")
+
+    assert ci_coverage_delta.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == f"Coverage delta written to {output_path}\n"
+    assert captured.err == ""
+    assert json.loads(output_path.read_text(encoding="utf-8")) == {
+        "timestamp": fixed_timestamp,
+        "current": 90.0006,
+        "baseline": 92.3457,
+        "delta": -2.3451,
+        "drop": 2.3451,
+        "threshold": 1.5,
+        "status": "fail",
+        "fail_on_drop": True,
+    }

--- a/tests/test_ci_coverage_delta.py
+++ b/tests/test_ci_coverage_delta.py
@@ -80,6 +80,22 @@ def test_extract_line_rate_reads_valid_cobertura_xml(tmp_path: Path) -> None:
             False,
         ),
         (
+            98.75,
+            99.0,
+            1.0,
+            False,
+            {
+                "current": 98.75,
+                "baseline": 99.0,
+                "delta": -0.25,
+                "drop": 0.25,
+                "threshold": 1.0,
+                "status": "ok",
+                "fail_on_drop": False,
+            },
+            False,
+        ),
+        (
             99.87654,
             99.12345,
             1.0,

--- a/tests/test_wasm_no_external_cdn.py
+++ b/tests/test_wasm_no_external_cdn.py
@@ -78,14 +78,14 @@ def _glob_one(directory: Path, pattern: str) -> Path:
 def test_wasm_index_has_no_external_cdn_or_runtime_urls() -> None:
     html = INDEX_HTML.read_text(encoding="utf-8")
 
-    assert "cdn.jsdelivr.net" not in html, (
-        "web/index.html must not reference cdn.jsdelivr.net for offline boot"
-    )
+    assert (
+        "cdn.jsdelivr.net" not in html
+    ), "web/index.html must not reference cdn.jsdelivr.net for offline boot"
 
     external_imports = [match.group("url") for match in MODULE_IMPORT_URL.finditer(html)]
-    assert external_imports == [], (
-        f"web/index.html must not import modules from external http(s) URLs: {external_imports}"
-    )
+    assert (
+        external_imports == []
+    ), f"web/index.html must not import modules from external http(s) URLs: {external_imports}"
 
     external_tags = [
         f"{location}={value}"
@@ -128,24 +128,24 @@ def test_wasm_index_points_at_local_vendor_runtime() -> None:
     pyodide_match = PYODIDE_URL.search(html)
     assert pyodide_match is not None, "web/index.html must set pyodideUrl via new URL(...)"
     pyodide_path = pyodide_match.group("url")
-    assert pyodide_path.startswith("./vendor/"), (
-        f"pyodideUrl must point at a local ./vendor path, got {pyodide_path!r}"
-    )
-    assert pyodide_path.endswith("pyodide.mjs"), (
-        f"pyodideUrl must target pyodide.mjs, got {pyodide_path!r}"
-    )
+    assert pyodide_path.startswith(
+        "./vendor/"
+    ), f"pyodideUrl must point at a local ./vendor path, got {pyodide_path!r}"
+    assert pyodide_path.endswith(
+        "pyodide.mjs"
+    ), f"pyodideUrl must target pyodide.mjs, got {pyodide_path!r}"
 
     wheel_paths = [match.group("url") for match in WHEEL_URL.finditer(html)]
-    assert len(wheel_paths) == 2, (
-        "web/index.html must declare local wheelUrls for stliteLib and streamlit"
-    )
+    assert (
+        len(wheel_paths) == 2
+    ), "web/index.html must declare local wheelUrls for stliteLib and streamlit"
     for wheel_path in wheel_paths:
-        assert wheel_path.startswith("./vendor/"), (
-            f"wheelUrls must point at local ./vendor paths, got {wheel_path!r}"
-        )
-        assert wheel_path.endswith(".whl"), (
-            f"wheelUrls must target vendored .whl files, got {wheel_path!r}"
-        )
+        assert wheel_path.startswith(
+            "./vendor/"
+        ), f"wheelUrls must point at local ./vendor paths, got {wheel_path!r}"
+        assert wheel_path.endswith(
+            ".whl"
+        ), f"wheelUrls must target vendored .whl files, got {wheel_path!r}"
 
 
 def test_vendored_pyodide_core_runtime_exists() -> None:


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1262 -->

### Source Issue #1262: [Route Weight][testgen] Add ci_coverage_delta utility tests

Base: main
Head: codex/issue-1262

Source: https://github.com/stranske/Manager-Database/issues/1262

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`scripts/ci_coverage_delta.py` computes coverage deltas from Cobertura XML and environment configuration, but current `origin/main` has no dedicated tests for XML parsing, JSON payload creation, failure behavior, or environment overrides. This is a safe Route-Weight `testgen` opener because it is deterministic and file-local.

#### Tasks
- [ ] Add tests for `scripts/ci_coverage_delta.py`.
- [ ] Cover `_extract_line_rate()` with valid coverage XML.
- [ ] Cover missing file handling through `main()`.
- [ ] Cover `_build_payload()` for no-baseline, ok, alert, and fail-on-drop cases.
- [ ] Cover `main()` writing JSON to `OUTPUT_PATH` with `COVERAGE_XML_PATH`, `BASELINE_COVERAGE`, `ALERT_DROP`, and `FAIL_ON_DROP` overrides.

#### Acceptance Criteria
- [ ] Tests use `tmp_path` and environment monkeypatching.
- [ ] Tests assert rounded JSON values and status fields.
- [ ] Existing script behavior is preserved.
- [ ] No GitHub API, network, or CI-only dependency is introduced.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

`scripts/ci_coverage_delta.py` computes coverage deltas from Cobertura XML and environment configuration, but current `origin/main` has no dedicated tests for XML parsing, JSON payload creation, failure behavior, or environment overrides. This is a safe Route-Weight `testgen` opener because it is deterministic and file-local.

## Scope

- Add tests for `scripts/ci_coverage_delta.py`.
- Cover `_extract_line_rate()` with valid coverage XML.
- Cover missing file handling through `main()`.
- Cover `_build_payload()` for no-baseline, ok, alert, and fail-on-drop cases.
- Cover `main()` writing JSON to `OUTPUT_PATH` with `COVERAGE_XML_PATH`, `BASELINE_COVERAGE`, `ALERT_DROP`, and `FAIL_ON_DROP` overrides.

## Acceptance Criteria

- Tests use `tmp_path` and environment monkeypatching.
- Tests assert rounded JSON values and status fields.
- Existing script behavior is preserved.
- No GitHub API, network, or CI-only dependency is introduced.

## Validation

```bash
python -m pytest tests/test_ci_coverage_delta.py -v
```

## Route-Weight Metadata

- `task_type`: `testgen`
- `lane`: `opener`
- `safe_opener`: `true`
- `defect_class`: `coverage-utility-coverage-gap`
- `source`: `Audits/2026-06-27-route-weight-candidate-matrix.md`

## Non-Goals

- Do not change CI thresholds.
- Do not add GitHub comment/update behavior.
- Do not modify `tools/coverage_guard.py` in this issue.



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a traceability comment at the top of a documentation note.
* **Tests**
  * Added a new test suite validating CI coverage delta parsing, payload calculation, and expected success/failure behavior (including missing-file handling).
  * Reformatted assertions in existing WASM no-external-CDN tests for clearer readability while keeping the same checks.
* **Style**
  * Reformatted a return type annotation for improved readability (no behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->