### PR TITLE
Fix static-safe WASM demo page routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ autofix_report_enriched.json
 artifacts/langsmith/
 artifacts/daily_diff/
 artifacts/digest/
+web/adapters/
+web/api/
+web/daily-report/
+web/embeddings.py
+web/manager_demo.sqlite
+web/search/
+web/ui/
+web/upload/
+web/utils/

--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -39,12 +39,15 @@ python scripts/build_wasm_demo.py
 python -m http.server 8000 -d web
 ```
 
-Then open `http://localhost:8000/index.html`. The page loads stlite/Pyodide in
-the browser, sets `UI_OFFLINE=1`, leaves `DB_URL` unset, points `DB_PATH` at the
-bundled `manager_demo.sqlite`, and renders Dashboard, Daily Report, Search, and
-Upload against seeded synthetic rows. The Upload page uses `USE_SIMPLE_EMBED=1`
-so no model download is attempted. Do not use this bundle for proprietary data
-on a public host; rebuild it only from synthetic or explicitly redacted inputs.
+Then open `http://localhost:8000/index.html` for Dashboard. The build also
+generates static-server-safe entrypoints for the other pages:
+`http://localhost:8000/daily-report/`, `http://localhost:8000/search/`, and
+`http://localhost:8000/upload/`. The page loads stlite/Pyodide in the browser,
+sets `UI_OFFLINE=1`, leaves `DB_URL` unset, points `DB_PATH` at the bundled
+`manager_demo.sqlite`, and renders Dashboard, Daily Report, Search, and Upload
+against seeded synthetic rows. The Upload page uses `USE_SIMPLE_EMBED=1` so no
+model download is attempted. Do not use this bundle for proprietary data on a
+public host; rebuild it only from synthetic or explicitly redacted inputs.
 
 The `schema.sql` file defines an `api_usage` table used for cost telemetry. Apply it to the Postgres container once it is running:
 

--- a/scripts/build_wasm_demo.py
+++ b/scripts/build_wasm_demo.py
@@ -16,6 +16,11 @@ from scripts.seed_readiness_data import READINESS_DOC_FILENAME, READINESS_DOC_TE
 
 DEFAULT_OUTPUT_DIR = Path("web")
 DEFAULT_DB_NAME = "manager_demo.sqlite"
+STATIC_ROUTE_PATHS = ("daily-report", "search", "upload")
+STATIC_SHELL_FILES = (
+    Path("web/index.html"),
+    Path("web/wasm_app.py"),
+)
 TEXT_BUNDLE_FILES = [
     Path("embeddings.py"),
     Path("ui/__init__.py"),
@@ -33,6 +38,32 @@ TEXT_BUNDLE_FILES = [
     Path("utils/__init__.py"),
     Path("utils/extract.py"),
 ]
+
+
+def _copy_static_shell(output_dir: Path) -> None:
+    """Copy the static shell when building into a separate output directory."""
+    for source in STATIC_SHELL_FILES:
+        target = output_dir / source.name
+        if source.resolve() == target.resolve():
+            continue
+        shutil.copy2(source, target)
+
+
+def _route_shell_html(index_html: str) -> str:
+    if "<base " in index_html:
+        return index_html
+    return index_html.replace("<head>", '<head>\n    <base href="../" />', 1)
+
+
+def _write_static_route_entrypoints(output_dir: Path) -> None:
+    index_path = output_dir / "index.html"
+    if not index_path.exists():
+        return
+    route_html = _route_shell_html(index_path.read_text(encoding="utf-8"))
+    for route_path in STATIC_ROUTE_PATHS:
+        route_index = output_dir / route_path / "index.html"
+        route_index.parent.mkdir(parents=True, exist_ok=True)
+        route_index.write_text(route_html, encoding="utf-8")
 
 
 def _create_schema(conn: sqlite3.Connection) -> None:
@@ -251,6 +282,8 @@ def build_wasm_demo(output_dir: Path = DEFAULT_OUTPUT_DIR) -> Path:
         target = output_dir / source
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, target)
+    _copy_static_shell(output_dir)
+    _write_static_route_entrypoints(output_dir)
     return db_path
 
 

--- a/tests/web/test_wasm_static_routes.py
+++ b/tests/web/test_wasm_static_routes.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import contextlib
+import functools
+import http.server
+import socketserver
+import threading
+from urllib.request import urlopen
+
+from scripts.build_wasm_demo import STATIC_ROUTE_PATHS, build_wasm_demo
+
+
+@contextlib.contextmanager
+def _static_server(directory):
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=directory)
+    with socketserver.TCPServer(("127.0.0.1", 0), handler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield f"http://127.0.0.1:{server.server_address[1]}"
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+
+def _fetch_text(url: str) -> tuple[int, str]:
+    with urlopen(url, timeout=10) as response:
+        return response.status, response.read().decode("utf-8")
+
+
+def test_wasm_demo_static_routes_serve_stlite_shell(tmp_path) -> None:
+    web_dir = tmp_path / "web"
+    build_wasm_demo(web_dir)
+
+    with _static_server(web_dir) as base_url:
+        for route in ("index.html", *(f"{path}/" for path in STATIC_ROUTE_PATHS)):
+            status, body = _fetch_text(f"{base_url}/{route}")
+            assert status == 200
+            assert "Manager-Database Offline Demo" in body
+            assert "stlite.js" in body
+            assert "Error response" not in body
+
+
+def test_wasm_demo_static_route_entrypoints_use_parent_base(tmp_path) -> None:
+    web_dir = tmp_path / "web"
+    build_wasm_demo(web_dir)
+
+    for route in STATIC_ROUTE_PATHS:
+        html = (web_dir / route / "index.html").read_text(encoding="utf-8")
+        assert '<base href="../" />' in html
+        assert "./vendor/stlite/browser-0.80.4/build/stlite.js" in html

--- a/tests/web/test_wasm_static_routes.py
+++ b/tests/web/test_wasm_static_routes.py
@@ -28,6 +28,11 @@ def _fetch_text(url: str) -> tuple[int, str]:
         return response.status, response.read().decode("utf-8")
 
 
+def _fetch_bytes(url: str) -> tuple[int, bytes]:
+    with urlopen(url, timeout=10) as response:
+        return response.status, response.read()
+
+
 def test_wasm_demo_static_routes_serve_stlite_shell(tmp_path) -> None:
     web_dir = tmp_path / "web"
     build_wasm_demo(web_dir)
@@ -39,6 +44,9 @@ def test_wasm_demo_static_routes_serve_stlite_shell(tmp_path) -> None:
             assert "Manager-Database Offline Demo" in body
             assert "stlite.js" in body
             assert "Error response" not in body
+        status, body = _fetch_bytes(f"{base_url}/wasm_app.py")
+        assert status == 200
+        assert b"Offline stlite entrypoint" in body
 
 
 def test_wasm_demo_static_route_entrypoints_use_parent_base(tmp_path) -> None:
@@ -48,4 +56,5 @@ def test_wasm_demo_static_route_entrypoints_use_parent_base(tmp_path) -> None:
     for route in STATIC_ROUTE_PATHS:
         html = (web_dir / route / "index.html").read_text(encoding="utf-8")
         assert '<base href="../" />' in html
-        assert "./vendor/stlite/browser-0.80.4/build/stlite.js" in html
+        assert "./vendor/stlite/browser-" in html
+        assert "/build/stlite.js" in html


### PR DESCRIPTION
Closes #1275

## Summary
- generate static-server-safe entrypoints for the offline stlite demo page routes
- copy the static shell when building to an alternate output directory and ignore default generated WASM output
- document Dashboard, Daily Report, Search, and Upload URLs for `python -m http.server -d web`

## Validation
- `python -m pytest tests/web/test_wasm_static_routes.py tests/test_wasm_demo_build.py tests/web/test_wasm_no_external_cdn.py -q`
- `black --check --line-length 100 --exclude '(\.workflows-lib|node_modules)' scripts/build_wasm_demo.py tests/web/test_wasm_static_routes.py`
- `python scripts/build_wasm_demo.py`; `python -m http.server 8123 -d web`; curl `http://127.0.0.1:8123/index.html` and `http://127.0.0.1:8123/search/` both returned HTTP 200 stlite shell responses


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the offline browser demo static build so additional pages open correctly from the generated entry points.
  * Route-specific entry HTML now loads with the proper parent-relative base, improving navigation across Dashboard, Daily Report, Search, and Upload.

* **Documentation**
  * Updated offline demo instructions and expanded details on the static/WASM build behavior and recommended browser-side settings, including a public-host warning.

* **Tests**
  * Added integration tests that build, serve, and validate offline static routes and entrypoint contents (including correct base-path usage).

* **Chores**
  * Updated ignore rules for additional generated web demo artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->