### PR TITLE
Fix Companies House adapter authentication

### DIFF
--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -76,6 +76,10 @@ Feel free to open issues or pull requests as you iterate.
    Use the Python command above for a one-off manual run; use the Prefect deployment command
    to activate the `edgar-nightly` schedule.
 
+   The UK Companies House adapter uses HTTP Basic auth for live filing-history
+   and document requests. Set `COMPANIES_HOUSE_API_KEY` to the Companies House
+   API key before running `etl/uk_flow.py` or the `uk-nightly` deployment.
+
 4. Generate the local analyst digest without sending email:
    ```bash
    DIGEST_DRY_RUN=true DIGEST_OUTPUT_PATH=/tmp/manager-digest.txt python etl/digest_flow.py

--- a/adapters/uk.py
+++ b/adapters/uk.py
@@ -12,6 +12,7 @@ Parsed fields:
 
 from __future__ import annotations
 
+import os
 import re
 import zlib
 from datetime import datetime
@@ -21,15 +22,30 @@ import httpx
 from .base import tracked_call
 
 BASE_URL = "https://api.company-information.service.gov.uk"
+API_KEY_ENV = "COMPANIES_HOUSE_API_KEY"
+
+
+class CompaniesHouseConfigError(RuntimeError):
+    """Raised when live Companies House requests lack required credentials."""
+
+
+def _companies_house_auth() -> tuple[str, str]:
+    api_key = os.getenv(API_KEY_ENV, "").strip()
+    if not api_key:
+        raise CompaniesHouseConfigError(
+            f"{API_KEY_ENV} must be set for Companies House API requests"
+        )
+    return (api_key, "")
 
 
 async def list_new_filings(company_number: str, since: str):
     """List filing history items since a date (YYYY-MM-DD)."""
     url = f"{BASE_URL}/company/{company_number}/filing-history"
     params = {"category": "annual-return", "since": since}
+    auth = _companies_house_auth()
     async with httpx.AsyncClient() as client:
         async with tracked_call("uk", url) as log:
-            r = await client.get(url, params=params)
+            r = await client.get(url, params=params, auth=auth)
             log(r)
         r.raise_for_status()
         data = r.json()
@@ -48,9 +64,10 @@ async def list_new_filings(company_number: str, since: str):
 async def download(filing: dict[str, str]):
     """Download the filing document."""
     url = f"{BASE_URL}/filing-history/{filing['transaction_id']}/document?format=pdf"
+    auth = _companies_house_auth()
     async with httpx.AsyncClient() as client:
         async with tracked_call("uk", url) as log:
-            r = await client.get(url)
+            r = await client.get(url, auth=auth)
             log(r)
         r.raise_for_status()
         return r.content

--- a/tests/test_uk_adapter.py
+++ b/tests/test_uk_adapter.py
@@ -180,6 +180,7 @@ async def test_list_new_filings_filters_and_maps(monkeypatch):
             {"transaction_id": "t2", "date": "2023-12-31T09:00:00Z"},
         ]
     }
+    calls = []
 
     @asynccontextmanager
     async def dummy_tracked_call(*args, **kwargs):
@@ -196,8 +197,10 @@ async def test_list_new_filings_filters_and_maps(monkeypatch):
             return False
 
         async def get(self, *args, **kwargs):
+            calls.append((args, kwargs))
             return httpx.Response(200, request=httpx.Request("GET", "x"), json=payload)
 
+    monkeypatch.setenv("COMPANIES_HOUSE_API_KEY", "test-key")
     monkeypatch.setattr(uk.httpx, "AsyncClient", DummyClient)
     monkeypatch.setattr(uk, "tracked_call", dummy_tracked_call)
 
@@ -210,11 +213,34 @@ async def test_list_new_filings_filters_and_maps(monkeypatch):
             "date": "2024-01-02",
         }
     ]
+    assert calls == [
+        (
+            (f"{uk.BASE_URL}/company/12345678/filing-history",),
+            {
+                "params": {"category": "annual-return", "since": "2024-01-01"},
+                "auth": ("test-key", ""),
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_new_filings_requires_companies_house_api_key(monkeypatch):
+    class DummyClient:
+        async def __aenter__(self):
+            raise AssertionError("network client should not be opened without credentials")
+
+    monkeypatch.delenv("COMPANIES_HOUSE_API_KEY", raising=False)
+    monkeypatch.setattr(uk.httpx, "AsyncClient", DummyClient)
+
+    with pytest.raises(uk.CompaniesHouseConfigError, match="COMPANIES_HOUSE_API_KEY"):
+        await uk.list_new_filings("12345678", "2024-01-01")
 
 
 @pytest.mark.asyncio
 async def test_download_returns_pdf_bytes(monkeypatch):
     pdf_bytes = b"%PDF-1.4\n%fake\n%%EOF"
+    calls = []
 
     @asynccontextmanager
     async def dummy_tracked_call(*args, **kwargs):
@@ -231,14 +257,22 @@ async def test_download_returns_pdf_bytes(monkeypatch):
             return False
 
         async def get(self, *args, **kwargs):
+            calls.append((args, kwargs))
             return httpx.Response(200, request=httpx.Request("GET", "x"), content=pdf_bytes)
 
+    monkeypatch.setenv("COMPANIES_HOUSE_API_KEY", "test-key")
     monkeypatch.setattr(uk.httpx, "AsyncClient", DummyClient)
     monkeypatch.setattr(uk, "tracked_call", dummy_tracked_call)
 
     result = await uk.download({"transaction_id": "t1"})
 
     assert result == pdf_bytes
+    assert calls == [
+        (
+            (f"{uk.BASE_URL}/filing-history/t1/document?format=pdf",),
+            {"auth": ("test-key", "")},
+        )
+    ]
 
 
 def test_unescape_pdf_string_and_date_helpers_cover_branches():

--- a/tests/test_uk_flow.py
+++ b/tests/test_uk_flow.py
@@ -48,10 +48,16 @@ class _MockCompaniesHouseClient:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    async def get(self, url: str, params: dict[str, str] | None = None):
+    async def get(
+        self,
+        url: str,
+        params: dict[str, str] | None = None,
+        auth: tuple[str, str] | None = None,
+    ):
         request = httpx.Request("GET", url, params=params)
         if url.endswith("/filing-history"):
             assert params == {"category": "annual-return", "since": "2024-01-01"}
+            assert auth == ("test-key", "")
             return httpx.Response(
                 200,
                 request=request,
@@ -65,6 +71,7 @@ class _MockCompaniesHouseClient:
                 },
             )
         if "document?format=pdf" in url:
+            assert auth == ("test-key", "")
             pdf = (
                 b"%PDF-1.4\n"
                 b"(Confirmation Statement CS01)\n"
@@ -168,6 +175,7 @@ async def test_uk_flow_mocks_companies_house_api_and_inserts_filing(tmp_path, mo
     monkeypatch.setattr(ingest_flow, "get_adapter", lambda _name: uk_adapter)
     monkeypatch.setattr(uk_adapter.httpx, "AsyncClient", _MockCompaniesHouseClient)
     monkeypatch.setattr(uk_adapter, "tracked_call", dummy_tracked_call)
+    monkeypatch.setenv("COMPANIES_HOUSE_API_KEY", "test-key")
     monkeypatch.setattr(ingest_flow.S3, "put_object", lambda **_kwargs: None)
     monkeypatch.setattr(ingest_flow, "store_document", lambda _raw: None)
 


### PR DESCRIPTION
Closes #1276

## Summary
- require COMPANIES_HOUSE_API_KEY before live Companies House requests
- pass HTTP Basic auth to filing-history and document download calls
- extend UK adapter tests to assert auth and document the env var

## Validation
- COMPANIES_HOUSE_API_KEY=test python -m pytest tests/test_uk_adapter.py::test_list_new_filings_filters_and_maps tests/test_uk_adapter.py::test_download_returns_pdf_bytes -q
- COMPANIES_HOUSE_API_KEY=test python -m pytest tests/test_uk_adapter.py -q
- black --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' adapters/uk.py tests/test_uk_adapter.py\n- deliberate-break: removing the filing-history auth kwarg makes tests/test_uk_adapter.py::test_list_new_filings_filters_and_maps fail on the missing auth tuple\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UK Companies House live filing-history and document downloads now use API-key authentication.

* **Bug Fixes**
  * Added a clearer failure when the API key is missing or blank, preventing incomplete/unauthenticated ETL runs.
  * Updated UK ETL request handling so both filing lookups and PDF downloads send the required authentication.

* **Documentation**
  * Documented the required `COMPANIES_HOUSE_API_KEY` setup for running the UK ETL flow and nightly deployment.

* **Tests**
  * Strengthened UK adapter and UK flow tests to verify authentication and request parameters end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->