### PR TITLE
Codex bootstrap for #1284

### DIFF
--- a/agents/codex-1284.md
+++ b/agents/codex-1284.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1284 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1284 -->

### Source Issue #1284: [Audit] Repair dependency setup validator drift

Base: main
Head: codex/issue-1284

Source: https://github.com/stranske/Manager-Database/issues/1284

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is a **current tooling break**. `scripts/validate_dependency_test_setup.py` looks for `.github/workflows/dependabot-auto-lock.yml` (`scripts/validate_dependency_test_setup.py:35`, `scripts/validate_dependency_test_setup.py:36`, `scripts/validate_dependency_test_setup.py:45`, `scripts/validate_dependency_test_setup.py:46`), but the current workflow file is `.github/workflows/maint-dependabot-auto-lock.yml`. The same script also contains stale checks for non-existent `src/trend_analysis/...` and `streamlit_app/...` paths (`scripts/validate_dependency_test_setup.py:95`, `scripts/validate_dependency_test_setup.py:96`, `scripts/validate_dependency_test_setup.py:107`, `scripts/validate_dependency_test_setup.py:117`). Separately, `scripts/check_test_dependencies.sh` tells users to run `./scripts/run_tests.sh` (`scripts/check_test_dependencies.sh:128`, `scripts/check_test_dependencies.sh:133`, `scripts/check_test_dependencies.sh:134`), but that file does not exist. Missing behavior: local dependency validation should validate this repo's current files and return actionable output.

#### Tasks
- [ ] In `scripts/validate_dependency_test_setup.py:35-46`, update the workflow lookup to `.github/workflows/maint-dependabot-auto-lock.yml` or discover the current dependabot lock workflow by filename/purpose.
- [ ] In `scripts/validate_dependency_test_setup.py:91-126`, remove or replace stale `src/trend_analysis` and `streamlit_app` metadata checks with checks that apply to current Manager-Database files, or delete that check if no longer relevant.
- [ ] Add `tests/test_validate_dependency_test_setup.py` covering the current workflow filename and proving the script does not require stale paths.
- [ ] In `scripts/check_test_dependencies.sh:128-135`, replace the missing `./scripts/run_tests.sh` recommendation with an existing command such as `python -m pytest` or the repo's documented test runner.
- [ ] Add a test or shellcheck-style assertion that every script path recommended by `scripts/check_test_dependencies.sh` exists.

#### Acceptance Criteria
- [ ] Named tests pass: `python -m pytest tests/test_validate_dependency_test_setup.py -q`.
- [ ] The validator command passes on current main after the fix: `python scripts/validate_dependency_test_setup.py` exits 0 and does not print `dependabot-auto-lock.yml not found`.
- [ ] **Deliberate-break gate:** temporarily point the validator back to `.github/workflows/dependabot-auto-lock.yml`. `tests/test_validate_dependency_test_setup.py::test_validator_uses_current_dependabot_lock_workflow` must FAIL. Revert the break before review.
- [ ] `bash scripts/check_test_dependencies.sh` no longer recommends any missing script path; if it prints a command under `scripts/`, `test -f` for that path succeeds.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is a **current tooling break**. `scripts/validate_dependency_test_setup.py` looks for `.github/workflows/dependabot-auto-lock.yml` (`scripts/validate_dependency_test_setup.py:35`, `scripts/validate_dependency_test_setup.py:36`, `scripts/validate_dependency_test_setup.py:45`, `scripts/validate_dependency_test_setup.py:46`), but the current workflow file is `.github/workflows/maint-dependabot-auto-lock.yml`. The same script also contains stale checks for non-existent `src/trend_analysis/...` and `streamlit_app/...` paths (`scripts/validate_dependency_test_setup.py:95`, `scripts/validate_dependency_test_setup.py:96`, `scripts/validate_dependency_test_setup.py:107`, `scripts/validate_dependency_test_setup.py:117`). Separately, `scripts/check_test_dependencies.sh` tells users to run `./scripts/run_tests.sh` (`scripts/check_test_dependencies.sh:128`, `scripts/check_test_dependencies.sh:133`, `scripts/check_test_dependencies.sh:134`), but that file does not exist. Missing behavior: local dependency validation should validate this repo's current files and return actionable output.

## Scope

Update dependency validation scripts to match Manager-Database's current workflow names, dependency source, and test commands.

## Non-Goals

- Do NOT add live network calls to the dependency validator.
- Do NOT validate unrelated `trend_analysis` or `streamlit_app` paths unless those paths are restored in this repo.
- Do NOT duplicate the full lockfile parser from `tests/test_dependency_version_alignment.py`; reuse or keep checks focused.
- Scaffold-only completion does NOT count: renaming one string while the validator still passes over stale non-existent paths or recommends a missing test script is a failure of this issue.

## Tasks

- [ ] In `scripts/validate_dependency_test_setup.py:35-46`, update the workflow lookup to `.github/workflows/maint-dependabot-auto-lock.yml` or discover the current dependabot lock workflow by filename/purpose.
- [ ] In `scripts/validate_dependency_test_setup.py:91-126`, remove or replace stale `src/trend_analysis` and `streamlit_app` metadata checks with checks that apply to current Manager-Database files, or delete that check if no longer relevant.
- [ ] Add `tests/test_validate_dependency_test_setup.py` covering the current workflow filename and proving the script does not require stale paths.
- [ ] In `scripts/check_test_dependencies.sh:128-135`, replace the missing `./scripts/run_tests.sh` recommendation with an existing command such as `python -m pytest` or the repo's documented test runner.
- [ ] Add a test or shellcheck-style assertion that every script path recommended by `scripts/check_test_dependencies.sh` exists.

## Acceptance Criteria

- [ ] Named tests pass: `python -m pytest tests/test_validate_dependency_test_setup.py -q`.
- [ ] The validator command passes on current main after the fix: `python scripts/validate_dependency_test_setup.py` exits 0 and does not print `dependabot-auto-lock.yml not found`.
- [ ] **Deliberate-break gate:** temporarily point the validator back to `.github/workflows/dependabot-auto-lock.yml`. `tests/test_validate_dependency_test_setup.py::test_validator_uses_current_dependabot_lock_workflow` must FAIL. Revert the break before review.
- [ ] `bash scripts/check_test_dependencies.sh` no longer recommends any missing script path; if it prints a command under `scripts/`, `test -f` for that path succeeds.

## Implementation Notes

Audit baseline: `main` at `e7e8f06a9658dbb7106da1fc3c128ecfd836c573` on 2026-06-28.

Confirmed current reproduction from audit: `python scripts/validate_dependency_test_setup.py` exited non-zero because `dependabot-auto-lock.yml` was not found, and `test -f scripts/run_tests.sh` returned false.



</details>

—
PR created automatically to engage Codex.