### PR TITLE
Emit large delta alerts from daily diff flow

### DIFF
--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -13,6 +13,8 @@ from prefect import flow, task
 from prefect.schedules import Cron
 
 from adapters.base import connect_db
+from alerts.integration import evaluate_and_record_alerts
+from alerts.models import AlertEvent
 from diff_holdings import diff_holdings
 from etl.logging_setup import configure_logging, log_outcome
 from tools.registry import run_contract_fields
@@ -197,6 +199,76 @@ def _daily_diff_data_quality(conn: Any, report_date: str) -> dict[str, Any]:
     }
 
 
+def _fetch_inserted_diffs(conn: Any, manager_id: int, report_date: str) -> list[dict[str, Any]]:
+    ph = _placeholder(conn)
+    rows = conn.execute(
+        "SELECT manager_id, report_date, cusip, name_of_issuer, delta_type, "
+        "shares_prev, shares_curr, value_prev, value_curr "
+        "FROM daily_diffs WHERE manager_id = "
+        f"{ph} AND report_date = {ph} ORDER BY cusip, delta_type",
+        (manager_id, report_date),
+    ).fetchall()
+    return [
+        {
+            "manager_id": row[0],
+            "report_date": row[1],
+            "cusip": row[2],
+            "name_of_issuer": row[3],
+            "delta_type": row[4],
+            "shares_prev": row[5],
+            "shares_curr": row[6],
+            "value_prev": row[7],
+            "value_curr": row[8],
+        }
+        for row in rows
+    ]
+
+
+def _large_delta_event_from_diff(row: dict[str, Any]) -> AlertEvent:
+    raw_delta_type = str(row["delta_type"]).upper()
+    normalized_delta_type = {
+        "ADD": "buy",
+        "INCREASE": "buy",
+        "EXIT": "sell",
+        "DECREASE": "sell",
+    }.get(raw_delta_type, raw_delta_type.lower())
+    value_prev = row.get("value_prev")
+    value_curr = row.get("value_curr")
+    value_usd = None
+    if value_prev is not None and value_curr is not None:
+        value_usd = abs(float(value_curr) - float(value_prev))
+    elif value_curr is not None:
+        value_usd = abs(float(value_curr))
+    elif value_prev is not None:
+        value_usd = abs(float(value_prev))
+
+    payload = {
+        "manager_id": row["manager_id"],
+        "report_date": row["report_date"],
+        "cusip": row["cusip"],
+        "name_of_issuer": row.get("name_of_issuer"),
+        "delta_type": normalized_delta_type,
+        "raw_delta_type": raw_delta_type,
+        "shares_prev": row.get("shares_prev"),
+        "shares_curr": row.get("shares_curr"),
+        "value_prev": value_prev,
+        "value_curr": value_curr,
+        "value_usd": value_usd,
+    }
+    return AlertEvent(
+        event_type="large_delta",
+        manager_id=int(row["manager_id"]),
+        payload=payload,
+    )
+
+
+def _record_large_delta_alerts(conn: Any, manager_id: int, report_date: str) -> list[int]:
+    alert_ids: list[int] = []
+    for row in _fetch_inserted_diffs(conn, manager_id, report_date):
+        alert_ids.extend(evaluate_and_record_alerts(conn, _large_delta_event_from_diff(row)))
+    return alert_ids
+
+
 @task
 def compute_manager_diffs(manager_id: int, report_date: str, conn: Any) -> int:
     """Compute and store diffs for a single manager. Returns change count."""
@@ -265,6 +337,8 @@ def daily_diff_flow(date: str | None = None) -> RunResult:
         for mid in manager_ids:
             try:
                 count = compute_manager_diffs.fn(mid, report_date, conn)
+                if count:
+                    _record_large_delta_alerts(conn, mid, report_date)
                 total_changes += count
                 managers_processed += 1
                 log_outcome(

--- a/tests/test_daily_diff.py
+++ b/tests/test_daily_diff.py
@@ -254,22 +254,24 @@ def test_daily_diff_flow_records_large_delta_alerts(tmp_path, monkeypatch):
     daily_diff_flow.fn(date="2024-05-01")
 
     conn = sqlite3.connect(db_path)
-    row = conn.execute("""SELECT ah.event_type, ah.payload_json, ah.delivered_channels
+    rows = conn.execute("""SELECT ah.event_type, ah.payload_json, ah.delivered_channels
            FROM alert_history ah
            JOIN alert_rules ar ON ar.rule_id = ah.rule_id
-           WHERE ar.name = 'Large buy'""").fetchone()
+           WHERE ar.name = 'Large buy'""").fetchall()
     conn.close()
 
-    assert row == (
-        "large_delta",
+    assert rows == [
         (
-            '{"cusip":"CCC","delta_type":"buy","manager_id":1,'
-            '"name_of_issuer":"CorpC","raw_delta_type":"ADD",'
-            '"report_date":"2024-05-01","shares_curr":40,"shares_prev":null,'
-            '"value_curr":400.0,"value_prev":null,"value_usd":400.0}'
-        ),
-        '["streamlit"]',
-    )
+            "large_delta",
+            (
+                '{"cusip":"CCC","delta_type":"buy","manager_id":1,'
+                '"name_of_issuer":"CorpC","raw_delta_type":"ADD",'
+                '"report_date":"2024-05-01","shares_curr":40,"shares_prev":null,'
+                '"value_curr":400.0,"value_prev":null,"value_usd":400.0}'
+            ),
+            '["streamlit"]',
+        )
+    ]
 
 
 def test_daily_diff_flow_defaults_to_yesterday(tmp_path, monkeypatch):

--- a/tests/test_daily_diff.py
+++ b/tests/test_daily_diff.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from alerts.db import ensure_alert_tables
 from etl.daily_diff_flow import compute_manager_diffs, daily_diff_flow
 from tools.run_contract import RunResult
 
@@ -225,6 +226,50 @@ def test_daily_diff_flow_processes_multiple_managers(tmp_path, monkeypatch):
         (1, "2024-05-01", "EEE", "DECREASE"),
         (2, "2024-05-01", "YYY", "ADD"),
     ]
+
+
+def test_daily_diff_flow_records_large_delta_alerts(tmp_path, monkeypatch):
+    db_path = _setup_db(tmp_path)
+    conn = sqlite3.connect(db_path)
+    ensure_alert_tables(conn)
+    conn.execute(
+        """INSERT INTO alert_rules(
+            name, event_type, condition_json, channels, enabled, manager_id
+        ) VALUES (?, ?, ?, ?, ?, ?)""",
+        (
+            "Large buy",
+            "large_delta",
+            '{"delta_type":"buy","value_usd_gt":350}',
+            '["streamlit"]',
+            1,
+            1,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.delenv("DB_URL", raising=False)
+
+    daily_diff_flow.fn(date="2024-05-01")
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute("""SELECT ah.event_type, ah.payload_json, ah.delivered_channels
+           FROM alert_history ah
+           JOIN alert_rules ar ON ar.rule_id = ah.rule_id
+           WHERE ar.name = 'Large buy'""").fetchone()
+    conn.close()
+
+    assert row == (
+        "large_delta",
+        (
+            '{"cusip":"CCC","delta_type":"buy","manager_id":1,'
+            '"name_of_issuer":"CorpC","raw_delta_type":"ADD",'
+            '"report_date":"2024-05-01","shares_curr":40,"shares_prev":null,'
+            '"value_curr":400.0,"value_prev":null,"value_usd":400.0}'
+        ),
+        '["streamlit"]',
+    )
 
 
 def test_daily_diff_flow_defaults_to_yesterday(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #1277

## Summary
- convert persisted daily diff rows into large_delta alert events
- evaluate and record matching alert rules during daily_diff_flow
- add a flow regression that proves alert_history receives the expected payload

## Validation
- python -m pytest tests/test_daily_diff.py::test_daily_diff_flow_records_large_delta_alerts tests/test_alert_engine.py::test_alert_engine_matches_value_threshold_and_delta_type -q
- python -m pytest tests/test_daily_diff.py tests/test_alert_integration.py -q
- black --fast --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' etl/daily_diff_flow.py tests/test_daily_diff.py\n- deliberate-break: removing the _record_large_delta_alerts call makes tests/test_daily_diff.py::test_daily_diff_flow_records_large_delta_alerts fail because alert_history remains empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily diff processing now evaluates and records “large delta” alerts when significant changes are detected.
  * The flow converts newly stored diff results into corresponding alert events and persists/evaluates them as part of the run.
* **Tests**
  * Added a new test to verify that alert history entries are created with the expected event type, payload JSON, and delivered channels for “large delta” rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->