### PR TITLE
Add schema SQL and Alembic parity gate

### DIFF
--- a/alembic/versions/001_canonical_schema.py
+++ b/alembic/versions/001_canonical_schema.py
@@ -147,6 +147,11 @@ def upgrade() -> None:
     op.create_index(
         "idx_news_items_manager_published_at", "news_items", ["manager_id", "published_at"]
     )
+    if pg:
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_news_items_topics_gin "
+            "ON news_items USING GIN (topics)"
+        )
 
     # ── documents ─────────────────────────────────────────────
     op.create_table(

--- a/alembic/versions/009_chat_feedback.py
+++ b/alembic/versions/009_chat_feedback.py
@@ -27,7 +27,7 @@ def upgrade() -> None:
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
-            nullable=True,
+            nullable=False,
             server_default=text("CURRENT_TIMESTAMP"),
         ),
         sa.CheckConstraint("rating BETWEEN 1 AND 5", name="ck_chat_feedback_rating_range"),

--- a/alembic/versions/010_schema_sql_parity_fixes.py
+++ b/alembic/versions/010_schema_sql_parity_fixes.py
@@ -1,0 +1,47 @@
+"""Close schema.sql and Alembic Postgres parity gaps.
+
+Revision ID: 010
+Revises: 009
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "010"
+down_revision = "009"
+branch_labels = None
+depends_on = None
+
+
+def _is_postgresql() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    if _is_postgresql():
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_news_items_topics_gin "
+            "ON news_items USING GIN (topics)"
+        )
+        op.alter_column(
+            "chat_feedback",
+            "created_at",
+            existing_type=sa.DateTime(timezone=True),
+            nullable=False,
+            existing_server_default=sa.text("CURRENT_TIMESTAMP"),
+        )
+
+
+def downgrade() -> None:
+    if _is_postgresql():
+        op.alter_column(
+            "chat_feedback",
+            "created_at",
+            existing_type=sa.DateTime(timezone=True),
+            nullable=True,
+            existing_server_default=sa.text("CURRENT_TIMESTAMP"),
+        )
+        op.execute("DROP INDEX IF EXISTS idx_news_items_topics_gin")

--- a/schema.sql
+++ b/schema.sql
@@ -248,7 +248,7 @@ CREATE TABLE IF NOT EXISTS chat_feedback (
     response_id text NOT NULL,
     rating int NOT NULL CHECK (rating BETWEEN 1 AND 5),
     comment text,
-    created_at timestamptz DEFAULT now()
+    created_at timestamptz NOT NULL DEFAULT now()
 );
 
 CREATE INDEX IF NOT EXISTS idx_chat_feedback_response_id

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -294,6 +294,7 @@ def test_alert_tables_schema_contract(monkeypatch, tmp_path):
         }
         assert chat_feedback["response_id"]["notnull"] is True
         assert chat_feedback["rating"]["notnull"] is True
+        assert chat_feedback["created_at"]["notnull"] is True
         assert chat_feedback["created_at"]["default"] in ("CURRENT_TIMESTAMP", "current_timestamp")
 
 

--- a/tests/test_schema_postgres_bootstrap.py
+++ b/tests/test_schema_postgres_bootstrap.py
@@ -239,7 +239,19 @@ def _reset_schema(conn, schema_name: str) -> None:
 
 
 def _catalog_snapshot(conn) -> dict[str, set[tuple[str, ...]]]:
+    def normalize_sql(value: str | None, schema_name: str) -> str:
+        if value is None:
+            return ""
+        return (
+            value.replace(f'"{schema_name}".', "")
+            .replace(f"{schema_name}.", "")
+            .replace("public.", "")
+        )
+
     with conn.cursor() as cur:
+        cur.execute("SELECT current_schema()")
+        schema_name = cur.fetchone()[0]
+
         cur.execute(
             """
             SELECT tablename
@@ -253,29 +265,80 @@ def _catalog_snapshot(conn) -> dict[str, set[tuple[str, ...]]]:
 
         cur.execute(
             """
-            SELECT table_name, column_name, is_nullable
-              FROM information_schema.columns
-             WHERE table_schema = current_schema()
-               AND table_name <> ALL(%s)
-             ORDER BY table_name, ordinal_position
+            SELECT
+                c.relname AS table_name,
+                a.attname AS column_name,
+                a.attnum::text AS ordinal_position,
+                format_type(a.atttypid, a.atttypmod) AS column_type,
+                CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+                pg_get_expr(d.adbin, d.adrelid) AS column_default
+            FROM pg_attribute a
+            JOIN pg_class c ON c.oid = a.attrelid
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+            WHERE n.nspname = current_schema()
+              AND c.relkind IN ('r', 'p')
+              AND c.relname <> ALL(%s)
+              AND a.attnum > 0
+              AND NOT a.attisdropped
+            ORDER BY c.relname, a.attnum
             """,
             (list(IGNORED_PARITY_TABLES),),
         )
-        columns = {(row[0], row[1], row[2]) for row in cur.fetchall()}
+        columns = {
+            (row[0], row[1], row[2], row[3], row[4], normalize_sql(row[5], schema_name))
+            for row in cur.fetchall()
+        }
 
         cur.execute(
             """
-            SELECT tablename, indexname
-              FROM pg_indexes
-             WHERE schemaname = current_schema()
-               AND tablename <> ALL(%s)
-             ORDER BY tablename, indexname
+            SELECT
+                tablename,
+                indexname,
+                indexdef
+            FROM pg_indexes
+            WHERE schemaname = current_schema()
+              AND tablename <> ALL(%s)
+            ORDER BY tablename, indexname
             """,
             (list(IGNORED_PARITY_TABLES),),
         )
-        indexes = {(row[0], row[1]) for row in cur.fetchall()}
+        indexes = {(row[0], row[1], normalize_sql(row[2], schema_name)) for row in cur.fetchall()}
 
-    return {"tables": tables, "columns": columns, "indexes": indexes}
+        cur.execute(
+            """
+            SELECT
+                c.relname AS table_name,
+                con.contype,
+                pg_get_constraintdef(con.oid, true) AS definition
+            FROM pg_constraint con
+            JOIN pg_class c ON c.oid = con.conrelid
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = current_schema()
+              AND c.relname <> ALL(%s)
+            ORDER BY c.relname, con.contype, pg_get_constraintdef(con.oid, true)
+            """,
+            (list(IGNORED_PARITY_TABLES),),
+        )
+        constraints = {
+            (row[0], row[1], normalize_sql(row[2], schema_name)) for row in cur.fetchall()
+        }
+
+        cur.execute("""
+            SELECT matviewname, definition
+              FROM pg_matviews
+             WHERE schemaname = current_schema()
+             ORDER BY matviewname
+            """)
+        matviews = {(row[0], normalize_sql(row[1], schema_name)) for row in cur.fetchall()}
+
+    return {
+        "tables": tables,
+        "columns": columns,
+        "indexes": indexes,
+        "constraints": constraints,
+        "materialized_views": matviews,
+    }
 
 
 def _assert_snapshots_match(
@@ -283,7 +346,7 @@ def _assert_snapshots_match(
     alembic_snapshot: dict[str, set[tuple[str, ...]]],
 ) -> None:
     messages: list[str] = []
-    for key in ("tables", "columns", "indexes"):
+    for key in ("tables", "columns", "indexes", "constraints", "materialized_views"):
         only_schema = schema_sql_snapshot[key] - alembic_snapshot[key]
         only_alembic = alembic_snapshot[key] - schema_sql_snapshot[key]
         if only_schema:

--- a/tests/test_schema_postgres_bootstrap.py
+++ b/tests/test_schema_postgres_bootstrap.py
@@ -19,8 +19,12 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from urllib.parse import quote
 
 import pytest
+from alembic.config import Config
+
+from alembic import command
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_SQL = ROOT / "schema.sql"
@@ -51,7 +55,8 @@ EXPECTED_TABLES = {
     "activism_events",
 }
 EXPECTED_MATVIEWS = {"monthly_usage", "mv_daily_report"}
-EXPECTED_INDEXES = {"mv_daily_report_idx"}
+EXPECTED_INDEXES = {"idx_news_items_topics_gin", "mv_daily_report_idx"}
+IGNORED_PARITY_TABLES = {"alembic_version"}
 
 
 def test_split_sql_statements_handles_dollar_quotes():
@@ -213,6 +218,81 @@ def _apply_schema_sql(conn) -> None:
     conn.commit()
 
 
+def _alembic_config(db_url: str) -> Config:
+    config = Config(str(ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(ROOT / "alembic"))
+    config.set_main_option("sqlalchemy.url", db_url)
+    return config
+
+
+def _url_with_search_path(db_url: str, schema_name: str) -> str:
+    separator = "&" if "?" in db_url else "?"
+    return f"{db_url}{separator}options={quote(f'-csearch_path={schema_name}', safe='')}"
+
+
+def _reset_schema(conn, schema_name: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE')
+        cur.execute(f'CREATE SCHEMA "{schema_name}"')
+        cur.execute(f'SET search_path TO "{schema_name}"')
+    conn.commit()
+
+
+def _catalog_snapshot(conn) -> dict[str, set[tuple[str, ...]]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT tablename
+              FROM pg_tables
+             WHERE schemaname = current_schema()
+               AND tablename <> ALL(%s)
+            """,
+            (list(IGNORED_PARITY_TABLES),),
+        )
+        tables = {(row[0],) for row in cur.fetchall()}
+
+        cur.execute(
+            """
+            SELECT table_name, column_name, is_nullable
+              FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name <> ALL(%s)
+             ORDER BY table_name, ordinal_position
+            """,
+            (list(IGNORED_PARITY_TABLES),),
+        )
+        columns = {(row[0], row[1], row[2]) for row in cur.fetchall()}
+
+        cur.execute(
+            """
+            SELECT tablename, indexname
+              FROM pg_indexes
+             WHERE schemaname = current_schema()
+               AND tablename <> ALL(%s)
+             ORDER BY tablename, indexname
+            """,
+            (list(IGNORED_PARITY_TABLES),),
+        )
+        indexes = {(row[0], row[1]) for row in cur.fetchall()}
+
+    return {"tables": tables, "columns": columns, "indexes": indexes}
+
+
+def _assert_snapshots_match(
+    schema_sql_snapshot: dict[str, set[tuple[str, ...]]],
+    alembic_snapshot: dict[str, set[tuple[str, ...]]],
+) -> None:
+    messages: list[str] = []
+    for key in ("tables", "columns", "indexes"):
+        only_schema = schema_sql_snapshot[key] - alembic_snapshot[key]
+        only_alembic = alembic_snapshot[key] - schema_sql_snapshot[key]
+        if only_schema:
+            messages.append(f"{key} only in schema.sql bootstrap: {sorted(only_schema)}")
+        if only_alembic:
+            messages.append(f"{key} only in Alembic bootstrap: {sorted(only_alembic)}")
+    assert not messages, "\n".join(messages)
+
+
 def test_schema_sql_bootstraps_clean_postgres(pg_url, psycopg_module):
     """schema.sql must apply end-to-end and create all API/ETL-critical tables and matviews."""
     with psycopg_module.connect(pg_url, autocommit=False) as conn:
@@ -235,6 +315,28 @@ def test_schema_sql_bootstraps_clean_postgres(pg_url, psycopg_module):
             f"schema.sql did not create expected matviews: {missing_matviews!r}\n"
             f"matviews present: {sorted(matviews)}"
         )
+
+
+def test_schema_sql_and_alembic_postgres_parity(pg_url, psycopg_module, monkeypatch):
+    """schema.sql and Alembic must produce the same Postgres structural contract."""
+    monkeypatch.delenv("DB_URL", raising=False)
+    schema_sql_schema = "mgr_schema_sql_parity"
+    alembic_schema = "mgr_alembic_parity"
+
+    with psycopg_module.connect(pg_url, autocommit=False) as conn:
+        _reset_schema(conn, schema_sql_schema)
+        _apply_schema_sql(conn)
+        schema_sql_snapshot = _catalog_snapshot(conn)
+
+        _reset_schema(conn, alembic_schema)
+
+    command.upgrade(_alembic_config(_url_with_search_path(pg_url, alembic_schema)), "head")
+
+    with psycopg_module.connect(pg_url, autocommit=False) as conn:
+        with conn.cursor() as cur:
+            cur.execute(f'SET search_path TO "{alembic_schema}"')
+        alembic_snapshot = _catalog_snapshot(conn)
+        _assert_snapshots_match(schema_sql_snapshot, alembic_snapshot)
 
 
 def test_schema_sql_creates_matviews_before_their_indexes(pg_url, psycopg_module):

--- a/tests/test_wasm_demo_build.py
+++ b/tests/test_wasm_demo_build.py
@@ -7,6 +7,7 @@ import sqlite3
 import sys
 
 import httpx
+import streamlit as st
 
 from scripts.build_wasm_demo import build_wasm_demo
 from scripts.seed_managers import SEED_MANAGERS
@@ -36,6 +37,7 @@ def test_deterministic_pages_render_offline(monkeypatch, tmp_path):
     monkeypatch.delenv("MINIO_ENDPOINT", raising=False)
     monkeypatch.setenv("UI_OFFLINE", "1")
     monkeypatch.setenv("USE_SIMPLE_EMBED", "1")
+    st.cache_data.clear()
 
     from ui import daily_report, dashboard, search, upload
 


### PR DESCRIPTION
Closes #1308

## Summary
- add a schema.sql/Alembic parity test for live PostgreSQL bootstrap drift
- align Alembic with schema.sql for the news_items topics GIN index
- make chat_feedback.created_at non-null in the schema contract and migration chain

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_schema.py tests/test_schema_postgres_bootstrap.py -q
- python -m ruff check alembic/versions/001_canonical_schema.py alembic/versions/009_chat_feedback.py alembic/versions/010_schema_sql_parity_fixes.py tests/test_schema.py tests/test_schema_postgres_bootstrap.py
- black --fast --check alembic/versions/001_canonical_schema.py alembic/versions/009_chat_feedback.py alembic/versions/010_schema_sql_parity_fixes.py tests/test_schema.py tests/test_schema_postgres_bootstrap.py
- git diff --check

Note: the live PostgreSQL parity test skips locally unless MGRDB_PG_TEST_URL is configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persisted chat feedback with required rating, optional comment, and automatic `created_at` timestamps.
* **Bug Fixes**
  * Improved PostgreSQL schema consistency by enforcing `chat_feedback.created_at` as NOT NULL.
  * Added an idempotent PostgreSQL GIN index on `news_items(topics)` to better support topic-based queries.
* **Tests**
  * Strengthened PostgreSQL bootstrap checks by comparing schema.sql vs migrations for structural parity (including updated index expectations).
  * Updated schema contract assertions and made WASM demo build tests deterministic by clearing Streamlit cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->