### PR TITLE
Codex bootstrap for #1279

### DIFF
--- a/agents/codex-1279.md
+++ b/agents/codex-1279.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1279 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1279 -->

### Source Issue #1279: [Audit] Make seed_universe subprocess tests independent of ambient PYTHONPATH

Base: main
Head: codex/issue-1279

Source: https://github.com/stranske/Manager-Database/issues/1279

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is a **current test/bootstrap break**. `tests/test_seed_universe.py` runs the script by absolute file path (`tests/test_seed_universe.py:8`, `tests/test_seed_universe.py:9`, `tests/test_seed_universe.py:17`, `tests/test_seed_universe.py:18`) with only `DB_PATH` added to the environment (`tests/test_seed_universe.py:16`, `tests/test_seed_universe.py:23`). The script imports `adapters.base` at top level (`scripts/seed_universe.py:13`). When executed as `python scripts/seed_universe.py` without ambient `PYTHONPATH=.`, Python places `scripts/` on `sys.path`, not the repo root, so `adapters` is not importable. Missing behavior: the documented executable script path and its subprocess tests should work without relying on shell-specific `PYTHONPATH` state.

#### Tasks
- [ ] In `scripts/seed_universe.py:1-14`, make repo-local imports resolve when the file is executed directly, for example by inserting the repo root before importing `adapters.base` or by moving the CLI to an import-safe module entry point.
- [ ] In `tests/test_seed_universe.py:12-24`, explicitly remove `PYTHONPATH` from the subprocess environment to prove the test no longer depends on ambient shell state.
- [ ] Add or update a direct CLI smoke in `tests/test_seed_universe.py` that runs `scripts/sample_universe.json` with `--dry-run` under `env -u PYTHONPATH`.
- [ ] Keep the existing idempotent JSON and CSV assertions at `tests/test_seed_universe.py:37-79` passing.

#### Acceptance Criteria
- [ ] Named tests pass without ambient path injection: `env -u PYTHONPATH python -m pytest tests/test_seed_universe.py -q`.
- [ ] **Deliberate-break gate:** temporarily remove the direct-execution import fix from `scripts/seed_universe.py:1-14`. `tests/test_seed_universe.py::test_seed_universe_json_upsert_is_idempotent` must FAIL with `ModuleNotFoundError: No module named 'adapters'`. Revert the break before review.
- [ ] Direct smoke succeeds: `env -u PYTHONPATH DB_PATH=/tmp/seed-smoke.db python scripts/seed_universe.py --file scripts/sample_universe.json --dry-run` exits 0 and prints `Dry run complete. No rows written.`
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is a **current test/bootstrap break**. `tests/test_seed_universe.py` runs the script by absolute file path (`tests/test_seed_universe.py:8`, `tests/test_seed_universe.py:9`, `tests/test_seed_universe.py:17`, `tests/test_seed_universe.py:18`) with only `DB_PATH` added to the environment (`tests/test_seed_universe.py:16`, `tests/test_seed_universe.py:23`). The script imports `adapters.base` at top level (`scripts/seed_universe.py:13`). When executed as `python scripts/seed_universe.py` without ambient `PYTHONPATH=.`, Python places `scripts/` on `sys.path`, not the repo root, so `adapters` is not importable. Missing behavior: the documented executable script path and its subprocess tests should work without relying on shell-specific `PYTHONPATH` state.

## Scope

Make `scripts/seed_universe.py` executable by path from the repo root and keep the subprocess tests hermetic.

## Non-Goals

- Do NOT weaken `tests/test_seed_universe.py` by only setting `PYTHONPATH` in the test environment.
- Do NOT remove JSON/CSV/dry-run/idempotency assertions from `tests/test_seed_universe.py:37-96`.
- Do NOT change manager-universe database semantics in this issue.
- Scaffold-only completion does NOT count: making only `pytest` invocation succeed while `env -u PYTHONPATH python scripts/seed_universe.py ...` still fails is a failure of this issue.

## Tasks

- [ ] In `scripts/seed_universe.py:1-14`, make repo-local imports resolve when the file is executed directly, for example by inserting the repo root before importing `adapters.base` or by moving the CLI to an import-safe module entry point.
- [ ] In `tests/test_seed_universe.py:12-24`, explicitly remove `PYTHONPATH` from the subprocess environment to prove the test no longer depends on ambient shell state.
- [ ] Add or update a direct CLI smoke in `tests/test_seed_universe.py` that runs `scripts/sample_universe.json` with `--dry-run` under `env -u PYTHONPATH`.
- [ ] Keep the existing idempotent JSON and CSV assertions at `tests/test_seed_universe.py:37-79` passing.

## Acceptance Criteria

- [ ] Named tests pass without ambient path injection: `env -u PYTHONPATH python -m pytest tests/test_seed_universe.py -q`.
- [ ] **Deliberate-break gate:** temporarily remove the direct-execution import fix from `scripts/seed_universe.py:1-14`. `tests/test_seed_universe.py::test_seed_universe_json_upsert_is_idempotent` must FAIL with `ModuleNotFoundError: No module named 'adapters'`. Revert the break before review.
- [ ] Direct smoke succeeds: `env -u PYTHONPATH DB_PATH=/tmp/seed-smoke.db python scripts/seed_universe.py --file scripts/sample_universe.json --dry-run` exits 0 and prints `Dry run complete. No rows written.`

## Implementation Notes

Audit baseline: `main` at `e7e8f06a9658dbb7106da1fc3c128ecfd836c573` on 2026-06-28.

Confirmed current reproduction from audit: `python -m pytest -q` failed the seed-universe subprocess tests with `ModuleNotFoundError: No module named 'adapters'`; `PYTHONPATH=. python -m pytest tests/test_seed_universe.py -q` passed.



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an initial markdown note to the project’s agent documentation as a bootstrap reference for an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->