### PR TITLE
Codex bootstrap for #1267

### DIFF
--- a/agents/codex-1267.md
+++ b/agents/codex-1267.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1267 -->

--- a/tests/test_dialect_portability_gate.py
+++ b/tests/test_dialect_portability_gate.py
@@ -237,6 +237,9 @@ def test_python_files_returns_sorted_unique_python_files(tmp_path: Path) -> None
     (scan_dir / "__pycache__" / "cached.py").write_text("")
     (scan_dir / "tests").mkdir()
     (scan_dir / "tests" / "test_module.py").write_text("")
+    (scan_dir / ".venv").mkdir()
+    (scan_dir / ".venv" / "vendored.py").write_text("")
+    (scan_dir / "check_dialect_portability.py").write_text("")
 
     files = _python_files([tmp_path, scan_dir])
     paths = [f.relative_to(tmp_path).as_posix() for f in files]
@@ -248,6 +251,8 @@ def test_python_files_returns_sorted_unique_python_files(tmp_path: Path) -> None
     assert "scan_dir/module4.py" in paths
     assert "__pycache__/cached.py" not in paths
     assert "tests/test_module.py" not in paths
+    assert "scan_dir/.venv/vendored.py" not in paths
+    assert "scan_dir/check_dialect_portability.py" not in paths
     # Should be sorted and unique
     assert paths == sorted(paths)
     assert len(paths) == len(set(paths))
@@ -271,6 +276,13 @@ def test_imports_connect_db_detects_function_def() -> None:
 
 def test_imports_connect_db_detects_direct_call() -> None:
     source = """conn = connect_db()
+"""
+    assert _imports_connect_db(source) is True
+
+
+def test_imports_connect_db_detects_direct_call_when_source_is_malformed() -> None:
+    source = """def broken(
+    conn = connect_db()
 """
     assert _imports_connect_db(source) is True
 

--- a/tests/test_dialect_portability_gate.py
+++ b/tests/test_dialect_portability_gate.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 from scripts.check_dialect_portability import (
     AUDITED_SQLITE_ONLY_ALLOWLIST,
+    _imports_connect_db,
+    _python_files,
+    _relative_path,
     allowlist_paths_missing_from_audit,
+    documented_audit_paths,
     scan,
 )
 
@@ -192,3 +196,159 @@ def test_allowlist_paths_missing_from_audit_accepts_documented_entries(tmp_path:
     )
 
     assert missing == []
+
+
+def test_relative_path_returns_relative_to_repo_root(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    file_path = repo_root / "src" / "module.py"
+    file_path.parent.mkdir()
+    file_path.write_text("")
+
+    result = _relative_path(file_path, repo_root)
+    assert result == "src/module.py"
+
+
+def test_relative_path_returns_absolute_when_outside_repo(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside_path = tmp_path / "outside" / "module.py"
+    outside_path.parent.mkdir()
+    outside_path.write_text("")
+
+    result = _relative_path(outside_path, repo_root)
+    assert result == outside_path.as_posix()
+
+
+def test_python_files_returns_sorted_unique_python_files(tmp_path: Path) -> None:
+    # Create some Python files
+    (tmp_path / "module1.py").write_text("")
+    (tmp_path / "module2.py").write_text("")
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "module3.py").write_text("")
+    # Create a directory to scan
+    scan_dir = tmp_path / "scan_dir"
+    scan_dir.mkdir()
+    (scan_dir / "module4.py").write_text("")
+    # Create non-Python files that should be ignored
+    (scan_dir / "readme.txt").write_text("")
+    (scan_dir / "__pycache__").mkdir()
+    (scan_dir / "__pycache__" / "cached.py").write_text("")
+    (scan_dir / "tests").mkdir()
+    (scan_dir / "tests" / "test_module.py").write_text("")
+
+    files = _python_files([tmp_path, scan_dir])
+    paths = [f.as_posix() for f in files]
+
+    # Should include all .py files except those in tests/ or __pycache__
+    assert "module1.py" in paths
+    assert "module2.py" in paths
+    assert "subdir/module3.py" in paths
+    assert "scan_dir/module4.py" in paths
+    assert "__pycache__/cached.py" not in paths
+    assert "tests/test_module.py" not in paths
+    # Should be sorted and unique
+    assert paths == sorted(paths)
+    assert len(paths) == len(set(paths))
+
+
+def test_imports_connect_db_detects_import_from_adapters_base() -> None:
+    source = """from adapters.base import connect_db
+
+def func():
+    pass
+"""
+    assert _imports_connect_db(source) is True
+
+
+def test_imports_connect_db_detects_function_def() -> None:
+    source = """def connect_db():
+    pass
+"""
+    assert _imports_connect_db(source) is True
+
+
+def test_imports_connect_db_detects_direct_call() -> None:
+    source = """conn = connect_db()
+"""
+    assert _imports_connect_db(source) is True
+
+
+def test_imports_connect_db_ignores_non_connect_db() -> None:
+    source = """def some_other_function():
+    pass
+"""
+    assert _imports_connect_db(source) is False
+
+
+def test_documented_audit_paths_returns_module_paths_from_table(tmp_path: Path) -> None:
+    report = tmp_path / "docs" / "reports" / "dialect_portability_audit.md"
+    report.parent.mkdir(parents=True)
+    report.write_text(
+        "\n".join(
+            [
+                "# Dialect Portability Audit",
+                "",
+                "| Surface | Classification | Evidence | Failure Mode Or Justification | Disposition |",
+                "| --- | --- | --- | --- | --- |",
+                "| `api/chat.py` | dialect-aware | evidence | justification | disposition |",
+                "| `etl/activism_flow.py` | dialect-aware | evidence | justification | disposition |",
+                "| Some other text with `not_a_module.py` in backticks | more | stuff |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    paths = documented_audit_paths(report)
+    assert paths == {"api/chat.py", "etl/activism_flow.py"}
+
+
+def test_documented_audit_paths_returns_empty_set_for_nonexistent_report(tmp_path: Path) -> None:
+    report = tmp_path / "nonexistent" / "report.md"
+    paths = documented_audit_paths(report)
+    assert paths == set()
+
+
+def test_dialect_gate_rejects_insert_or_ignore(tmp_path: Path) -> None:
+    module = tmp_path / "feature.py"
+    module.write_text(
+        "\n".join(
+            [
+                "from adapters.base import connect_db",
+                "",
+                "def migrate() -> None:",
+                "    conn = connect_db()",
+                "    conn.execute('INSERT OR IGNORE INTO managers (id, name) VALUES (1, \"test\")')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = scan([module], repo_root=tmp_path, allowlist={})
+
+    assert len(findings) == 1
+    assert findings[0].path == "feature.py"
+    assert findings[0].token == "INSERT OR IGNORE"
+
+
+def test_dialect_gate_rejects_pragma_table_info(tmp_path: Path) -> None:
+    module = tmp_path / "feature.py"
+    module.write_text(
+        "\n".join(
+            [
+                "from adapters.base import connect_db",
+                "",
+                "def inspect() -> None:",
+                "    conn = connect_db()",
+                "    conn.execute('PRAGMA table_info(managers)')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = scan([module], repo_root=tmp_path, allowlist={})
+
+    assert len(findings) == 1
+    assert findings[0].path == "feature.py"
+    assert findings[0].token == "PRAGMA table_info"

--- a/tests/test_dialect_portability_gate.py
+++ b/tests/test_dialect_portability_gate.py
@@ -239,7 +239,7 @@ def test_python_files_returns_sorted_unique_python_files(tmp_path: Path) -> None
     (scan_dir / "tests" / "test_module.py").write_text("")
 
     files = _python_files([tmp_path, scan_dir])
-    paths = [f.as_posix() for f in files]
+    paths = [f.relative_to(tmp_path).as_posix() for f in files]
 
     # Should include all .py files except those in tests/ or __pycache__
     assert "module1.py" in paths


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1267 -->

### Source Issue #1267: [Route Weight][testgen] Add dialect portability guard tests

Base: main
Head: codex/issue-1267

Source: https://github.com/stranske/Manager-Database/issues/1267

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Add focused tests for:

#### Tasks
- [ ] `_python_files()` excludes `tests`, `__pycache__`, `.venv`, and the guard script itself while accepting direct `.py` files.
- [ ] `_imports_connect_db()` recognizes imports from `adapters.base`, local `connect_db()` definitions, and fallback text matches while ignoring unrelated modules.
- [ ] `scan()` reports SQLite-only tokens in DB-facing files and respects `scan_all=True`.
- [ ] `scan()` suppresses allowlisted tokens only for the exact allowlisted path/token.
- [ ] `documented_audit_paths()` and `allowlist_paths_missing_from_audit()` detect when allowlist entries are absent from the disposition table.
- [ ] `main()` returns non-zero for missing allowlist audit documentation and for unaudited findings.

#### Acceptance Criteria
- [ ] New tests live under `tests/` using existing Manager test conventions.
- [ ] Tests are deterministic and do not require database or network access.
- [ ] Existing guard output remains compatible with CI.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Route Weight candidate

Source: 2026-06-27 focused Route Weight audit follow-up.

`scripts/check_dialect_portability.py` is a repo guardrail that rejects unaudited SQLite-only SQL in Postgres-capable paths. The audit found no dedicated tests covering its AST scan, allowlist, and audit-report checks. This is a deterministic testgen opener using temporary files.

## Scope

Add focused tests for:

- `_python_files()` excludes `tests`, `__pycache__`, `.venv`, and the guard script itself while accepting direct `.py` files.
- `_imports_connect_db()` recognizes imports from `adapters.base`, local `connect_db()` definitions, and fallback text matches while ignoring unrelated modules.
- `scan()` reports SQLite-only tokens in DB-facing files and respects `scan_all=True`.
- `scan()` suppresses allowlisted tokens only for the exact allowlisted path/token.
- `documented_audit_paths()` and `allowlist_paths_missing_from_audit()` detect when allowlist entries are absent from the disposition table.
- `main()` returns non-zero for missing allowlist audit documentation and for unaudited findings.

Use `tmp_path` fixtures and pass `repo_root` explicitly. Do not scan the real repository tree in unit tests.

## Acceptance criteria

- New tests live under `tests/` using existing Manager test conventions.
- Tests are deterministic and do not require database or network access.
- Existing guard output remains compatible with CI.

## Validation

- `python -m pytest tests/test_check_dialect_portability.py -v`



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new top-of-file comment clarifying the bootstrap note for this issue.

* **Tests**
  * Expanded dialect portability gate coverage with new unit tests for path handling, Python file discovery, connection-import detection, audit report parsing, and additional rejection cases (`INSERT OR IGNORE`, `PRAGMA table_info`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->