### PR TITLE
Make seed_universe executable without PYTHONPATH

### DIFF
--- a/scripts/seed_universe.py
+++ b/scripts/seed_universe.py
@@ -15,7 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from adapters.base import connect_db
+from adapters.base import connect_db  # noqa: E402
 
 DEFAULT_ROLE = "Manager"
 

--- a/scripts/seed_universe.py
+++ b/scripts/seed_universe.py
@@ -7,8 +7,13 @@ import argparse
 import csv
 import json
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from adapters.base import connect_db
 

--- a/tests/test_coverage_guard.py
+++ b/tests/test_coverage_guard.py
@@ -290,7 +290,12 @@ def test_recovery_window_satisfied_fails_when_recent_sample_below_baseline() -> 
     ]
     trend_data = {"current": 85.0, "run_id": "run-3"}
 
-    assert _recovery_window_satisfied(trend_data, baseline=80.0, recovery_window=3, history_records=history_records) is False
+    assert (
+        _recovery_window_satisfied(
+            trend_data, baseline=80.0, recovery_window=3, history_records=history_records
+        )
+        is False
+    )
 
 
 def test_recovery_window_satisfied_passes_for_consecutive_above_baseline_samples() -> None:
@@ -300,7 +305,12 @@ def test_recovery_window_satisfied_passes_for_consecutive_above_baseline_samples
     ]
     trend_data = {"current": 83.0, "run_id": "run-3"}
 
-    assert _recovery_window_satisfied(trend_data, baseline=80.0, recovery_window=3, history_records=history_records) is True
+    assert (
+        _recovery_window_satisfied(
+            trend_data, baseline=80.0, recovery_window=3, history_records=history_records
+        )
+        is True
+    )
 
 
 @pytest.mark.parametrize(
@@ -318,5 +328,7 @@ def test_recovery_window_satisfied_passes_for_consecutive_above_baseline_samples
         ({"current": float("nan")}, None),
     ],
 )
-def test_coverage_value_for_recovery_uses_supported_keys(record: dict, expected: float | None) -> None:
+def test_coverage_value_for_recovery_uses_supported_keys(
+    record: dict, expected: float | None
+) -> None:
     assert _coverage_value_for_recovery(record) == expected

--- a/tests/test_github_api_retry_sparse_checkout.py
+++ b/tests/test_github_api_retry_sparse_checkout.py
@@ -30,7 +30,10 @@ def _sparse_checkout_paths(block: str) -> list[str]:
 
 
 def _iter_sparse_checkout_blocks(workflow_text: str) -> list[list[str]]:
-    return [_sparse_checkout_paths(match.group(1)) for match in SPARSE_CHECKOUT_BLOCK.finditer(workflow_text)]
+    return [
+        _sparse_checkout_paths(match.group(1))
+        for match in SPARSE_CHECKOUT_BLOCK.finditer(workflow_text)
+    ]
 
 
 def test_sparse_checkouts_include_error_classifier_with_retry_helper() -> None:
@@ -44,8 +47,7 @@ def test_sparse_checkouts_include_error_classifier_with_retry_helper() -> None:
 
     assert not offenders, (
         "github-api-with-retry.js requires ./error_classifier at module load; "
-        "add error_classifier.js to sparse-checkout:\n"
-        + "\n".join(offenders)
+        "add error_classifier.js to sparse-checkout:\n" + "\n".join(offenders)
     )
 
 
@@ -74,7 +76,9 @@ def test_github_api_retry_imports_with_minimal_sparse_checkout(tmp_path: Path) -
 
 
 def test_record_autofix_metrics_job_sparse_checkout_paths() -> None:
-    workflow = yaml.safe_load((WORKFLOWS_DIR / "agents-81-gate-followups.yml").read_text(encoding="utf-8"))
+    workflow = yaml.safe_load(
+        (WORKFLOWS_DIR / "agents-81-gate-followups.yml").read_text(encoding="utf-8")
+    )
     checkout_step = workflow["jobs"]["metrics"]["steps"][0]
     paths = _sparse_checkout_paths(checkout_step["with"]["sparse-checkout"])
 

--- a/tests/test_seed_universe.py
+++ b/tests/test_seed_universe.py
@@ -98,7 +98,8 @@ def test_sample_universe_json_contains_confirmed_managers_and_seeds(tmp_path):
 
 
 def test_sample_universe_direct_dry_run_without_pythonpath(tmp_path):
-    env = {**os.environ, "DB_PATH": str(tmp_path / "seed-smoke.db")}
+    db_path = tmp_path / "seed-smoke.db"
+    env = {**os.environ, "DB_PATH": str(db_path)}
     env.pop("PYTHONPATH", None)
 
     result = subprocess.run(
@@ -117,3 +118,9 @@ def test_sample_universe_direct_dry_run_without_pythonpath(tmp_path):
     )
 
     assert "Dry run complete. No rows written." in result.stdout
+    conn = sqlite3.connect(db_path)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM managers").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 0

--- a/tests/test_seed_universe.py
+++ b/tests/test_seed_universe.py
@@ -14,6 +14,7 @@ def _run_seed(
 ) -> subprocess.CompletedProcess[str]:
     db_path = tmp_path / "seed.db"
     env = {**os.environ, "DB_PATH": str(db_path)}
+    env.pop("PYTHONPATH", None)
     return subprocess.run(
         [sys.executable, str(SCRIPT_PATH), "--file", str(input_path), *extra_args],
         check=True,
@@ -94,3 +95,25 @@ def test_sample_universe_json_contains_confirmed_managers_and_seeds(tmp_path):
     result = _run_seed(tmp_path, sample_path)
     assert "Created: 10" in result.stdout
     assert "Updated: 0" in result.stdout
+
+
+def test_sample_universe_direct_dry_run_without_pythonpath(tmp_path):
+    env = {**os.environ, "DB_PATH": str(tmp_path / "seed-smoke.db")}
+    env.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--file",
+            str(REPO_ROOT / "scripts" / "sample_universe.json"),
+            "--dry-run",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+
+    assert "Dry run complete. No rows written." in result.stdout


### PR DESCRIPTION
Closes #1279

## Summary
- Add repo-root path initialization before seed_universe imports repo-local adapters.
- Strip PYTHONPATH in seed_universe subprocess tests so direct execution is hermetic.
- Add a sample_universe dry-run smoke under env without PYTHONPATH.

## Validation
- env -u PYTHONPATH python -m pytest tests/test_seed_universe.py -q
- env -u PYTHONPATH DB_PATH=/tmp/seed-smoke.db python scripts/seed_universe.py --file scripts/sample_universe.json --dry-run
- black --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' scripts/seed_universe.py tests/test_seed_universe.py\n- Deliberate break: removing the import fix makes tests/test_seed_universe.py::test_seed_universe_json_upsert_is_idempotent fail with ModuleNotFoundError: No module named 'adapters'; restored before commit.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the universe seed command to start reliably by ensuring required Python import paths are set up automatically.
  * Prevented inherited `PYTHONPATH` from affecting direct seed invocations, improving consistency for dry-run behavior.
* **Tests**
  * Added coverage for running the seed command directly with `PYTHONPATH` removed, verifying expected dry-run messaging and that no database rows are written.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->