### PR TITLE
Codex bootstrap for #1276

### DIFF
--- a/agents/codex-1276.md
+++ b/agents/codex-1276.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1276 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1276 -->

### Source Issue #1276: [Audit] Add authenticated Companies House requests for UK adapter

Base: main
Head: codex/issue-1276

Source: https://github.com/stranske/Manager-Database/issues/1276

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is a **current integration break** for live UK filings. The UK adapter calls Companies House filing-history and document endpoints without authentication (`adapters/uk.py:26`, `adapters/uk.py:30`, `adapters/uk.py:32`, `adapters/uk.py:48`, `adapters/uk.py:51`, `adapters/uk.py:53`), and the scheduled UK flow routes through that adapter (`etl/uk_flow.py:13`, `etl/uk_flow.py:14`, `etl/uk_flow.py:15`). The official Companies House authentication page at `https://developer.company-information.service.gov.uk/authentication` states that the API uses HTTP Basic auth with the API or stream key as the username. Existing tests mock HTTP responses but do not assert auth parameters (`tests/test_uk_adapter.py:175-204`, `tests/test_uk_adapter.py:215-241`). Missing behavior: live Companies House requests must include configured credentials and fail clearly when credentials are absent.

#### Tasks
- [ ] In `adapters/uk.py:23-34`, add a small helper that reads `COMPANIES_HOUSE_API_KEY` or a clearly documented repo-specific env var and returns the `httpx` auth tuple/header required by Companies House.
- [ ] In `adapters/uk.py:30-34`, pass the auth configuration to the filing-history `client.get()` call.
- [ ] In `adapters/uk.py:51-55`, pass the same auth configuration to the document-download `client.get()` call.
- [ ] Update `tests/test_uk_adapter.py:175-204` to assert `list_new_filings()` sends auth when the env var is set and raises a clear configuration error when it is not set for live calls.
- [ ] Update `tests/test_uk_adapter.py:215-241` to assert `download()` sends the same auth.
- [ ] Document the required env var near the UK flow setup docs, such as `README_bootstrap.md` or a focused runbook if one exists.

#### Acceptance Criteria
- [ ] Named tests pass: `python -m pytest tests/test_uk_adapter.py::test_list_new_filings_filters_and_maps tests/test_uk_adapter.py::test_download_returns_pdf_bytes -q`, with those tests extended to assert auth.
- [ ] **Deliberate-break gate:** temporarily remove the auth argument/header from `adapters/uk.py:32`. The extended `tests/test_uk_adapter.py::test_list_new_filings_filters_and_maps` must FAIL because the dummy client records no auth. Revert the break before review.
- [ ] Running `COMPANIES_HOUSE_API_KEY=test python -m pytest tests/test_uk_adapter.py -q` passes without making any real network calls.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is a **current integration break** for live UK filings. The UK adapter calls Companies House filing-history and document endpoints without authentication (`adapters/uk.py:26`, `adapters/uk.py:30`, `adapters/uk.py:32`, `adapters/uk.py:48`, `adapters/uk.py:51`, `adapters/uk.py:53`), and the scheduled UK flow routes through that adapter (`etl/uk_flow.py:13`, `etl/uk_flow.py:14`, `etl/uk_flow.py:15`). The official Companies House authentication page at `https://developer.company-information.service.gov.uk/authentication` states that the API uses HTTP Basic auth with the API or stream key as the username. Existing tests mock HTTP responses but do not assert auth parameters (`tests/test_uk_adapter.py:175-204`, `tests/test_uk_adapter.py:215-241`). Missing behavior: live Companies House requests must include configured credentials and fail clearly when credentials are absent.

## Scope

Add a configured Companies House API key path for `adapters/uk.py` and assert both list and document-download requests use it. Keep parser behavior and ingest persistence unchanged.

## Non-Goals

- Do NOT hard-code a real Companies House key or put secrets in tests.
- Do NOT change EDGAR, Canada, Singapore, or ASIC adapters in this issue.
- Do NOT rewrite UK PDF parsing; this issue is only request authentication and missing-credential behavior.
- Scaffold-only completion does NOT count: adding an environment variable name without passing it to both `client.get()` calls is a failure of this issue.

## Tasks

- [ ] In `adapters/uk.py:23-34`, add a small helper that reads `COMPANIES_HOUSE_API_KEY` or a clearly documented repo-specific env var and returns the `httpx` auth tuple/header required by Companies House.
- [ ] In `adapters/uk.py:30-34`, pass the auth configuration to the filing-history `client.get()` call.
- [ ] In `adapters/uk.py:51-55`, pass the same auth configuration to the document-download `client.get()` call.
- [ ] Update `tests/test_uk_adapter.py:175-204` to assert `list_new_filings()` sends auth when the env var is set and raises a clear configuration error when it is not set for live calls.
- [ ] Update `tests/test_uk_adapter.py:215-241` to assert `download()` sends the same auth.
- [ ] Document the required env var near the UK flow setup docs, such as `README_bootstrap.md` or a focused runbook if one exists.

## Acceptance Criteria

- [ ] Named tests pass: `python -m pytest tests/test_uk_adapter.py::test_list_new_filings_filters_and_maps tests/test_uk_adapter.py::test_download_returns_pdf_bytes -q`, with those tests extended to assert auth.
- [ ] **Deliberate-break gate:** temporarily remove the auth argument/header from `adapters/uk.py:32`. The extended `tests/test_uk_adapter.py::test_list_new_filings_filters_and_maps` must FAIL because the dummy client records no auth. Revert the break before review.
- [ ] Running `COMPANIES_HOUSE_API_KEY=test python -m pytest tests/test_uk_adapter.py -q` passes without making any real network calls.

## Implementation Notes

Audit baseline: `main` at `e7e8f06a9658dbb7106da1fc3c128ecfd836c573` on 2026-06-28.

Confirmed current reproduction: current `DummyClient.get()` tests accept calls with no auth kwargs, so the unauthenticated path is unguarded.



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Markdown note related to issue tracking and internal guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->