### PR TITLE
Guard numeric trust boundaries

### DIFF
--- a/adapters/edgar.py
+++ b/adapters/edgar.py
@@ -13,8 +13,9 @@ from xml.etree import ElementTree as ET
 
 import httpx
 
-from .base import tracked_call
 from utils.numeric import parse_finite_float
+
+from .base import tracked_call
 
 USER_AGENT = os.getenv("EDGAR_UA", "manager-intel/0.1")
 BASE_URL = "https://data.sec.gov"

--- a/adapters/edgar.py
+++ b/adapters/edgar.py
@@ -14,6 +14,7 @@ from xml.etree import ElementTree as ET
 import httpx
 
 from .base import tracked_call
+from utils.numeric import parse_finite_float
 
 USER_AGENT = os.getenv("EDGAR_UA", "manager-intel/0.1")
 BASE_URL = "https://data.sec.gov"
@@ -22,7 +23,21 @@ DEFAULT_FORM_TYPES = ["13F-HR"]
 THIRTEEN_F_FORMS = {"13F-HR", "13F-HR/A", "13-F"}
 ACTIVISM_FORMS = {"SC 13D", "SC 13D/A", "SC 13G", "SC 13G/A"}
 logger = logging.getLogger(__name__)
-EDGAR_MIN_REQUEST_INTERVAL: float = float(os.getenv("EDGAR_MIN_REQUEST_INTERVAL", "0.11"))
+
+
+def _parse_edgar_min_request_interval(raw: str | None) -> float:
+    try:
+        parsed = parse_finite_float(raw or "0.11", min_value=0.0, max_value=10.0, allow_none=False)
+    except (TypeError, ValueError):
+        logger.warning("Invalid EDGAR_MIN_REQUEST_INTERVAL; using default", extra={"value": raw})
+        return 0.11
+    assert parsed is not None
+    return parsed
+
+
+EDGAR_MIN_REQUEST_INTERVAL: float = _parse_edgar_min_request_interval(
+    os.getenv("EDGAR_MIN_REQUEST_INTERVAL")
+)
 _last_edgar_request_at: float | None = None
 
 
@@ -335,7 +350,12 @@ def _parse_float(value: str | None) -> float | None:
         return None
     cleaned = value.replace("%", "").replace(",", " ").strip()
     match = re.search(r"\d+(?:\.\d+)?", cleaned)
-    return float(match.group(0)) if match else None
+    if not match:
+        return None
+    try:
+        return parse_finite_float(match.group(0), min_value=0.0, max_value=100.0)
+    except ValueError:
+        return None
 
 
 def _extract_group_members(item_two_text: str) -> list[str]:

--- a/alerts/engine.py
+++ b/alerts/engine.py
@@ -7,12 +7,11 @@ from typing import Any
 
 from alerts.db import deserialize_json_object, ensure_alert_tables, placeholder, rule_from_row
 from alerts.models import AlertEvent, AlertRule, FiredAlert
+from utils.numeric import finite_float_or_none
 
 
 def _as_float(value: Any) -> float | None:
-    if value in (None, ""):
-        return None
-    return float(value)
+    return finite_float_or_none(value)
 
 
 def _as_int(value: Any) -> int | None:
@@ -66,7 +65,8 @@ class AlertEngine:
         for key, expected in condition.items():
             if key == "value_usd_gt":
                 value = _as_float(payload.get("value_usd"))
-                if value is None or value <= float(expected):
+                threshold = _as_float(expected)
+                if value is None or threshold is None or value <= threshold:
                     return False
                 continue
             if key == "delta_type":
@@ -88,22 +88,34 @@ class AlertEngine:
                     return False
                 continue
             if key == "time_window_hours":
-                if _event_age_hours(event) > float(expected):
+                hours = _as_float(expected)
+                if hours is None or _event_age_hours(event) > hours:
                     return False
                 continue
             if key == "min_ownership_pct":
-                ownership = _as_float(payload.get("ownership_pct"))
-                if ownership is None or ownership < float(expected):
+                ownership = finite_float_or_none(
+                    payload.get("ownership_pct"), min_value=0.0, max_value=100.0
+                )
+                threshold = finite_float_or_none(expected, min_value=0.0, max_value=100.0)
+                if ownership is None or threshold is None or ownership < threshold:
                     return False
                 continue
             if key == "min_delta_pct":
                 delta = _as_float(payload.get("delta_pct"))
-                if delta is None or abs(delta) < float(expected):
+                threshold = finite_float_or_none(expected, min_value=0.0, max_value=100.0)
+                if delta is None or threshold is None or abs(delta) < threshold:
                     return False
                 continue
             if key == "threshold_crossed":
-                threshold = _as_float(payload.get("threshold_crossed"))
-                if threshold != _as_float(expected):
+                threshold = finite_float_or_none(
+                    payload.get("threshold_crossed"), min_value=0.0, max_value=100.0
+                )
+                expected_threshold = finite_float_or_none(expected, min_value=0.0, max_value=100.0)
+                if (
+                    threshold is None
+                    or expected_threshold is None
+                    or threshold != expected_threshold
+                ):
                     return False
                 continue
 

--- a/api/search.py
+++ b/api/search.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sqlite3
 from typing import Any, Literal
 
+from utils.numeric import finite_float_or_none
+
 try:
     from pydantic import BaseModel, Field
 except ModuleNotFoundError:
@@ -69,18 +71,18 @@ def _table_exists(conn: Any, table_name: str) -> bool:
 
 
 def _normalize_rank(rank: float | int | None) -> float:
-    if rank is None:
+    rank_value = finite_float_or_none(rank, min_value=0.0)
+    if rank_value is None:
         return 0.0
-    rank_value = float(rank)
-    if rank_value <= 0.0:
+    if rank_value == 0.0:
         return 0.0
     return min(rank_value / (rank_value + 1.0), 1.0)
 
 
 def _vector_relevance(distance: float | int | None) -> float:
-    if distance is None:
+    dist = finite_float_or_none(distance, min_value=0.0)
+    if dist is None:
         return 0.0
-    dist = max(float(distance), 0.0)
     if dist > 1.0:
         dist = 1.0
     return 1.0 - dist

--- a/etl/activism_detection.py
+++ b/etl/activism_detection.py
@@ -104,15 +104,12 @@ def _parse_thresholds() -> tuple[float, ...]:
         stripped = part.strip()
         if not stripped:
             continue
-        try:
-            parsed = parse_finite_float(stripped, min_value=0.0, max_value=100.0, allow_none=False)
-            assert parsed is not None
-            values.append(round(parsed, 4))
-        except (TypeError, ValueError):
-            continue
+        parsed = parse_finite_float(stripped, min_value=0.0, max_value=100.0, allow_none=False)
+        assert parsed is not None
+        values.append(round(parsed, 4))
     valid_values = {value for value in values if value > 0}
     if not valid_values:
-        return OWNERSHIP_THRESHOLDS
+        raise ValueError("ACTIVISM_THRESHOLDS must contain at least one positive threshold")
     return tuple(sorted(valid_values))
 
 

--- a/etl/activism_detection.py
+++ b/etl/activism_detection.py
@@ -12,6 +12,7 @@ from typing import Any
 from alerts.db import ensure_alert_tables as _ensure_alert_tables
 from alerts.integration import fire_alerts_for_event_sync as _dispatch_alerts_for_event_sync
 from alerts.models import AlertEvent
+from utils.numeric import finite_float_or_none, parse_finite_float
 
 OWNERSHIP_THRESHOLDS = (5.0, 10.0, 15.0, 20.0, 25.0, 33.3, 50.0)
 ALERT_EVENT_TYPE = "activism_event"
@@ -85,9 +86,8 @@ def _deserialize_json_array(raw: Any) -> list[str]:
 
 
 def _to_float(value: Any) -> float | None:
-    if value is None or value == "":
-        return None
-    return round(float(value), 4)
+    parsed = finite_float_or_none(value, min_value=0.0, max_value=100.0)
+    return round(parsed, 4) if parsed is not None else None
 
 
 def _to_int(value: Any) -> int:
@@ -105,12 +105,15 @@ def _parse_thresholds() -> tuple[float, ...]:
         if not stripped:
             continue
         try:
-            values.append(round(float(stripped), 4))
-        except ValueError:
+            parsed = parse_finite_float(stripped, min_value=0.0, max_value=100.0, allow_none=False)
+            assert parsed is not None
+            values.append(round(parsed, 4))
+        except (TypeError, ValueError):
             continue
-    if not values:
+    valid_values = {value for value in values if value > 0}
+    if not valid_values:
         return OWNERSHIP_THRESHOLDS
-    return tuple(sorted({value for value in values if value > 0}))
+    return tuple(sorted(valid_values))
 
 
 def _normalize_form_type(form_type: str | None) -> str:
@@ -429,12 +432,14 @@ def _condition_matches(condition_json: Mapping[str, Any], payload: Mapping[str, 
     for key, expected in condition_json.items():
         if key == "min_ownership_pct":
             ownership_pct = _to_float(payload.get("ownership_pct"))
-            if ownership_pct is None or ownership_pct < float(expected):
+            expected_pct = _to_float(expected)
+            if ownership_pct is None or expected_pct is None or ownership_pct < expected_pct:
                 return False
             continue
         if key == "min_delta_pct":
-            delta_pct = _to_float(payload.get("delta_pct"))
-            if delta_pct is None or abs(delta_pct) < float(expected):
+            delta_pct = finite_float_or_none(payload.get("delta_pct"))
+            expected_delta = finite_float_or_none(expected, min_value=0.0, max_value=100.0)
+            if delta_pct is None or expected_delta is None or abs(delta_pct) < expected_delta:
                 return False
             continue
         if key == "threshold_crossed":

--- a/etl/conviction_flow.py
+++ b/etl/conviction_flow.py
@@ -139,9 +139,7 @@ def compute_conviction_scores(filing_id: int, conn: Any) -> int:
         logger.info("No holdings found for filing", extra={"filing_id": filing_id})
         return 0
 
-    holding_values = [
-        parse_finite_float(row[3] or 0.0, min_value=0.0, allow_none=False) for row in rows
-    ]
+    holding_values = [parse_finite_float(row[3], min_value=0.0, allow_none=False) for row in rows]
     total_value = sum(holding_values)
 
     upsert_sql = (

--- a/etl/conviction_flow.py
+++ b/etl/conviction_flow.py
@@ -16,6 +16,7 @@ from adapters.base import connect_db
 from alerts.integration import fire_alerts_for_event_sync
 from alerts.models import AlertEvent
 from etl.logging_setup import configure_logging
+from utils.numeric import parse_finite_float
 
 configure_logging("conviction_flow")
 logger = logging.getLogger(__name__)
@@ -138,7 +139,10 @@ def compute_conviction_scores(filing_id: int, conn: Any) -> int:
         logger.info("No holdings found for filing", extra={"filing_id": filing_id})
         return 0
 
-    total_value = sum(float(row[3] or 0.0) for row in rows)
+    holding_values = [
+        parse_finite_float(row[3] or 0.0, min_value=0.0, allow_none=False) for row in rows
+    ]
+    total_value = sum(holding_values)
 
     upsert_sql = (
         "INSERT INTO conviction_scores "
@@ -155,8 +159,9 @@ def compute_conviction_scores(filing_id: int, conn: Any) -> int:
         "computed_at = CURRENT_TIMESTAMP"
     )
 
-    for cusip, issuer, shares, value_usd in rows:
-        numeric_value = float(value_usd or 0.0)
+    for (cusip, issuer, shares, _value_usd), numeric_value in zip(
+        rows, holding_values, strict=True
+    ):
         if total_value > 0:
             portfolio_weight = numeric_value / total_value
             conviction_pct = portfolio_weight * 100.0

--- a/etl/conviction_flow.py
+++ b/etl/conviction_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import json
 import logging
+import math
 import os
 import sqlite3
 from typing import Any, TypedDict
@@ -141,6 +142,8 @@ def compute_conviction_scores(filing_id: int, conn: Any) -> int:
 
     holding_values = [parse_finite_float(row[3], min_value=0.0, allow_none=False) for row in rows]
     total_value = sum(holding_values)
+    if not math.isfinite(total_value):
+        raise ValueError("total holding value must be finite")
 
     upsert_sql = (
         "INSERT INTO conviction_scores "

--- a/tests/test_activism_detection.py
+++ b/tests/test_activism_detection.py
@@ -116,8 +116,30 @@ def test_detect_events_ignores_non_finite_ownership(tmp_path):
 
         events = detect_events(conn, filing)
 
+        assert "initial_stake" in _event_types(events)
         assert "threshold_crossing" not in _event_types(events)
         assert all(event.ownership_pct is None for event in events)
+    finally:
+        conn.close()
+
+
+def test_detect_events_rejects_invalid_threshold_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("ACTIVISM_THRESHOLDS", "5,inf,25")
+    conn = _setup_db(tmp_path / "activism.db")
+    try:
+        filing = _insert_filing(
+            conn,
+            filing_type="SC 13D",
+            filed_date="2024-05-01",
+            ownership_pct=6.0,
+        )
+
+        try:
+            detect_events(conn, filing)
+        except ValueError as exc:
+            assert "non-finite numeric value" in str(exc)
+        else:
+            raise AssertionError("invalid ACTIVISM_THRESHOLDS should fail fast")
     finally:
         conn.close()
 

--- a/tests/test_activism_detection.py
+++ b/tests/test_activism_detection.py
@@ -104,6 +104,24 @@ def test_detect_events_initial_stake(tmp_path):
         conn.close()
 
 
+def test_detect_events_ignores_non_finite_ownership(tmp_path):
+    conn = _setup_db(tmp_path / "activism.db")
+    try:
+        filing = _insert_filing(
+            conn,
+            filing_type="SC 13D",
+            filed_date="2024-05-01",
+            ownership_pct=float("inf"),
+        )
+
+        events = detect_events(conn, filing)
+
+        assert "threshold_crossing" not in _event_types(events)
+        assert all(event.ownership_pct is None for event in events)
+    finally:
+        conn.close()
+
+
 def test_detect_events_stake_increase(tmp_path):
     conn = _setup_db(tmp_path / "activism.db")
     try:

--- a/tests/test_alert_engine.py
+++ b/tests/test_alert_engine.py
@@ -65,6 +65,30 @@ def test_alert_engine_matches_value_threshold_and_delta_type(tmp_path):
         conn.close()
 
 
+def test_alert_engine_ignores_non_finite_numeric_rule_values(tmp_path):
+    conn = _setup_db(tmp_path / "alerts.db")
+    try:
+        _insert_rule(
+            conn,
+            name="NaN Threshold",
+            event_type="large_delta",
+            condition_json='{"value_usd_gt":"nan"}',
+        )
+
+        engine = AlertEngine(conn)
+        fired = engine.evaluate(
+            AlertEvent(
+                event_type="large_delta",
+                manager_id=1,
+                payload={"value_usd": 1.0},
+            )
+        )
+
+        assert fired == []
+    finally:
+        conn.close()
+
+
 def test_alert_engine_manager_filter_and_disabled_rules(tmp_path):
     conn = _setup_db(tmp_path / "alerts.db")
     try:

--- a/tests/test_conviction_flow.py
+++ b/tests/test_conviction_flow.py
@@ -109,6 +109,27 @@ def test_compute_conviction_scores_edge_cases(tmp_path, holdings, expected_pct, 
     assert row[1] == pytest.approx(expected_weight, rel=1e-6)
 
 
+def test_compute_conviction_scores_rejects_non_finite_values(tmp_path):
+    db_path = tmp_path / "nonfinite.db"
+    conn = sqlite3.connect(db_path)
+    _create_base_tables(conn)
+    conviction_flow._ensure_conviction_scores_table(conn)
+
+    _seed_manager_and_filing(conn, manager_id=4, filing_id=40, filed_date="2025-12-31")
+    conn.executemany(
+        "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) VALUES (?, ?, ?, ?, ?)",
+        [
+            (40, "GOOD01", "Good Corp", 10, 100.0),
+            (40, "BAD001", "Bad Corp", 10, "nan"),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="non-finite numeric value"):
+        conviction_flow.compute_conviction_scores.fn(40, conn)
+
+    assert conn.execute("SELECT COUNT(*) FROM conviction_scores").fetchone() == (0,)
+
+
 def test_compute_conviction_scores_upsert_is_idempotent(tmp_path):
     db_path = tmp_path / "upsert.db"
     conn = sqlite3.connect(db_path)

--- a/tests/test_conviction_flow.py
+++ b/tests/test_conviction_flow.py
@@ -130,6 +130,27 @@ def test_compute_conviction_scores_rejects_non_finite_values(tmp_path):
     assert conn.execute("SELECT COUNT(*) FROM conviction_scores").fetchone() == (0,)
 
 
+def test_compute_conviction_scores_rejects_missing_values(tmp_path):
+    db_path = tmp_path / "missing.db"
+    conn = sqlite3.connect(db_path)
+    _create_base_tables(conn)
+    conviction_flow._ensure_conviction_scores_table(conn)
+
+    _seed_manager_and_filing(conn, manager_id=4, filing_id=41, filed_date="2025-12-31")
+    conn.executemany(
+        "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) VALUES (?, ?, ?, ?, ?)",
+        [
+            (41, "GOOD01", "Good Corp", 10, 100.0),
+            (41, "MISS01", "Missing Corp", 10, None),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="numeric value is required"):
+        conviction_flow.compute_conviction_scores.fn(41, conn)
+
+    assert conn.execute("SELECT COUNT(*) FROM conviction_scores").fetchone() == (0,)
+
+
 def test_compute_conviction_scores_upsert_is_idempotent(tmp_path):
     db_path = tmp_path / "upsert.db"
     conn = sqlite3.connect(db_path)

--- a/tests/test_conviction_flow.py
+++ b/tests/test_conviction_flow.py
@@ -133,22 +133,49 @@ def test_compute_conviction_scores_rejects_non_finite_values(tmp_path):
 def test_compute_conviction_scores_rejects_missing_values(tmp_path):
     db_path = tmp_path / "missing.db"
     conn = sqlite3.connect(db_path)
-    _create_base_tables(conn)
-    conviction_flow._ensure_conviction_scores_table(conn)
+    try:
+        _create_base_tables(conn)
+        conviction_flow._ensure_conviction_scores_table(conn)
 
-    _seed_manager_and_filing(conn, manager_id=4, filing_id=41, filed_date="2025-12-31")
-    conn.executemany(
-        "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) VALUES (?, ?, ?, ?, ?)",
-        [
-            (41, "GOOD01", "Good Corp", 10, 100.0),
-            (41, "MISS01", "Missing Corp", 10, None),
-        ],
-    )
+        _seed_manager_and_filing(conn, manager_id=4, filing_id=41, filed_date="2025-12-31")
+        conn.executemany(
+            "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) VALUES (?, ?, ?, ?, ?)",
+            [
+                (41, "GOOD01", "Good Corp", 10, 100.0),
+                (41, "MISS01", "Missing Corp", 10, None),
+            ],
+        )
 
-    with pytest.raises(ValueError, match="numeric value is required"):
-        conviction_flow.compute_conviction_scores.fn(41, conn)
+        with pytest.raises(ValueError, match="numeric value is required"):
+            conviction_flow.compute_conviction_scores.fn(41, conn)
 
-    assert conn.execute("SELECT COUNT(*) FROM conviction_scores").fetchone() == (0,)
+        assert conn.execute("SELECT COUNT(*) FROM conviction_scores").fetchone() == (0,)
+    finally:
+        conn.close()
+
+
+def test_compute_conviction_scores_rejects_overflowed_total_value(tmp_path):
+    db_path = tmp_path / "overflow.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        _create_base_tables(conn)
+        conviction_flow._ensure_conviction_scores_table(conn)
+
+        _seed_manager_and_filing(conn, manager_id=4, filing_id=42, filed_date="2025-12-31")
+        conn.executemany(
+            "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) VALUES (?, ?, ?, ?, ?)",
+            [
+                (42, "BIG001", "Big Corp", 10, 1e308),
+                (42, "BIG002", "Bigger Corp", 10, 1e308),
+            ],
+        )
+
+        with pytest.raises(ValueError, match="total holding value must be finite"):
+            conviction_flow.compute_conviction_scores.fn(42, conn)
+
+        assert conn.execute("SELECT COUNT(*) FROM conviction_scores").fetchone() == (0,)
+    finally:
+        conn.close()
 
 
 def test_compute_conviction_scores_upsert_is_idempotent(tmp_path):

--- a/tests/test_numeric.py
+++ b/tests/test_numeric.py
@@ -1,0 +1,8 @@
+import pytest
+
+from utils.numeric import parse_finite_float
+
+
+def test_parse_finite_float_normalizes_overflow() -> None:
+    with pytest.raises(ValueError, match="numeric value overflow"):
+        parse_finite_float(10**1000, allow_none=False)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -12,7 +12,7 @@ import httpx
 from fastapi.encoders import jsonable_encoder
 
 import api.chat as chat_api_module
-from api.search import SearchResult, universal_search
+from api.search import SearchResult, _score_result, universal_search
 from tests.route_helpers import route_paths
 from ui.search import (
     _count_results_by_entity_type,
@@ -185,6 +185,19 @@ def test_universal_search_returns_ranked_multi_entity_results():
     entity_types = {item.entity_type for item in results}
     assert {"manager", "filing", "news", "document", "holding"}.issubset(entity_types)
     assert results == sorted(results, key=lambda item: item.relevance, reverse=True)
+
+
+def test_score_result_clamps_non_finite_rank_and_distance():
+    score = _score_result(
+        "news",
+        "elliott",
+        "Elliott files 13D",
+        "activist position",
+        fts_rank=float("nan"),
+        vector_distance=float("inf"),
+    )
+
+    assert 0.0 <= score <= 1.0
 
 
 def test_universal_search_filters_results_by_entity_type():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -188,6 +188,14 @@ def test_universal_search_returns_ranked_multi_entity_results():
 
 
 def test_score_result_clamps_non_finite_rank_and_distance():
+    baseline = _score_result(
+        "news",
+        "elliott",
+        "Elliott files 13D",
+        "activist position",
+        fts_rank=None,
+        vector_distance=None,
+    )
     score = _score_result(
         "news",
         "elliott",
@@ -197,7 +205,7 @@ def test_score_result_clamps_non_finite_rank_and_distance():
         vector_distance=float("inf"),
     )
 
-    assert 0.0 <= score <= 1.0
+    assert score == baseline
 
 
 def test_universal_search_filters_results_by_entity_type():

--- a/tests/test_wasm_demo_build.py
+++ b/tests/test_wasm_demo_build.py
@@ -7,6 +7,7 @@ import sqlite3
 import sys
 
 import httpx
+import streamlit as st
 
 from scripts.build_wasm_demo import build_wasm_demo
 from scripts.seed_managers import SEED_MANAGERS
@@ -36,6 +37,7 @@ def test_deterministic_pages_render_offline(monkeypatch, tmp_path):
     monkeypatch.delenv("MINIO_ENDPOINT", raising=False)
     monkeypatch.setenv("UI_OFFLINE", "1")
     monkeypatch.setenv("USE_SIMPLE_EMBED", "1")
+    st.cache_data.clear()
 
     from ui import daily_report, dashboard, search, upload
 

--- a/utils/numeric.py
+++ b/utils/numeric.py
@@ -1,0 +1,42 @@
+"""Numeric parsing helpers for external trust boundaries."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def parse_finite_float(
+    value: Any,
+    *,
+    min_value: float | None = None,
+    max_value: float | None = None,
+    allow_none: bool = True,
+) -> float | None:
+    """Parse a finite float and optionally enforce inclusive bounds."""
+    if value in (None, ""):
+        if allow_none:
+            return None
+        raise ValueError("numeric value is required")
+
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite numeric value: {value!r}")
+    if min_value is not None and parsed < min_value:
+        raise ValueError(f"numeric value below minimum {min_value}: {value!r}")
+    if max_value is not None and parsed > max_value:
+        raise ValueError(f"numeric value above maximum {max_value}: {value!r}")
+    return parsed
+
+
+def finite_float_or_none(
+    value: Any,
+    *,
+    min_value: float | None = None,
+    max_value: float | None = None,
+) -> float | None:
+    """Parse a finite float, returning None for invalid or out-of-range input."""
+    try:
+        return parse_finite_float(value, min_value=min_value, max_value=max_value)
+    except (TypeError, ValueError):
+        return None

--- a/utils/numeric.py
+++ b/utils/numeric.py
@@ -19,7 +19,10 @@ def parse_finite_float(
             return None
         raise ValueError("numeric value is required")
 
-    parsed = float(value)
+    try:
+        parsed = float(value)
+    except OverflowError as exc:
+        raise ValueError(f"numeric value overflow: {value!r}") from exc
     if not math.isfinite(parsed):
         raise ValueError(f"non-finite numeric value: {value!r}")
     if min_value is not None and parsed < min_value:


### PR DESCRIPTION
Closes #1299

## Summary
- add a shared finite float parser for external numeric trust boundaries
- reject or quarantine NaN/inf/out-of-range values in alert rules, activism detection, conviction scoring, EDGAR pacing/parsing, and search relevance scoring
- add focused regressions for NaN alert thresholds, non-finite activism ownership, non-finite conviction values, and non-finite search scoring inputs

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_alert_engine.py tests/test_activism_detection.py tests/test_conviction_flow.py tests/test_search.py -q
- black --fast --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' utils/numeric.py alerts/engine.py etl/activism_detection.py etl/conviction_flow.py adapters/edgar.py api/search.py tests/test_alert_engine.py tests/test_activism_detection.py tests/test_conviction_flow.py tests/test_search.py\n- deliberate break: replacing alerts.engine._as_float with raw float made tests/test_alert_engine.py::test_alert_engine_ignores_non_finite_numeric_rule_values fail, then restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced centralized safe numeric parsing helpers with optional bounds for consistent validation of external inputs.
* **Bug Fixes**
  * Prevents alerts, ETL scoring, search relevance, and activism detection from using `NaN`/`inf` or out-of-range values.
  * Validates minimum request interval configuration with warnings and safe fallback.
  * Improves threshold handling to fail fast when configuration yields no valid values.
* **Tests**
  * Added coverage for non-finite numeric inputs, invalid threshold environment values, and overflow behavior in numeric parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->