### PR TITLE
Codex bootstrap for #1299

### DIFF
--- a/agents/codex-1299.md
+++ b/agents/codex-1299.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1299 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1299 -->

### Source Issue #1299: [Audit] Add finite/bounds validation at numeric trust boundaries (NaN/inf)

Base: main
Head: codex/issue-1299

Source: https://github.com/stranske/Manager-Database/issues/1299

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Multiple numeric trust boundaries parse external/LLM/EDGAR/env values with raw `float()` and **no `math.isfinite()` / range check**, so `NaN` and `inf` flow into comparisons and scoring. (`explainability.py` already guards finiteness — the rest don't.) Verified sites at `e5764a5`:

- `alerts/engine.py:12` `_as_float()` → `return float(value)`. A rule `{"value_usd_gt": "nan"}` fires for any finite payload (`value <= NaN` is `False`); `{"value_usd": "inf"}` beats any finite threshold; NaN ages/deltas silently suppress valid alerts.
- `etl/activism_detection.py:87` `_to_float()` and `:97` `_parse_thresholds()` accept non-finite and out-of-range percentages. Ownership `"inf"` crosses every threshold (`:333`); `ACTIVISM_THRESHOLDS=nan` yields an empty threshold set; ownership outside `0..100` is not rejected.
- `etl/conviction_flow.py:141,159` sums `float(value_usd or 0.0)` then divides — one NaN holding makes `total_value` NaN (all conviction → 0); an `inf` produces non-finite weights, which are persisted and drive crowded-trade/contrarian calcs.
- `adapters/edgar.py:25` `EDGAR_MIN_REQUEST_INTERVAL` parsed with raw `float()`; `nan` disables the `>0` throttle check and `inf`/negative break pacing.
- `api/search.py:71,80` `_normalize_rank()`/`_vector_relevance()` — non-finite rank/distance propagate into `SearchResult(relevance=...)` (Pydantic may then 500 the whole response).

These survive green CI because baseline fixtures are homogeneous (no NaN/inf/out-of-range cases).

#### Tasks
- [ ] Add a shared finite-parse helper (e.g. in `adapters/base.py` or a `utils` module) and use it in: `alerts/engine.py:12`, `etl/activism_detection.py:87,97`, `etl/conviction_flow.py:141`, `adapters/edgar.py:25`, `api/search.py:71,80`.
- [ ] Enforce domain ranges: ownership/threshold `0..100`; EDGAR interval finite and within a sane min/max; relevance finite in `[0,1]`.
- [ ] Reject invalid alert-rule numeric definitions at create/update; reject non-finite `ACTIVISM_THRESHOLDS`/`EDGAR_MIN_REQUEST_INTERVAL` at startup (fail-fast or explicit fallback + warning).

#### Acceptance Criteria
- [ ] **New tests, each currently failing:** (a) alert rule `condition_json={"value_usd_gt":"nan"}` + payload `{"value_usd":1}` → no fired alert / rule rejected; (b) `detect_events()` with ownership `"inf"` → no threshold crossing; (c) `compute_conviction_scores` with one NaN `value_usd` → raises/skips, no corrupted rows; (d) `_score_result(..., fts_rank=float("nan"))` returns finite `[0,1]`.
- [ ] **Deliberate-break demonstration:** removing any one finite-check makes its test fail; restoring passes.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

Multiple numeric trust boundaries parse external/LLM/EDGAR/env values with raw `float()` and **no `math.isfinite()` / range check**, so `NaN` and `inf` flow into comparisons and scoring. (`explainability.py` already guards finiteness — the rest don't.) Verified sites at `e5764a5`:

- `alerts/engine.py:12` `_as_float()` → `return float(value)`. A rule `{"value_usd_gt": "nan"}` fires for any finite payload (`value <= NaN` is `False`); `{"value_usd": "inf"}` beats any finite threshold; NaN ages/deltas silently suppress valid alerts.
- `etl/activism_detection.py:87` `_to_float()` and `:97` `_parse_thresholds()` accept non-finite and out-of-range percentages. Ownership `"inf"` crosses every threshold (`:333`); `ACTIVISM_THRESHOLDS=nan` yields an empty threshold set; ownership outside `0..100` is not rejected.
- `etl/conviction_flow.py:141,159` sums `float(value_usd or 0.0)` then divides — one NaN holding makes `total_value` NaN (all conviction → 0); an `inf` produces non-finite weights, which are persisted and drive crowded-trade/contrarian calcs.
- `adapters/edgar.py:25` `EDGAR_MIN_REQUEST_INTERVAL` parsed with raw `float()`; `nan` disables the `>0` throttle check and `inf`/negative break pacing.
- `api/search.py:71,80` `_normalize_rank()`/`_vector_relevance()` — non-finite rank/distance propagate into `SearchResult(relevance=...)` (Pydantic may then 500 the whole response).

These survive green CI because baseline fixtures are homogeneous (no NaN/inf/out-of-range cases).

## Scope

Add a finite/bounds validation seam used at every numeric trust boundary above. Reject or quarantine non-finite/out-of-range values with a data-quality log; reject invalid rule/env definitions at create/parse time.

## Non-Goals

- Do NOT change valid-value behavior or rounding for in-range finite inputs.
- Do NOT add a heavyweight validation framework — a small shared helper (e.g. `parse_finite(value, lo=None, hi=None)`) is sufficient.

## Tasks

- [ ] Add a shared finite-parse helper (e.g. in `adapters/base.py` or a `utils` module) and use it in: `alerts/engine.py:12`, `etl/activism_detection.py:87,97`, `etl/conviction_flow.py:141`, `adapters/edgar.py:25`, `api/search.py:71,80`.
- [ ] Enforce domain ranges: ownership/threshold `0..100`; EDGAR interval finite and within a sane min/max; relevance finite in `[0,1]`.
- [ ] Reject invalid alert-rule numeric definitions at create/update; reject non-finite `ACTIVISM_THRESHOLDS`/`EDGAR_MIN_REQUEST_INTERVAL` at startup (fail-fast or explicit fallback + warning).

## Acceptance Criteria

- [ ] **New tests, each currently failing:** (a) alert rule `condition_json={"value_usd_gt":"nan"}` + payload `{"value_usd":1}` → no fired alert / rule rejected; (b) `detect_events()` with ownership `"inf"` → no threshold crossing; (c) `compute_conviction_scores` with one NaN `value_usd` → raises/skips, no corrupted rows; (d) `_score_result(..., fts_rank=float("nan"))` returns finite `[0,1]`.
- [ ] **Deliberate-break demonstration:** removing any one finite-check makes its test fail; restoring passes.

## Implementation Notes

Audit baseline: `main` @ `e5764a5` on 2026-06-28. Generalizes the Inv-Man-Intake "finite/bounds sweep" (`<0/>1` guards are insufficient — use `math.isfinite` + range). All cited line numbers source-verified.



</details>

—
PR created automatically to engage Codex.