### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,48 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/getting-started/configure-coderabbit
+# Fleet default, synced from stranske/Workflows (templates/consumer-repo/.coderabbit.yaml).
+# Tuned for the stranske autonomous-agent fleet:
+#   - assertive review of substantial agent-authored PRs
+#   - advisory / non-gating, matching the fleet rule that review never blocks a merge
+#   - maintenance-bot PRs and generated sync/draft PRs do not spend review budget
+#   - a workflow-injection guard, since workflow YAML is synced across consumer repos
+language: en-US
+reviews:
+  profile: assertive
+  request_changes_workflow: false      # advisory: never auto-block a merge (fleet rule)
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false                      # opener creates drafts; review when marked ready
+    # Skip automatic-review budget on maintenance-bot PRs (dependency bumps, CI/version
+    # syncs). agents-workflows-bot is intentionally NOT listed — it authors substantial
+    # agent code PRs (e.g. "Agent belt for #N") that should still be reviewed.
+    ignore_usernames:
+      - "renovate[bot]"
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+      - "stranske-keepalive[bot]"
+    # Also skip generated maintenance / sync PRs by title and by negative label.
+    ignore_title_keywords:
+      - "chore: sync workflow templates"
+      - "sync workflow templates"
+    labels:
+      - "!sync"
+      - "!workflow:source-sync"
+      - "!workflow:source-maintenance"
+      - "!consumer-sync"
+      - "!integration-sync"
+      - "!workflows-sync"
+      - "!template-sync"
+  path_filters:
+    - "!**/*.lock"
+    - "!**/vendor/**"
+    - "!**/.workflows-lib/**"
+  path_instructions:
+    - path: ".github/workflows/**"
+      instructions: >-
+        Flag template-injection, unpinned third-party actions, and spoofable bot-actor
+        checks — this workflow YAML is synced across consumer repos, so one bug
+        replicates fleet-wide.
+chat:
+  auto_reply: true

--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -1283,7 +1283,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
-            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -1354,7 +1353,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
-            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -1553,7 +1551,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
-            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/runtime_ac_merge_guard.js
             .github/scripts/token_load_balancer.js

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -842,12 +842,9 @@ def evaluate_pr_multiple(
 ) -> list[EvaluationResult]:
     change_type = _classify_change_type(_bounded_diff_for_classification(diff))
     runner = ComparisonRunner.from_environment(context, diff, model1, model2)
-    families = {_provider_family(provider) for _, provider, _ in runner.clients}
-    if len(runner.clients) < 2 or len(families) < 2:
-        result = _fallback_evaluation(
-            "unverified: compare mode requires two cross-family verifier judges; "
-            f"available families: {', '.join(sorted(families)) or 'none'}."
-        )
+    is_valid, error_message = _validate_comparison_clients(runner.clients)
+    if not is_valid:
+        result = _fallback_evaluation(error_message)
         result.change_type = change_type
         return [result]
     results: list[EvaluationResult] = []
@@ -867,6 +864,47 @@ def _provider_family(provider: str) -> str:
     if "anthropic" in label or "claude" in label:
         return "anthropic"
     return label.split("/", 1)[0].strip() or "unknown"
+
+
+def _get_provider_families(clients: list[tuple[object, str, str]]) -> set[str]:
+    """Extract the set of unique provider families from a list of clients.
+
+    Args:
+        clients: List of (client, provider, model) tuples.
+
+    Returns:
+        Set of provider family names (e.g., {"openai", "anthropic"}).
+    """
+    return {_provider_family(provider) for _, provider, _ in clients}
+
+
+def _validate_comparison_clients(clients: list[tuple[object, str, str]]) -> tuple[bool, str]:
+    """Validate that client list is sufficient for cross-family comparison.
+
+    Args:
+        clients: List of (client, provider, model) tuples.
+
+    Returns:
+        Tuple of (is_valid, error_message).
+        is_valid is True if there are >= 2 clients from >= 2 different provider families.
+        error_message describes the reason if validation fails.
+    """
+    families = _get_provider_families(clients)
+    if len(clients) < 2:
+        family_str = ", ".join(sorted(families)) or "none"
+        return (
+            False,
+            f"unverified: compare mode requires two cross-family verifier judges; "
+            f"available families: {family_str}.",
+        )
+    if len(families) < 2:
+        family_str = ", ".join(sorted(families)) or "none"
+        return (
+            False,
+            f"unverified: compare mode requires two cross-family verifier judges; "
+            f"available families: {family_str}.",
+        )
+    return True, ""
 
 
 def _normalize_text(text: str) -> str:

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -130,6 +130,10 @@ def _provider_instruction_path(workspace: Path, provider: str) -> Path:
     return workspace / ".github" / "claude" / "AGENT_INSTRUCTIONS.md"
 
 
+def _repository_guidance_path(workspace: Path) -> Path:
+    return workspace / "AGENTS.md"
+
+
 def _prompt_output_name(provider: str, pr_number: str | int | None) -> str:
     suffix = f"-{pr_number}" if pr_number not in (None, "") else ""
     return f"{provider}-prompt{suffix}.md"
@@ -488,6 +492,10 @@ def assemble_prompt(
 
     if appendix:
         parts.extend(["\n\n## Run context\n", appendix.rstrip()])
+
+    repository_guidance = _repository_guidance_path(workspace)
+    if repository_guidance.is_file():
+        parts.extend(["\n\n## Repository Guidance\n", _read_text(repository_guidance).rstrip()])
 
     reference_summary = workspace / ".reference" / "REFERENCE_PACKS.md"
     if reference_summary.is_file():

--- a/scripts/validate_run_contract.py
+++ b/scripts/validate_run_contract.py
@@ -261,6 +261,20 @@ def validate_envelope(
     return report
 
 
+def _find_participant(registry: dict[str, Any], repo: str) -> dict[str, Any] | None:
+    """Look up a participant by repo in the registry. Returns None if not found."""
+    return _find_entry(registry, repo)
+
+
+def _is_missing_envelope_a_failure(entry: dict[str, Any] | None) -> bool:
+    """Decide whether a missing envelope should fail (True) or skip (False).
+
+    An emitting or conformant participant MUST have an envelope; all others
+    (absent, candidate, none, planned) are opt-in skip.
+    """
+    return entry is not None and entry.get("status") in EMITTING_STATUSES
+
+
 def missing_envelope_report(registry: dict[str, Any], repo: str, run_json: Path) -> Report:
     """Decide what a MISSING run envelope means for ``repo``.
 
@@ -274,10 +288,10 @@ def missing_envelope_report(registry: dict[str, Any], repo: str, run_json: Path)
     is never failed just for lacking an envelope) without silencing a real
     regression in an active participant.
     """
-    entry = _find_entry(registry, repo)
+    entry = _find_participant(registry, repo)
     report = Report(repo=repo, role=entry.get("role", "") if entry else "")
-    is_active_participant = entry is not None and entry.get("status") in EMITTING_STATUSES
-    if is_active_participant:
+
+    if _is_missing_envelope_a_failure(entry):
         assert entry is not None
         report.fail(
             f"{repo} is an active backplane participant "
@@ -406,9 +420,11 @@ def _self_smoke(schema_dir: Path, registry_path: Path) -> int:
                     True,
                 )
             )
+        # Unsafe raw payload fixtures must fail without echoing sensitive values.
         for inv in (
             "missing_cost.json",
             "unsafe_rows_inline.json",
+            "unsafe_prompt_inline.json",
             "artifact_not_in_manifest.json",
             "bad_identity_ref.json",
         ):


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-81-gate-followups.yml: Gate followups hub - consolidates keepalive and autofix followups
- runner_lib/ (1 files): Shared runner prompt assembly, output parsing, and dispatch debounce helpers
- pr_verifier.py: PR verifier - validates PR changes against acceptance criteria
- validate_run_contract.py: Validates a repo's emitted run-contract/v1 run envelope (producer/bridge) or ingested satellite object (consumer) against the canonical Workflows schemas + opt-in participant registry. Offline/deterministic; opt-in skip for non-participants. Synced so participants can validate locally and the reusable conformance gate can invoke it.
- .coderabbit.yaml: CodeRabbit auto-review config - skips maintenance-bot PRs (renovate/dependabot/github-actions/keepalive) and generated sync/draft PRs, while keeping substantial agent-authored PR reviews enabled. Advisory/non-gating per fleet rule.

### Files Skipped
- .github/workflows/pr-00-gate.yml: Maintains a fully custom Gate workflow; never overwrite (replaces the hard-coded custom_gate_repos list in maint-68).
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `a39db6ed099915c1a982d8326764033279c2ad88`
**Template hash:** `5a2d084a5b65`
**Sync branch:** `sync/workflows-5a2d084a5b65`
**Consumer repo:** `stranske/Manager-Database`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Manager-Database","source_repository":"stranske/Workflows","source_sha":"a39db6ed099915c1a982d8326764033279c2ad88","template_hash":"5a2d084a5b65","sync_branch":"sync/workflows-5a2d084a5b65","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"28353148009","run_attempt":"1","changes_count":5} -->