### PR TITLE
Fix EDGAR ingest idempotency and watermarking

### DIFF
--- a/etl/edgar_flow.py
+++ b/etl/edgar_flow.py
@@ -269,6 +269,40 @@ def _delete_holdings_for_filing(conn: Any, filing_id: int) -> None:
     conn.execute(f"DELETE FROM holdings WHERE filing_id = {marker}", (filing_id,))
 
 
+def _run_in_transaction(conn: Any, work: Any) -> Any:
+    transaction = getattr(conn, "transaction", None)
+    if callable(transaction):
+        with transaction():
+            return work()
+    return work()
+
+
+def _replace_holdings_for_filing(
+    conn: Any,
+    *,
+    filing_id: int,
+    rows: list[dict[str, Any]],
+    manager_id: int | None,
+    cik: str,
+    accession: str,
+    filed_date: str | None,
+) -> None:
+    def _work() -> None:
+        _delete_holdings_for_filing(conn, filing_id)
+        for row in rows:
+            _insert_holding_legacy(
+                conn,
+                filing_id,
+                row,
+                manager_id=manager_id,
+                cik=cik,
+                accession=accession,
+                filed_date=filed_date,
+            )
+
+    _run_in_transaction(conn, _work)
+
+
 def _latest_filed_date_for_cik(cik: str) -> str | None:
     conn = connect_db(DB_PATH)
     try:
@@ -279,9 +313,14 @@ def _latest_filed_date_for_cik(cik: str) -> str | None:
         if manager_id is None:
             return None
         marker = _placeholder(conn)
+        where = f"manager_id = {marker}"
+        params: list[Any] = [manager_id]
+        if "source" in filing_columns:
+            where += f" AND source = {marker}"
+            params.append("edgar")
         row = conn.execute(
-            f"SELECT MAX(filed_date) FROM filings WHERE manager_id = {marker}",
-            (manager_id,),
+            f"SELECT MAX(filed_date) FROM filings WHERE {where}",
+            tuple(params),
         ).fetchone()
         return str(row[0]) if row and row[0] is not None else None
     finally:
@@ -330,17 +369,15 @@ async def fetch_and_store(cik: str, since: str):
             filed_date=filing.get("filed"),
             raw_key=raw_key,
         )
-        _delete_holdings_for_filing(conn, filing_id)
-        for row in parsed_rows:
-            _insert_holding_legacy(
-                conn,
-                filing_id,
-                row,
-                manager_id=manager_id,
-                cik=cik,
-                accession=accession,
-                filed_date=filing.get("filed"),
-            )
+        _replace_holdings_for_filing(
+            conn,
+            filing_id=filing_id,
+            rows=parsed_rows,
+            manager_id=manager_id,
+            cik=cik,
+            accession=accession,
+            filed_date=filing.get("filed"),
+        )
         conn.commit()
         await fire_alerts_for_event(
             conn,

--- a/etl/edgar_flow.py
+++ b/etl/edgar_flow.py
@@ -16,19 +16,26 @@ from adapters.base import connect_db, get_adapter
 from alerts.integration import build_new_filing_event, fire_alerts_for_event
 from etl.logging_setup import configure_logging, log_outcome
 
-try:
-    from embeddings import store_document
-except ModuleNotFoundError:
 
-    def store_document(
-        text: str,
-        db_path: str | None = None,
-        manager_id: int | None = None,
-        kind: str = "note",
-        filename: str | None = None,
-    ) -> int:
+def store_document(
+    text: str,
+    db_path: str | None = None,
+    manager_id: int | None = None,
+    kind: str = "note",
+    filename: str | None = None,
+) -> int:
+    try:
+        from embeddings import store_document as _store_document
+    except Exception:
         _ = (text, db_path, manager_id, kind, filename)
         return 0
+    return _store_document(
+        text,
+        db_path=db_path,
+        manager_id=manager_id,
+        kind=kind,
+        filename=filename,
+    )
 
 
 RAW_DIR = ingest_module.RAW_DIR
@@ -255,6 +262,32 @@ def _insert_holding_legacy(
     )
 
 
+def _delete_holdings_for_filing(conn: Any, filing_id: int) -> None:
+    if filing_id <= 0 or "filing_id" not in _columns(conn, "holdings"):
+        return
+    marker = _placeholder(conn)
+    conn.execute(f"DELETE FROM holdings WHERE filing_id = {marker}", (filing_id,))
+
+
+def _latest_filed_date_for_cik(cik: str) -> str | None:
+    conn = connect_db(DB_PATH)
+    try:
+        filing_columns = _columns(conn, "filings")
+        if "filed_date" not in filing_columns or "manager_id" not in filing_columns:
+            return None
+        manager_id = _manager_id_for_cik(conn, cik)
+        if manager_id is None:
+            return None
+        marker = _placeholder(conn)
+        row = conn.execute(
+            f"SELECT MAX(filed_date) FROM filings WHERE manager_id = {marker}",
+            (manager_id,),
+        ).fetchone()
+        return str(row[0]) if row and row[0] is not None else None
+    finally:
+        conn.close()
+
+
 @task
 async def fetch_and_store(cik: str, since: str):
     filings = await ADAPTER.list_new_filings(cik, since)
@@ -297,6 +330,7 @@ async def fetch_and_store(cik: str, since: str):
             filed_date=filing.get("filed"),
             raw_key=raw_key,
         )
+        _delete_holdings_for_filing(conn, filing_id)
         for row in parsed_rows:
             _insert_holding_legacy(
                 conn,
@@ -331,11 +365,16 @@ async def edgar_flow(cik_list: list[str] | None = None, since: str | None = None
     ingest_module.DB_PATH = DB_PATH
     ingest_module.logger = cast(Any, _EdgarLogProxy(logger))
     ingest_callable = getattr(ingest_module.ingest_flow, "fn", ingest_module.ingest_flow)
+
+    async def _fetch_with_watermark(cik: str, fallback_since: str) -> list[dict[str, Any]]:
+        resolved_since = since or _latest_filed_date_for_cik(cik) or fallback_since
+        return await fetch_and_store(cik, resolved_since)
+
     all_rows = await ingest_callable(
         jurisdiction="us",
         identifiers=cik_list,
         since=since,
-        fetcher=fetch_and_store,
+        fetcher=_fetch_with_watermark,
     )
     log_outcome(
         logger,

--- a/etl/ingest_flow.py
+++ b/etl/ingest_flow.py
@@ -16,19 +16,26 @@ from prefect import flow, task
 from adapters.base import connect_db, get_adapter
 from etl.logging_setup import configure_logging, log_outcome
 
-try:
-    from embeddings import store_document
-except ModuleNotFoundError:
 
-    def store_document(
-        text: str,
-        db_path: str | None = None,
-        manager_id: int | None = None,
-        kind: str = "note",
-        filename: str | None = None,
-    ) -> int:
+def store_document(
+    text: str,
+    db_path: str | None = None,
+    manager_id: int | None = None,
+    kind: str = "note",
+    filename: str | None = None,
+) -> int:
+    try:
+        from embeddings import store_document as _store_document
+    except Exception:
         _ = (text, db_path, manager_id, kind, filename)
         return 0
+    return _store_document(
+        text,
+        db_path=db_path,
+        manager_id=manager_id,
+        kind=kind,
+        filename=filename,
+    )
 
 
 RAW_DIR = Path(os.getenv("RAW_DIR", "./data/raw"))
@@ -254,24 +261,33 @@ def _insert_filing(
     if _is_sqlite(conn):
         if has_external_id:
             sql = (
-                "INSERT OR REPLACE INTO filings(manager_id, source, external_id, filed_date, type, parsed_payload) "
-                "VALUES (?, ?, ?, ?, ?, ?)"
+                "INSERT INTO filings(manager_id, source, external_id, filed_date, type, parsed_payload) "
+                "VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(source, external_id) DO UPDATE SET "
+                "manager_id = excluded.manager_id, "
+                "filed_date = excluded.filed_date, "
+                "type = excluded.type, "
+                "parsed_payload = excluded.parsed_payload "
+                f"RETURNING {id_column}"
             )
-            cursor = conn.execute(
+            row = conn.execute(
                 sql,
                 (manager_id, source, external_id, filed_date, filing_type, payload),
-            )
-            return int(cursor.lastrowid or 0)
+            ).fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
         sql = (
-            "INSERT OR REPLACE INTO filings(manager_id, source, type, filed_date, raw_key, parsed_payload) "
-            "VALUES (?, ?, ?, ?, ?, ?)"
-        )
-        conn.execute(
-            sql,
-            (manager_id, source, filing_type, filed_date, raw_key, payload),
+            "INSERT INTO filings(manager_id, source, type, filed_date, raw_key, parsed_payload) "
+            "VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(raw_key) DO UPDATE SET "
+            "manager_id = excluded.manager_id, "
+            "filed_date = excluded.filed_date, "
+            "type = excluded.type, "
+            "parsed_payload = excluded.parsed_payload "
+            f"RETURNING {id_column}"
         )
         row = conn.execute(
-            f"SELECT {id_column} FROM filings WHERE raw_key = ?", (raw_key,)
+            sql,
+            (manager_id, source, filing_type, filed_date, raw_key, payload),
         ).fetchone()
         return int(row[0]) if row and row[0] is not None else 0
     if has_external_id:
@@ -364,6 +380,14 @@ def _insert_holdings_rows(
     return inserted
 
 
+def _delete_holdings_rows(conn: Any, *, filing_id: int) -> None:
+    holdings_columns = _table_columns(conn, "holdings")
+    if "filing_id" not in holdings_columns:
+        return
+    marker = _placeholder(conn)
+    conn.execute(f"DELETE FROM holdings WHERE filing_id = {marker}", (filing_id,))
+
+
 @task
 async def fetch_and_store(
     identifier: str,
@@ -421,6 +445,7 @@ async def fetch_and_store(
         # UK filings are metadata-driven (e.g., CS01/AR01) and should be
         # stored as parsed payload on the filings row, not expanded holdings.
         if jurisdiction != "uk" and _looks_like_holdings_rows(parsed_rows):
+            _delete_holdings_rows(conn, filing_id=filing_id)
             row_count += _insert_holdings_rows(
                 conn,
                 filing_id=filing_id,

--- a/etl/ingest_flow.py
+++ b/etl/ingest_flow.py
@@ -388,6 +388,41 @@ def _delete_holdings_rows(conn: Any, *, filing_id: int) -> None:
     conn.execute(f"DELETE FROM holdings WHERE filing_id = {marker}", (filing_id,))
 
 
+def _run_in_transaction(conn: Any, work: Any) -> Any:
+    transaction = getattr(conn, "transaction", None)
+    if callable(transaction):
+        with transaction():
+            return work()
+    return work()
+
+
+def _replace_holdings_rows(
+    conn: Any,
+    *,
+    filing_id: int,
+    manager_id: int,
+    identifier: str,
+    external_id: str,
+    filed_date: str | None,
+    parsed_rows: list[dict[str, Any]],
+    jurisdiction: str,
+) -> int:
+    def _work() -> int:
+        _delete_holdings_rows(conn, filing_id=filing_id)
+        return _insert_holdings_rows(
+            conn,
+            filing_id=filing_id,
+            manager_id=manager_id,
+            identifier=identifier,
+            external_id=external_id,
+            filed_date=filed_date,
+            parsed_rows=parsed_rows,
+            jurisdiction=jurisdiction,
+        )
+
+    return int(_run_in_transaction(conn, _work))
+
+
 @task
 async def fetch_and_store(
     identifier: str,
@@ -445,8 +480,7 @@ async def fetch_and_store(
         # UK filings are metadata-driven (e.g., CS01/AR01) and should be
         # stored as parsed payload on the filings row, not expanded holdings.
         if jurisdiction != "uk" and _looks_like_holdings_rows(parsed_rows):
-            _delete_holdings_rows(conn, filing_id=filing_id)
-            row_count += _insert_holdings_rows(
+            row_count += _replace_holdings_rows(
                 conn,
                 filing_id=filing_id,
                 manager_id=manager_id,

--- a/tests/test_edgar_flow.py
+++ b/tests/test_edgar_flow.py
@@ -115,6 +115,9 @@ class StrictPostgresConnection:
         if "INSERT INTO holdings" in sql:
             self.holdings.append(tuple(params))
             return StrictPostgresCursor([])
+        if "DELETE FROM holdings" in sql:
+            self.holdings = [holding for holding in self.holdings if holding[0] != params[0]]
+            return StrictPostgresCursor([])
         return StrictPostgresCursor([])
 
     def commit(self):
@@ -417,6 +420,24 @@ def test_upsert_filing_legacy_handles_minimal_raw_key_schema(tmp_path):
     assert rows == [("raw.xml",)]
 
 
+def test_latest_filed_date_for_cik_reads_existing_watermark(monkeypatch, tmp_path):
+    db_path = tmp_path / "dev.db"
+    _setup_relational_schema(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        "INSERT INTO filings(manager_id, type, filed_date, source, raw_key) VALUES (?,?,?,?,?)",
+        [
+            (100, "13F-HR", "2024-01-01", "edgar", "raw/1.xml"),
+            (100, "13F-HR", "2024-05-01", "edgar", "raw/2.xml"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(flow, "DB_PATH", str(db_path))
+
+    assert flow._latest_filed_date_for_cik("0") == "2024-05-01"
+
+
 @pytest.mark.asyncio
 async def test_fetch_and_store_skips_when_manager_missing(monkeypatch, tmp_path):
     db_path = tmp_path / "dev.db"
@@ -462,10 +483,7 @@ async def test_fetch_and_store_idempotent_rerun(monkeypatch, tmp_path):
 
     # Must have exactly 1 filing (not 2) after two runs with the same data
     assert filing_count == 1
-    # Holdings: first run inserts 1; second run resolves the existing filing_id
-    # via the ON CONFLICT fallback lookup and inserts holdings again.
-    # This is expected — holdings dedup is not in scope for this fix.
-    assert holding_count == 2
+    assert holding_count == 1
 
 
 @pytest.mark.asyncio
@@ -488,6 +506,43 @@ async def test_edgar_flow_skips_userwarning_and_writes_json(monkeypatch, tmp_pat
     parsed_path = tmp_path / "parsed.json"
     assert parsed_path.exists()
     assert json.loads(parsed_path.read_text()) == rows
+
+
+@pytest.mark.asyncio
+async def test_edgar_flow_uses_latest_stored_filed_date_when_since_missing(monkeypatch, tmp_path):
+    db_path = tmp_path / "dev.db"
+    _setup_relational_schema(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO filings(manager_id, type, filed_date, source, raw_key) VALUES (?,?,?,?,?)",
+        (100, "13F-HR", "2024-05-01", "edgar", "raw/latest.xml"),
+    )
+    conn.commit()
+    conn.close()
+
+    captured = {"since": None}
+
+    async def fake_ingest_flow(*, jurisdiction, identifiers, since, fetcher):
+        assert jurisdiction == "us"
+        assert identifiers == ["0"]
+        assert since is None
+        rows = await fetcher("0", "1970-01-01")
+        return rows
+
+    async def fake_fetch_and_store(cik, since):
+        assert cik == "0"
+        captured["since"] = since
+        return [{"nameOfIssuer": "Corp", "cusip": "AAA", "value": 1, "sshPrnamt": 1}]
+
+    monkeypatch.setattr(flow, "DB_PATH", str(db_path))
+    monkeypatch.setattr(flow.ingest_module, "ingest_flow", fake_ingest_flow)
+    monkeypatch.setattr(flow, "fetch_and_store", fake_fetch_and_store)
+    monkeypatch.setattr(flow, "RAW_DIR", tmp_path)
+
+    rows = await flow.edgar_flow.fn(cik_list=["0"], since=None)
+
+    assert captured["since"] == "2024-05-01"
+    assert rows == [{"nameOfIssuer": "Corp", "cusip": "AAA", "value": 1, "sshPrnamt": 1}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_edgar_flow.py
+++ b/tests/test_edgar_flow.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import sqlite3
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -93,7 +94,13 @@ class StrictPostgresConnection:
         self.filings = []
         self.holdings = []
         self.commits = 0
+        self.transactions = 0
         self.closed = False
+
+    @contextmanager
+    def transaction(self):
+        self.transactions += 1
+        yield
 
     def execute(self, sql, params=()):
         forbidden = ["PRAGMA", "AUTOINCREMENT", "INSERT OR IGNORE"]
@@ -398,6 +405,7 @@ async def test_fetch_and_store_uses_postgres_safe_persistence(monkeypatch):
         (9001, "BBB", "CorpB", 2, 2),
     ]
     assert conn.commits == 1
+    assert conn.transactions == 1
     assert conn.closed is True
     assert len(events) == 1
     assert events[0].event_type == "new_filing"
@@ -429,6 +437,7 @@ def test_latest_filed_date_for_cik_reads_existing_watermark(monkeypatch, tmp_pat
         [
             (100, "13F-HR", "2024-01-01", "edgar", "raw/1.xml"),
             (100, "13F-HR", "2024-05-01", "edgar", "raw/2.xml"),
+            (100, "ADV", "2024-08-01", "manual", "raw/manual.xml"),
         ],
     )
     conn.commit()
@@ -436,6 +445,30 @@ def test_latest_filed_date_for_cik_reads_existing_watermark(monkeypatch, tmp_pat
     monkeypatch.setattr(flow, "DB_PATH", str(db_path))
 
     assert flow._latest_filed_date_for_cik("0") == "2024-05-01"
+
+
+def test_replace_holdings_for_filing_uses_postgres_transaction():
+    conn = StrictPostgresConnection()
+
+    flow._replace_holdings_for_filing(
+        conn,
+        filing_id=9001,
+        rows=[
+            {"nameOfIssuer": "CorpA", "cusip": "AAA", "value": 1, "sshPrnamt": 1},
+            {"nameOfIssuer": "CorpB", "cusip": "BBB", "value": 2, "sshPrnamt": 2},
+        ],
+        manager_id=321,
+        cik="0",
+        accession="1",
+        filed_date="2024-05-01",
+    )
+
+    assert conn.transactions == 1
+    assert any("DELETE FROM holdings" in sql for sql in conn.sql)
+    assert conn.holdings == [
+        (9001, "AAA", "CorpA", 1, 1),
+        (9001, "BBB", "CorpB", 2, 2),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_edgar_flow.py
+++ b/tests/test_edgar_flow.py
@@ -449,6 +449,7 @@ def test_latest_filed_date_for_cik_reads_existing_watermark(monkeypatch, tmp_pat
 
 def test_replace_holdings_for_filing_uses_postgres_transaction():
     conn = StrictPostgresConnection()
+    conn.holdings = [(9001, "OLD", "Old Corp", 9, 9)]
 
     flow._replace_holdings_for_filing(
         conn,
@@ -464,7 +465,9 @@ def test_replace_holdings_for_filing_uses_postgres_transaction():
     )
 
     assert conn.transactions == 1
-    assert any("DELETE FROM holdings" in sql for sql in conn.sql)
+    assert ("DELETE FROM holdings WHERE filing_id = %s", (9001,)) in list(
+        zip(conn.sql, conn.params, strict=True)
+    )
     assert conn.holdings == [
         (9001, "AAA", "CorpA", 1, 1),
         (9001, "BBB", "CorpB", 2, 2),

--- a/tests/test_ingest_flow.py
+++ b/tests/test_ingest_flow.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+from contextlib import contextmanager
 
 import pytest
 
@@ -85,6 +86,21 @@ class _MetadataOnlyAdapter:
                 "raw_bytes": len(raw),
             }
         ]
+
+
+class _TransactionalConn:
+    def __init__(self):
+        self.transactions = 0
+        self.sql = []
+
+    @contextmanager
+    def transaction(self):
+        self.transactions += 1
+        yield
+
+    def execute(self, sql, params=()):
+        self.sql.append((sql, tuple(params)))
+        return []
 
 
 @pytest.mark.asyncio
@@ -250,6 +266,32 @@ def test_adapter_registry_covers_documented_jurisdictions():
         "au": "asic",
     }
     assert set(ingest_flow._IDENTIFIER_ENV) == {"us", "uk", "ca", "sg", "au"}
+
+
+def test_replace_holdings_rows_uses_postgres_transaction(monkeypatch):
+    conn = _TransactionalConn()
+
+    monkeypatch.setattr(ingest_flow, "_table_columns", lambda _conn, _table: {"filing_id"})
+    monkeypatch.setattr(
+        ingest_flow,
+        "_insert_holdings_rows",
+        lambda *args, **kwargs: 2,
+    )
+
+    inserted = ingest_flow._replace_holdings_rows(
+        conn,
+        filing_id=42,
+        manager_id=7,
+        identifier="0000000001",
+        external_id="0001-24-000001",
+        filed_date="2024-01-05",
+        parsed_rows=[{"cusip": "123456789"}],
+        jurisdiction="us",
+    )
+
+    assert inserted == 2
+    assert conn.transactions == 1
+    assert conn.sql == [("DELETE FROM holdings WHERE filing_id = %s", (42,))]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ingest_flow.py
+++ b/tests/test_ingest_flow.py
@@ -123,6 +123,43 @@ async def test_fetch_and_store_us_uses_manager_cik_and_inserts_holdings(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_store_us_replaces_existing_holdings_for_same_filing(tmp_path, monkeypatch):
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE managers (id INTEGER PRIMARY KEY AUTOINCREMENT, cik TEXT, registry_ids TEXT)"
+    )
+    conn.execute("INSERT INTO managers(cik, registry_ids) VALUES (?, ?)", ("0000000001", "{}"))
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(ingest_flow, "get_adapter", lambda _name: _USAdapter())
+    monkeypatch.setattr(ingest_flow.S3, "put_object", lambda **_kwargs: None)
+    monkeypatch.setattr(ingest_flow, "store_document", lambda _raw: None)
+
+    await ingest_flow.fetch_and_store.fn(
+        "0000000001",
+        "2024-01-01",
+        jurisdiction="us",
+        db_path=str(db_path),
+    )
+    await ingest_flow.fetch_and_store.fn(
+        "0000000001",
+        "2024-01-01",
+        jurisdiction="us",
+        db_path=str(db_path),
+    )
+
+    conn = sqlite3.connect(db_path)
+    holdings_count = conn.execute("SELECT COUNT(*) FROM holdings").fetchone()[0]
+    holding = conn.execute("SELECT accession, cusip, value, sshPrnamt FROM holdings").fetchone()
+    conn.close()
+
+    assert holdings_count == 1
+    assert holding == ("0001-24-000001", "123456789", 1000, 50)
+
+
+@pytest.mark.asyncio
 async def test_fetch_and_store_uk_uses_registry_id_and_stores_payload(tmp_path, monkeypatch):
     db_path = tmp_path / "dev.db"
     conn = sqlite3.connect(db_path)
@@ -327,7 +364,7 @@ async def test_edgar_flow_is_us_wrapper(monkeypatch):
     assert captured["jurisdiction"] == "us"
     assert captured["identifiers"] == ["0001"]
     assert captured["since"] == "2024-01-01"
-    assert captured["fetcher"] is edgar_flow.fetch_and_store
+    assert captured["fetcher"] is not edgar_flow.fetch_and_store
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1298

## Summary
- replace EDGAR holdings for an upserted filing before reinserting parsed rows
- preserve generic ingest SQLite filing ids with conflict updates instead of INSERT OR REPLACE
- resolve scheduled EDGAR runs from latest stored filed_date before falling back to 1970-01-01
- lazy-load embeddings storage to avoid import-time torch crashes in ingest tests

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_edgar_flow.py tests/test_ingest_flow.py -q
- black --fast --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' etl/edgar_flow.py etl/ingest_flow.py tests/test_edgar_flow.py tests/test_ingest_flow.py\n- deliberate-break: removing the legacy holdings replacement made tests/test_edgar_flow.py::test_fetch_and_store_idempotent_rerun fail with holding_count 2\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-running ingestion now replaces existing holdings for the same filing using a single transactional delete-then-replace flow (prevents duplicates).
  * When no start date is provided, EDGAR ingestion now resumes from the latest stored filed date for the relevant CIK.
  * UK filings now clear prior holdings before saving refreshed holdings.
  * Improved resilience: document storage now safely degrades when optional embedding support isn’t available.
* **Tests**
  * Extended coverage for EDGAR watermark behavior, holdings replacement transactions, and updated idempotency expectations.
  * Added assertions around safe persistence behavior and fetcher wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->