### PR TITLE
Codex bootstrap for #1274

### DIFF
--- a/agents/codex-1274.md
+++ b/agents/codex-1274.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1274 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1274 -->

### Source Issue #1274: [Audit] Route chat LLM client through approved model registry

Base: main
Head: codex/issue-1274

Source: https://github.com/stranske/Manager-Database/issues/1274

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is a **current policy break**. The chat API imports `llm.client` first (`api/chat.py:450`, `api/chat.py:454`, `api/chat.py:460`, `api/chat.py:463`) and only falls back to `tools.langchain_client` when `llm.client` is missing (`api/chat.py:466`, `api/chat.py:468`). `llm.client` prefers `llm/config/llm_slots.json` (`llm/client.py:24`, `llm/client.py:78`, `llm/client.py:82`, `llm/client.py:83`), whose first slot is `openai/gpt-4o-mini` (`llm/config/llm_slots.json:3`). The root model registry explicitly marks `gpt-4o-mini` as blocked (`config/model_registry.json:150`, `config/model_registry.json:156`, `config/model_registry.json:157`). Missing behavior: the runtime chat path must not select a model that the repo's approved registry blocks.

#### Tasks
- [ ] In `llm/client.py:24-25` and `llm/client.py:78-90`, stop preferring the stale package-local slot file over the approved root slot configuration, or validate the package-local file through the root registry before use.
- [ ] In `llm/client.py:71-75` and `llm/client.py:96-104`, make default and loaded slots skip or reject models blocked by `config/model_registry.json`.
- [ ] In `api/chat.py:450-468`, keep the API path on the same registry-backed behavior so importing `llm.client` cannot bypass blocked-model checks.
- [ ] Update `tests/test_llm_client.py:12-22` and `tests/test_llm_client.py:24-33` so the default selected models are approved current slots, not `gpt-4o-mini` or stale Claude names.
- [ ] Add `tests/test_llm_client.py::test_blocked_slot_model_is_not_selected` that monkeypatches a slot config containing `openai/gpt-4o-mini` and asserts `build_chat_client()` skips or returns `None` rather than constructing that model.

#### Acceptance Criteria
- [ ] Named tests pass: `python -m pytest tests/test_llm_client.py tests/test_chat_api.py::test_build_chat_client_info_prefers_llm_client_module -q`.
- [ ] **Deliberate-break gate:** temporarily reintroduce `openai/gpt-4o-mini` as the first eligible slot in the active slot config. `tests/test_llm_client.py::test_blocked_slot_model_is_not_selected` must FAIL if `create_llm` is called for that model. Revert the break before review.
- [ ] Runtime smoke with fake keys does not select the blocked model: `MANAGER_DB_OPENAI_API_KEY=test python - <<'PY'
from llm.client import build_chat_client
print(build_chat_client().model if build_chat_client() else 'none')
PY` prints an approved non-blocked model or `none`, never `gpt-4o-mini`.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is a **current policy break**. The chat API imports `llm.client` first (`api/chat.py:450`, `api/chat.py:454`, `api/chat.py:460`, `api/chat.py:463`) and only falls back to `tools.langchain_client` when `llm.client` is missing (`api/chat.py:466`, `api/chat.py:468`). `llm.client` prefers `llm/config/llm_slots.json` (`llm/client.py:24`, `llm/client.py:78`, `llm/client.py:82`, `llm/client.py:83`), whose first slot is `openai/gpt-4o-mini` (`llm/config/llm_slots.json:3`). The root model registry explicitly marks `gpt-4o-mini` as blocked (`config/model_registry.json:150`, `config/model_registry.json:156`, `config/model_registry.json:157`). Missing behavior: the runtime chat path must not select a model that the repo's approved registry blocks.

## Scope

Make `llm.client` and the `api/chat.py` chat-client path use the same approved-slot and blocked-model checks as `tools/langchain_client.py`, or route both through one shared registry-backed implementation. Keep environment overrides, slot fallback, and no-key behavior intact.

## Non-Goals

- Do NOT introduce a new model registry file; use `config/model_registry.json` and `config/llm_slots.json` or the existing helper layer under `tools/llm_registry.py`.
- Do NOT remove the `llm.client.build_chat_client()` public API unless every import in `llm/__init__.py:3` and tests using it are updated.
- Do NOT make live provider calls in tests; use the existing fake `create_llm` pattern in `tests/test_llm_client.py`.
- Scaffold-only completion does NOT count: deleting `llm/config/llm_slots.json` or changing only a default string without asserting blocked-model rejection is a failure of this issue.

## Tasks

- [ ] In `llm/client.py:24-25` and `llm/client.py:78-90`, stop preferring the stale package-local slot file over the approved root slot configuration, or validate the package-local file through the root registry before use.
- [ ] In `llm/client.py:71-75` and `llm/client.py:96-104`, make default and loaded slots skip or reject models blocked by `config/model_registry.json`.
- [ ] In `api/chat.py:450-468`, keep the API path on the same registry-backed behavior so importing `llm.client` cannot bypass blocked-model checks.
- [ ] Update `tests/test_llm_client.py:12-22` and `tests/test_llm_client.py:24-33` so the default selected models are approved current slots, not `gpt-4o-mini` or stale Claude names.
- [ ] Add `tests/test_llm_client.py::test_blocked_slot_model_is_not_selected` that monkeypatches a slot config containing `openai/gpt-4o-mini` and asserts `build_chat_client()` skips or returns `None` rather than constructing that model.

## Acceptance Criteria

- [ ] Named tests pass: `python -m pytest tests/test_llm_client.py tests/test_chat_api.py::test_build_chat_client_info_prefers_llm_client_module -q`.
- [ ] **Deliberate-break gate:** temporarily reintroduce `openai/gpt-4o-mini` as the first eligible slot in the active slot config. `tests/test_llm_client.py::test_blocked_slot_model_is_not_selected` must FAIL if `create_llm` is called for that model. Revert the break before review.
- [ ] Runtime smoke with fake keys does not select the blocked model: `MANAGER_DB_OPENAI_API_KEY=test python - <<'PY'
from llm.client import build_chat_client
print(build_chat_client().model if build_chat_client() else 'none')
PY` prints an approved non-blocked model or `none`, never `gpt-4o-mini`.

## Implementation Notes

Audit baseline: `main` at `e7e8f06a9658dbb7106da1fc3c128ecfd836c573` on 2026-06-28.

Confirmed current reproduction: `tests/test_llm_client.py:17-22` currently expects `gpt-4o-mini` when an OpenAI key is present.



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new markdown note to support issue-related bootstrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->