### PR TITLE
fix: include error_classifier in autofix metrics sparse checkout

### DIFF
--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -1283,6 +1283,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -1353,6 +1354,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -1551,6 +1553,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/runtime_ac_merge_guard.js
             .github/scripts/token_load_balancer.js

--- a/tests/test_github_api_retry_sparse_checkout.py
+++ b/tests/test_github_api_retry_sparse_checkout.py
@@ -1,0 +1,82 @@
+"""Guard sparse-checkout blocks that load github-api-with-retry.js."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = ROOT / ".github" / "workflows"
+SCRIPTS_DIR = ROOT / ".github" / "scripts"
+
+RETRY_SCRIPT = ".github/scripts/github-api-with-retry.js"
+CLASSIFIER_SCRIPT = ".github/scripts/error_classifier.js"
+SPARSE_CHECKOUT_BLOCK = re.compile(
+    r"sparse-checkout:\s*\|\s*\n((?:[ \t]+[^\n]+\n)+)",
+    re.MULTILINE,
+)
+
+
+def _sparse_checkout_paths(block: str) -> list[str]:
+    return [
+        line.strip()
+        for line in block.splitlines()
+        if line.strip() and not line.strip().startswith("sparse-checkout-cone-mode")
+    ]
+
+
+def _iter_sparse_checkout_blocks(workflow_text: str) -> list[list[str]]:
+    return [_sparse_checkout_paths(match.group(1)) for match in SPARSE_CHECKOUT_BLOCK.finditer(workflow_text)]
+
+
+def test_sparse_checkouts_include_error_classifier_with_retry_helper() -> None:
+    offenders: list[str] = []
+
+    for workflow_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        text = workflow_path.read_text(encoding="utf-8")
+        for index, paths in enumerate(_iter_sparse_checkout_blocks(text), start=1):
+            if RETRY_SCRIPT in paths and CLASSIFIER_SCRIPT not in paths:
+                offenders.append(f"{workflow_path.name} block {index}: {paths}")
+
+    assert not offenders, (
+        "github-api-with-retry.js requires ./error_classifier at module load; "
+        "add error_classifier.js to sparse-checkout:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_github_api_retry_imports_with_minimal_sparse_checkout(tmp_path: Path) -> None:
+    """Simulate the Record autofix metrics checkout and require the helper."""
+    checkout_root = tmp_path / "repo"
+    scripts_dir = checkout_root / ".github" / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    for script_name in ("error_classifier.js", "github-api-with-retry.js"):
+        shutil.copy2(SCRIPTS_DIR / script_name, scripts_dir / script_name)
+
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            "require('./.github/scripts/github-api-with-retry.js');",
+        ],
+        cwd=checkout_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_record_autofix_metrics_job_sparse_checkout_paths() -> None:
+    workflow = yaml.safe_load((WORKFLOWS_DIR / "agents-81-gate-followups.yml").read_text(encoding="utf-8"))
+    checkout_step = workflow["jobs"]["metrics"]["steps"][0]
+    paths = _sparse_checkout_paths(checkout_step["with"]["sparse-checkout"])
+
+    assert RETRY_SCRIPT in paths
+    assert CLASSIFIER_SCRIPT in paths


### PR DESCRIPTION
## Summary

- Diagnosis: the **Record autofix metrics** job (and two sibling gate-followups jobs) sparse-checkout `github-api-with-retry.js` but not its hard dependency `error_classifier.js`, causing `Cannot find module './error_classifier'` at require time.
- Fix: add `.github/scripts/error_classifier.js` to sparse-checkout in the `needs-human`, `metrics`, and `guarded-merge` jobs in `agents-81-gate-followups.yml` (matching the `prepare` job pattern).
- Regression: add `tests/test_github_api_retry_sparse_checkout.py` to assert sparse-checkout co-presence across workflows and smoke-test the Node import in a minimal checkout layout.

Closes #1264.

## Test plan

- [x] Direct run of `tests/test_github_api_retry_sparse_checkout.py` test functions (all pass)
- [ ] CI pytest on PR (full suite via reusable workflow)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow reliability by ensuring required helper files are available in relevant automation jobs.
  * Reduced the risk of failures when retry-related automation runs in sparse-checkout environments.

* **Tests**
  * Added coverage for workflow sparse-checkout configurations.
  * Verified that the retry helper can load successfully when only the expected files are checked out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->