### PR TITLE
Fix Streamlit dashboard default page

### DIFF
--- a/tests/test_ui_navigation.py
+++ b/tests/test_ui_navigation.py
@@ -1,8 +1,40 @@
 import importlib
+import sqlite3
 import sys
 from pathlib import Path
 
+from streamlit.testing.v1 import AppTest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def _create_empty_dashboard_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT);
+        CREATE TABLE filings (
+            filing_id INTEGER PRIMARY KEY,
+            manager_id INTEGER,
+            type TEXT,
+            filed_date TEXT
+        );
+        CREATE TABLE holdings (
+            filing_id INTEGER,
+            manager_id INTEGER,
+            filed TEXT
+        );
+        CREATE TABLE news_items (
+            manager_id INTEGER,
+            headline TEXT,
+            url TEXT,
+            published_at TEXT,
+            source TEXT,
+            topics TEXT,
+            confidence REAL
+        );
+        CREATE TABLE api_usage (ts TEXT);
+        """)
+    conn.close()
 
 
 class FakeNavigation:
@@ -19,14 +51,20 @@ class FakeStreamlit:
         self.navigation_calls: list[dict[str, object]] = []
         self.navigation_instance = FakeNavigation()
 
-    def Page(
-        self, target, title: str, icon: str, url_path: str
-    ):  # noqa: N802 - mirrors streamlit API
+    def Page(  # noqa: N802 - mirrors streamlit API
+        self,
+        target,
+        title: str,
+        icon: str,
+        url_path: str,
+        default: bool = False,
+    ):
         page = {
             "target": target,
             "title": title,
             "icon": icon,
             "url_path": url_path,
+            "default": default,
         }
         self.page_calls.append(page)
         return page
@@ -49,4 +87,16 @@ def test_navigation_includes_research_page(monkeypatch):
 
     assert "research" in url_paths
     assert "🔬 Research" in titles
+    assert fake_st.page_calls[0]["default"] is True
     assert fake_st.navigation_instance.run_called is True
+
+
+def test_real_streamlit_navigation_constructs_without_exception(tmp_path, monkeypatch):
+    db_path = tmp_path / "dashboard.db"
+    _create_empty_dashboard_db(db_path)
+    monkeypatch.delenv("DB_URL", raising=False)
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    at = AppTest.from_file("ui/app.py").run(timeout=5)
+
+    assert not at.exception

--- a/ui/app.py
+++ b/ui/app.py
@@ -12,7 +12,7 @@ from ui import daily_report, dashboard, research, search, upload
 def _build_pages() -> list[Any]:
     """Define sidebar navigation and URL paths for all UI pages."""
     return [
-        st.Page(dashboard.main, title="Dashboard", icon="📈", url_path=""),
+        st.Page(dashboard.main, title="Dashboard", icon="📈", url_path="", default=True),
         st.Page(daily_report.main, title="Daily Report", icon="🗞️", url_path="daily-report"),
         st.Page(search.main, title="Search", icon="🔎", url_path="search"),
         st.Page(upload.main, title="Upload", icon="📝", url_path="upload"),


### PR DESCRIPTION
Closes #1297

## Summary
- Mark the Dashboard Streamlit page as the default page while preserving the empty root URL path.
- Add a real AppTest navigation regression with a minimal SQLite fixture so page construction is exercised without dashboard data dependencies.

## Validation
- python -m pytest tests/test_ui_navigation.py -q
- black --fast --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' ui/app.py tests/test_ui_navigation.py\n- Deliberate break: removing default=True makes test_real_streamlit_navigation_constructs_without_exception fail with the Streamlit empty-url default-page exception.\n- DB_PATH=/tmp/manager-1297-live-smoke.db env -u DB_URL streamlit run ui/app.py --server.headless=true --server.port=8599; curl root page and verify no StreamlitAPIException in logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app navigation so the Dashboard is now treated as the default page.
  * Added coverage for the app starting cleanly with a local database, helping prevent navigation-related startup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->