### PR TITLE
Codex bootstrap for #1297

### DIFF
--- a/agents/codex-1297.md
+++ b/agents/codex-1297.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1297 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1297 -->

### Source Issue #1297: [Audit] Streamlit analyst UI crashes on load (url_path empty, missing default=True)

Base: main
Head: codex/issue-1297

Source: https://github.com/stranske/Manager-Database/issues/1297

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is a **current runtime break**: the Streamlit analyst UI (`make app` / `streamlit run ui/app.py`, the `mgrdb-app` console path) **crashes on load on every page**. At the pinned `streamlit==1.58.0` (`requirements.lock:538`), `ui/app.py:15` constructs the Dashboard page with an empty `url_path` but without marking it the default:

```
st.Page(dashboard.main, title="Dashboard", icon="📈", url_path=""),
```

Streamlit 1.58 raises at `streamlit/navigation/page.py:375`:
`StreamlitAPIException: The URL path cannot be an empty string unless the page is the default page.`

Reproduced two ways (audit baseline `e5764a5`, streamlit 1.58.0):
- Live browser: loading the app shows the exception traceback, no UI.
- `AppTest`: `AppTest.from_file("ui/app.py").run()` → `at.exception` contains the StreamlitAPIException at `ui/app.py:15`.

**Why CI is green:** `tests/test_ui_navigation.py` monkeypatches `st` with a `FakeStreamlit` whose `Page()` is a no-op recorder — it never constructs a real `st.Page`, so it cannot catch the construction-time error. The real-launch smoke (`make app-smoke` / `scripts/readiness_smoke.py --launch-ui`) is **not wired into `ci.yml`**.

**In-repo reference for the fix:** the offline twin `web/wasm_app.py:29` already does it correctly: `st.Page(dashboard.main, ..., url_path="", default=True)`. The server UI builder was missed.

#### Tasks
- [ ] In `ui/app.py:15`, mark the Dashboard page as default (e.g. `st.Page(dashboard.main, title="Dashboard", icon="📈", default=True)`), mirroring `web/wasm_app.py:29`.
- [ ] Replace/augment `tests/test_ui_navigation.py` with a real-construction test using `streamlit.testing.v1.AppTest` that asserts `AppTest.from_file("ui/app.py").run().exception is None`.
- [ ] (Optional, recommended) Wire `make app-smoke` (`readiness_smoke.py --launch-ui`) into the CI/nightly path so a real launch is exercised.

#### Acceptance Criteria
- [ ] Named gate passes: `python -m pytest tests/test_ui_navigation.py -q`, and the new AppTest asserts no exception on load.
- [ ] **Live verification gate:** `streamlit run ui/app.py --server.headless=true --server.port=8599` starts and the root page renders the sidebar nav (Dashboard/Daily Report/Search/Upload/Research) with NO StreamlitAPIException.
- [ ] **Deliberate-break demonstration:** reverting the `default=True` fix makes the new AppTest test FAIL; restoring it makes it pass.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is a **current runtime break**: the Streamlit analyst UI (`make app` / `streamlit run ui/app.py`, the `mgrdb-app` console path) **crashes on load on every page**. At the pinned `streamlit==1.58.0` (`requirements.lock:538`), `ui/app.py:15` constructs the Dashboard page with an empty `url_path` but without marking it the default:

```
st.Page(dashboard.main, title="Dashboard", icon="📈", url_path=""),
```

Streamlit 1.58 raises at `streamlit/navigation/page.py:375`:
`StreamlitAPIException: The URL path cannot be an empty string unless the page is the default page.`

Reproduced two ways (audit baseline `e5764a5`, streamlit 1.58.0):
- Live browser: loading the app shows the exception traceback, no UI.
- `AppTest`: `AppTest.from_file("ui/app.py").run()` → `at.exception` contains the StreamlitAPIException at `ui/app.py:15`.

**Why CI is green:** `tests/test_ui_navigation.py` monkeypatches `st` with a `FakeStreamlit` whose `Page()` is a no-op recorder — it never constructs a real `st.Page`, so it cannot catch the construction-time error. The real-launch smoke (`make app-smoke` / `scripts/readiness_smoke.py --launch-ui`) is **not wired into `ci.yml`**.

**In-repo reference for the fix:** the offline twin `web/wasm_app.py:29` already does it correctly: `st.Page(dashboard.main, ..., url_path="", default=True)`. The server UI builder was missed.

## Scope

Make `ui/app.py` navigation construct successfully under `streamlit==1.58.0`, and add a test that exercises the REAL Streamlit page construction so this regresses loudly.

## Non-Goals

- Do NOT change `web/wasm_app.py` (already correct) — that offline-demo nav is tracked separately (issue 1275).
- Do NOT downgrade or unpin Streamlit.
- Scaffold-only does NOT count: a test that keeps mocking `st.Page` is a failure of this issue — the gate must build real pages.

## Tasks

- [ ] In `ui/app.py:15`, mark the Dashboard page as default (e.g. `st.Page(dashboard.main, title="Dashboard", icon="📈", default=True)`), mirroring `web/wasm_app.py:29`.
- [ ] Replace/augment `tests/test_ui_navigation.py` with a real-construction test using `streamlit.testing.v1.AppTest` that asserts `AppTest.from_file("ui/app.py").run().exception is None`.
- [ ] (Optional, recommended) Wire `make app-smoke` (`readiness_smoke.py --launch-ui`) into the CI/nightly path so a real launch is exercised.

## Acceptance Criteria

- [ ] Named gate passes: `python -m pytest tests/test_ui_navigation.py -q`, and the new AppTest asserts no exception on load.
- [ ] **Live verification gate:** `streamlit run ui/app.py --server.headless=true --server.port=8599` starts and the root page renders the sidebar nav (Dashboard/Daily Report/Search/Upload/Research) with NO StreamlitAPIException.
- [ ] **Deliberate-break demonstration:** reverting the `default=True` fix makes the new AppTest test FAIL; restoring it makes it pass.

## Implementation Notes

Audit baseline: `main` @ `e5764a5` on 2026-06-28. Confirmed via Streamlit `AppTest` and live browser at `streamlit==1.58.0` (matches `requirements.lock`). Root cause is `url_path=""` without `default=True`; the offline twin already carries the fix.



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new introductory comment to the project notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->