### PR TITLE
Codex bootstrap for #1277

### DIFF
--- a/agents/codex-1277.md
+++ b/agents/codex-1277.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1277 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1277 -->

### Source Issue #1277: [Audit] Emit large_delta alerts from daily_diff_flow

Base: main
Head: codex/issue-1277

Source: https://github.com/stranske/Manager-Database/issues/1277

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is a **current product wiring gap**. `large_delta` is a first-class alert event type (`alerts/models.py:10`, `alerts/models.py:12`), and the engine can match it by value and delta type (`alerts/engine.py:51`, `alerts/engine.py:67`, `alerts/engine.py:72`). The generic persistence hook exists (`alerts/integration.py:60`, `alerts/integration.py:67`, `alerts/integration.py:68`). But `daily_diff_flow` computes and inserts holding diffs (`etl/daily_diff_flow.py:200`, `etl/daily_diff_flow.py:203`, `etl/daily_diff_flow.py:205`) and then only returns run counts/artifacts (`etl/daily_diff_flow.py:321`, `etl/daily_diff_flow.py:328`, `etl/daily_diff_flow.py:331`) without creating `AlertEvent(event_type="large_delta")` records. Missing behavior: configured `large_delta` alert rules should fire when daily diffs cross their conditions.

#### Tasks
- [ ] In `etl/daily_diff_flow.py:200-206`, return enough inserted diff data from `compute_manager_diffs` or add a focused fetch helper after insertion so alert payloads include `manager_id`, `report_date`, `cusip`, `delta_type`, and a value field.
- [ ] In `etl/daily_diff_flow.py:265-300`, after manager diffs are inserted and before commit/return, create `AlertEvent(event_type="large_delta", ...)` objects and call `alerts.integration.evaluate_and_record_alerts` for each eligible diff.
- [ ] Add `tests/test_daily_diff.py::test_daily_diff_flow_records_large_delta_alerts` that seeds an enabled `large_delta` rule, runs `daily_diff_flow.fn(date="2024-05-01")`, and asserts one matching `alert_history` row is persisted.
- [ ] Extend or reuse `tests/test_alert_engine.py:42-63` if condition payload keys need normalization between `ADD`/`INCREASE`/`EXIT`/`DECREASE` and alert rule config.
- [ ] Keep `tests/test_daily_diff.py::test_daily_diff_flow_refreshes_matview_on_postgres` passing by ensuring any Postgres alert hook uses backend-safe SQL and transaction ordering.

#### Acceptance Criteria
- [ ] Named tests pass: `python -m pytest tests/test_daily_diff.py::test_daily_diff_flow_records_large_delta_alerts tests/test_alert_engine.py::test_alert_engine_matches_value_threshold_and_delta_type -q`.
- [ ] **Deliberate-break gate:** temporarily remove the `evaluate_and_record_alerts` call from `etl/daily_diff_flow.py`. `tests/test_daily_diff.py::test_daily_diff_flow_records_large_delta_alerts` must FAIL because `alert_history` remains empty. Revert the break before review.
- [ ] `python -m pytest tests/test_daily_diff.py tests/test_alert_integration.py -q` passes without external services.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is a **current product wiring gap**. `large_delta` is a first-class alert event type (`alerts/models.py:10`, `alerts/models.py:12`), and the engine can match it by value and delta type (`alerts/engine.py:51`, `alerts/engine.py:67`, `alerts/engine.py:72`). The generic persistence hook exists (`alerts/integration.py:60`, `alerts/integration.py:67`, `alerts/integration.py:68`). But `daily_diff_flow` computes and inserts holding diffs (`etl/daily_diff_flow.py:200`, `etl/daily_diff_flow.py:203`, `etl/daily_diff_flow.py:205`) and then only returns run counts/artifacts (`etl/daily_diff_flow.py:321`, `etl/daily_diff_flow.py:328`, `etl/daily_diff_flow.py:331`) without creating `AlertEvent(event_type="large_delta")` records. Missing behavior: configured `large_delta` alert rules should fire when daily diffs cross their conditions.

## Scope

Wire daily diff rows into the alert engine after successful diff computation, with deterministic payload fields that rules can match. Cover SQLite unit behavior and preserve Postgres transaction safety.

## Non-Goals

- Do NOT implement email or Slack delivery in this issue; `alerts/integration.py:63-64` says downstream delivery is separate.
- Do NOT change the `new_filing` alert path.
- Do NOT change `diff_holdings()` semantics or daily diff row schema except for alert payload data needed by this integration.
- Scaffold-only completion does NOT count: creating a helper that is never called from `daily_diff_flow()` or recording alerts without the inserted diff payload is a failure of this issue.

## Tasks

- [ ] In `etl/daily_diff_flow.py:200-206`, return enough inserted diff data from `compute_manager_diffs` or add a focused fetch helper after insertion so alert payloads include `manager_id`, `report_date`, `cusip`, `delta_type`, and a value field.
- [ ] In `etl/daily_diff_flow.py:265-300`, after manager diffs are inserted and before commit/return, create `AlertEvent(event_type="large_delta", ...)` objects and call `alerts.integration.evaluate_and_record_alerts` for each eligible diff.
- [ ] Add `tests/test_daily_diff.py::test_daily_diff_flow_records_large_delta_alerts` that seeds an enabled `large_delta` rule, runs `daily_diff_flow.fn(date="2024-05-01")`, and asserts one matching `alert_history` row is persisted.
- [ ] Extend or reuse `tests/test_alert_engine.py:42-63` if condition payload keys need normalization between `ADD`/`INCREASE`/`EXIT`/`DECREASE` and alert rule config.
- [ ] Keep `tests/test_daily_diff.py::test_daily_diff_flow_refreshes_matview_on_postgres` passing by ensuring any Postgres alert hook uses backend-safe SQL and transaction ordering.

## Acceptance Criteria

- [ ] Named tests pass: `python -m pytest tests/test_daily_diff.py::test_daily_diff_flow_records_large_delta_alerts tests/test_alert_engine.py::test_alert_engine_matches_value_threshold_and_delta_type -q`.
- [ ] **Deliberate-break gate:** temporarily remove the `evaluate_and_record_alerts` call from `etl/daily_diff_flow.py`. `tests/test_daily_diff.py::test_daily_diff_flow_records_large_delta_alerts` must FAIL because `alert_history` remains empty. Revert the break before review.
- [ ] `python -m pytest tests/test_daily_diff.py tests/test_alert_integration.py -q` passes without external services.

## Implementation Notes

Audit baseline: `main` at `e7e8f06a9658dbb7106da1fc3c128ecfd836c573` on 2026-06-28.

Confirmed current reproduction: `tests/test_daily_diff.py:207-227` verifies diff rows are written, but no current test asserts corresponding `alert_history` rows.



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a brief bootstrap note related to Codex for issue `#1277`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->