### PR TITLE
Fix registry-backed chat LLM client selection

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -94,8 +94,20 @@ def _load_slot_config() -> list[SlotDefinition]:
         return _default_slots()
 
     registry = load_model_registry()
+    if not isinstance(payload, dict):
+        logger.warning("Invalid LLM slot config %s; expected object", path)
+        return _default_slots()
+
+    raw_slots = payload.get("slots", [])
+    if not isinstance(raw_slots, list):
+        logger.warning("Invalid LLM slot config %s; expected slots list", path)
+        return _default_slots()
+
     slots: list[SlotDefinition] = []
-    for index, entry in enumerate(payload.get("slots", []), start=1):
+    for index, entry in enumerate(raw_slots, start=1):
+        if not isinstance(entry, dict):
+            logger.warning("Ignoring invalid LLM slot entry in %s; expected object", path)
+            continue
         provider = _normalize_provider(str(entry.get("provider", "")))
         model = str(entry.get("model", "")).strip()
         tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()
@@ -120,7 +132,13 @@ def _apply_slot_env_overrides(slots: list[SlotDefinition]) -> list[SlotDefinitio
         )
         model_override = os.environ.get(f"{ENV_SLOT_PREFIX}{index}_MODEL")
         provider = provider_override or slot.provider
-        model = (model_override or slot.model).strip()
+        model = slot.model.strip()
+        if model_override is not None:
+            candidate_model = model_override.strip()
+            if candidate_model:
+                model = candidate_model
+            else:
+                logger.warning("Ignoring blank LLM slot model override for %s", slot.name)
         if is_model_blocked(provider, model, registry=registry):
             logger.warning("Skipping blocked LLM slot override: %s/%s", provider, model)
             override_requested = provider_override is not None or model_override is not None

--- a/llm/client.py
+++ b/llm/client.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from llm.provider import LLMProviderConfig, create_llm
+from tools import llm_registry as _llm_registry
+from tools.llm_registry import is_model_blocked, load_model_registry, select_model_for_tier
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +23,8 @@ ENV_SLOT_PREFIX = "LANGCHAIN_SLOT"
 
 DEFAULT_TIMEOUT = 60
 DEFAULT_MAX_RETRIES = 2
-DEFAULT_SLOT_CONFIG_PATH = Path(__file__).resolve().parent / "config" / "llm_slots.json"
-LEGACY_SLOT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "llm_slots.json"
+DEFAULT_SLOT_CONFIG_PATH = _llm_registry.DEFAULT_SLOT_CONFIG_PATH
+DEFAULT_MODEL_REGISTRY_CONFIG_PATH = _llm_registry.DEFAULT_MODEL_REGISTRY_CONFIG_PATH
 
 _PROVIDER_ALIASES = {
     "openai": "openai",
@@ -70,8 +72,8 @@ def _normalize_provider(value: str | None) -> str | None:
 
 def _default_slots() -> list[SlotDefinition]:
     return [
-        SlotDefinition(name="slot1", provider="openai", model="gpt-4o-mini"),
-        SlotDefinition(name="slot2", provider="anthropic", model="claude-sonnet-4-20250514"),
+        SlotDefinition(name="slot1", provider="openai", model="gpt-5.4"),
+        SlotDefinition(name="slot2", provider="anthropic", model="claude-sonnet-4-6"),
     ]
 
 
@@ -79,9 +81,7 @@ def _slot_config_path() -> Path:
     configured = os.environ.get(ENV_SLOT_CONFIG)
     if configured:
         return Path(configured)
-    if DEFAULT_SLOT_CONFIG_PATH.is_file():
-        return DEFAULT_SLOT_CONFIG_PATH
-    return LEGACY_SLOT_CONFIG_PATH
+    return DEFAULT_SLOT_CONFIG_PATH
 
 
 def _load_slot_config() -> list[SlotDefinition]:
@@ -93,11 +93,18 @@ def _load_slot_config() -> list[SlotDefinition]:
     except (OSError, json.JSONDecodeError):
         return _default_slots()
 
+    registry = load_model_registry()
     slots: list[SlotDefinition] = []
     for index, entry in enumerate(payload.get("slots", []), start=1):
         provider = _normalize_provider(str(entry.get("provider", "")))
         model = str(entry.get("model", "")).strip()
+        tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()
+        if provider and not model and tier:
+            model = select_model_for_tier(provider=provider, tier=tier, registry=registry) or ""
         if not provider or not model:
+            continue
+        if is_model_blocked(provider, model, registry=registry):
+            logger.warning("Skipping blocked LLM model in slot config: %s/%s", provider, model)
             continue
         name = str(entry.get("name") or f"slot{index}").strip() or f"slot{index}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
@@ -105,17 +112,28 @@ def _load_slot_config() -> list[SlotDefinition]:
 
 
 def _apply_slot_env_overrides(slots: list[SlotDefinition]) -> list[SlotDefinition]:
+    registry = load_model_registry()
     updated: list[SlotDefinition] = []
     for index, slot in enumerate(slots, start=1):
         provider_override = _normalize_provider(
             os.environ.get(f"{ENV_SLOT_PREFIX}{index}_PROVIDER")
         )
         model_override = os.environ.get(f"{ENV_SLOT_PREFIX}{index}_MODEL")
+        provider = provider_override or slot.provider
+        model = (model_override or slot.model).strip()
+        if is_model_blocked(provider, model, registry=registry):
+            logger.warning("Skipping blocked LLM slot override: %s/%s", provider, model)
+            override_requested = provider_override is not None or model_override is not None
+            if override_requested and not is_model_blocked(
+                slot.provider, slot.model, registry=registry
+            ):
+                updated.append(slot)
+            continue
         updated.append(
             SlotDefinition(
                 name=slot.name,
-                provider=provider_override or slot.provider,
-                model=(model_override or slot.model).strip(),
+                provider=provider,
+                model=model,
             )
         )
     return updated
@@ -207,13 +225,25 @@ def build_chat_client(
         selected_model = (model or os.environ.get(ENV_MODEL) or "").strip()
         if not selected_model:
             selected_model = _default_slots()[0].model
+        if is_model_blocked(selected_provider, selected_model):
+            logger.warning("Refusing blocked LLM model: %s/%s", selected_provider, selected_model)
+            return None
         return _build_for(selected_provider, selected_model, selected_timeout, selected_retries)
 
     slots = _resolve_slots()
+    registry = load_model_registry()
     for index, slot in enumerate(slots, start=1):
         slot_model = slot.model
         if index == 1 and (model or os.environ.get(ENV_MODEL)):
             slot_model = (model or os.environ.get(ENV_MODEL) or slot.model).strip()
+            if is_model_blocked(slot.provider, slot_model, registry=registry):
+                logger.warning(
+                    "Skipping blocked LLM model override: %s/%s", slot.provider, slot_model
+                )
+                slot_model = slot.model
+        if is_model_blocked(slot.provider, slot_model, registry=registry):
+            logger.warning("Skipping blocked LLM model: %s/%s", slot.provider, slot_model)
+            continue
         client_info = _build_for(slot.provider, slot_model, selected_timeout, selected_retries)
         if client_info is not None:
             return client_info

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -150,7 +150,22 @@ def test_blocked_slot_env_model_falls_back_to_slot_model(monkeypatch, tmp_path):
     assert captured == ["gpt-5.4"]
 
 
-def test_invalid_slot_config_shape_falls_back_to_defaults(monkeypatch, tmp_path):
+def test_invalid_slot_config_slots_shape_falls_back_to_defaults(monkeypatch, tmp_path):
+    config_path = tmp_path / "llm_slots.json"
+    config_path.write_text(json.dumps({"slots": {"name": "slot1"}}))
+    monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
+    monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("MANAGER_DB_ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(llm_client, "create_llm", lambda config: _FakeClient())
+
+    client_info = llm_client.build_chat_client()
+
+    assert client_info is not None
+    assert client_info.provider == "openai"
+    assert client_info.model == "gpt-5.4"
+
+
+def test_invalid_slot_config_entry_falls_back_to_defaults(monkeypatch, tmp_path):
     config_path = tmp_path / "llm_slots.json"
     config_path.write_text(json.dumps({"slots": [None]}))
     monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -18,7 +18,7 @@ def test_build_chat_client_returns_openai_when_key_available(monkeypatch):
 
     assert client_info is not None
     assert client_info.provider == "openai"
-    assert client_info.model == "gpt-4o-mini"
+    assert client_info.model == "gpt-5.4"
 
 
 def test_build_chat_client_falls_back_to_anthropic(monkeypatch):
@@ -30,7 +30,7 @@ def test_build_chat_client_falls_back_to_anthropic(monkeypatch):
 
     assert client_info is not None
     assert client_info.provider == "anthropic"
-    assert client_info.model == "claude-sonnet-4-20250514"
+    assert client_info.model == "claude-sonnet-4-6"
 
 
 def test_build_chat_client_returns_none_when_no_keys(monkeypatch):
@@ -82,3 +82,36 @@ def test_slot_config_loading_from_json_file(monkeypatch, tmp_path):
     assert client_info is not None
     assert client_info.provider == "anthropic"
     assert client_info.model == "claude-test"
+
+
+def test_blocked_slot_model_is_not_selected(monkeypatch, tmp_path):
+    config_path = tmp_path / "llm_slots.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "slots": [
+                    {"name": "blocked", "provider": "openai", "model": "gpt-4o-mini"},
+                    {"name": "approved", "provider": "openai", "model": "gpt-5.4"},
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
+    monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("MANAGER_DB_ANTHROPIC_API_KEY", raising=False)
+    captured = []
+
+    def _fake_create_llm(config):
+        captured.append(config.model_name)
+        if config.model_name == "gpt-4o-mini":
+            raise AssertionError("blocked model reached create_llm")
+        return _FakeClient()
+
+    monkeypatch.setattr(llm_client, "create_llm", _fake_create_llm)
+
+    client_info = llm_client.build_chat_client()
+
+    assert client_info is not None
+    assert client_info.provider == "openai"
+    assert client_info.model == "gpt-5.4"
+    assert captured == ["gpt-5.4"]

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -115,3 +115,82 @@ def test_blocked_slot_model_is_not_selected(monkeypatch, tmp_path):
     assert client_info.provider == "openai"
     assert client_info.model == "gpt-5.4"
     assert captured == ["gpt-5.4"]
+
+
+def test_blocked_slot_env_model_falls_back_to_slot_model(monkeypatch, tmp_path):
+    config_path = tmp_path / "llm_slots.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "slots": [
+                    {"name": "approved", "provider": "openai", "model": "gpt-5.4"},
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
+    monkeypatch.setenv("LANGCHAIN_SLOT1_MODEL", "gpt-4o-mini")
+    monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("MANAGER_DB_ANTHROPIC_API_KEY", raising=False)
+    captured = []
+
+    def _fake_create_llm(config):
+        captured.append(config.model_name)
+        if config.model_name == "gpt-4o-mini":
+            raise AssertionError("blocked override reached create_llm")
+        return _FakeClient()
+
+    monkeypatch.setattr(llm_client, "create_llm", _fake_create_llm)
+
+    client_info = llm_client.build_chat_client()
+
+    assert client_info is not None
+    assert client_info.provider == "openai"
+    assert client_info.model == "gpt-5.4"
+    assert captured == ["gpt-5.4"]
+
+
+def test_invalid_slot_config_shape_falls_back_to_defaults(monkeypatch, tmp_path):
+    config_path = tmp_path / "llm_slots.json"
+    config_path.write_text(json.dumps({"slots": [None]}))
+    monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
+    monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("MANAGER_DB_ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(llm_client, "create_llm", lambda config: _FakeClient())
+
+    client_info = llm_client.build_chat_client()
+
+    assert client_info is not None
+    assert client_info.provider == "openai"
+    assert client_info.model == "gpt-5.4"
+
+
+def test_blank_slot_env_model_falls_back_to_slot_model(monkeypatch, tmp_path):
+    config_path = tmp_path / "llm_slots.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "slots": [
+                    {"name": "approved", "provider": "openai", "model": "gpt-5.4"},
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
+    monkeypatch.setenv("LANGCHAIN_SLOT1_MODEL", "   ")
+    monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("MANAGER_DB_ANTHROPIC_API_KEY", raising=False)
+    captured = []
+
+    def _fake_create_llm(config):
+        captured.append(config.model_name)
+        return _FakeClient()
+
+    monkeypatch.setattr(llm_client, "create_llm", _fake_create_llm)
+
+    client_info = llm_client.build_chat_client()
+
+    assert client_info is not None
+    assert client_info.provider == "openai"
+    assert client_info.model == "gpt-5.4"
+    assert captured == ["gpt-5.4"]


### PR DESCRIPTION
Closes #1274

## Summary
- route `llm.client` slot loading through the root `config/llm_slots.json` path instead of the stale package-local slot file
- skip or reject models blocked by `config/model_registry.json`, including slot configs and env overrides
- update LLM client tests to assert current approved defaults and blocked-slot rejection before provider construction

## Validation
- `python -m pytest tests/test_llm_client.py tests/test_chat_api.py::test_build_chat_client_info_prefers_llm_client_module -q`
- `black --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' llm/client.py tests/test_llm_client.py`\n- `MANAGER_DB_OPENAI_API_KEY=test python - <<'PY'\nfrom llm.client import build_chat_client\ninfo = build_chat_client()\nprint(info.model if info else 'none')\nPY` -> `gpt-5.4`\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blocked-model handling by filtering blocked candidates earlier during slot resolution and chat client creation.
  * More consistent fallback to default slots when slot configs are missing, invalid, or contain no usable models.
  * Environment slot overrides now respect blocked-model rules and ignore blank overrides with a warning.

* **New Features**
  * Added tier-aware model selection via the shared model registry.
  * Updated default slot model choices to newer approved options.

* **Tests**
  * Expanded coverage for blocked models, invalid slot shapes/entries, and environment override behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->