### PR TITLE
Harden DB connection lifecycle

### DIFF
--- a/adapters/base.py
+++ b/adapters/base.py
@@ -173,14 +173,14 @@ async def tracked_call(
         latency = int((time.perf_counter() - start) * 1000)
         status = getattr(resp, "status_code", 0)
         size = len(getattr(resp, "content", b""))
-        if callable(cost_usd):
-            computed_cost = float(cost_usd(resp)) if resp is not None else 0.0
-        elif cost_usd is not None:
-            computed_cost = float(cost_usd)
-        else:
-            computed_cost = 0.0
         conn: Any | None = None
         try:
+            if callable(cost_usd):
+                computed_cost = float(cost_usd(resp)) if resp is not None else 0.0
+            elif cost_usd is not None:
+                computed_cost = float(cost_usd)
+            else:
+                computed_cost = 0.0
             conn = connect_db(db_path)
             if isinstance(conn, sqlite3.Connection):
                 _ensure_sqlite_usage_schema(conn)

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sqlite3
 import time
@@ -17,6 +18,8 @@ except ImportError:  # pragma: no cover - optional dependency
     psycopg: ModuleType | None = None
 else:  # pragma: no cover - imported above when available
     psycopg = _psycopg
+
+logger = logging.getLogger(__name__)
 
 
 class AdapterProtocol(Protocol):
@@ -176,21 +179,38 @@ async def tracked_call(
             computed_cost = float(cost_usd)
         else:
             computed_cost = 0.0
-        conn = connect_db(db_path)
-        if isinstance(conn, sqlite3.Connection):
-            _ensure_sqlite_usage_schema(conn)
-            placeholder = "?"
-        else:  # Postgres
-            _ensure_postgres_usage_schema(conn)
-            placeholder = "%s"
-        values_clause = ",".join([placeholder] * 6)
-        sql = (
-            "INSERT INTO api_usage(source, endpoint, status, bytes, latency_ms, cost_usd)"
-            f" VALUES ({values_clause})"
-        )
-        conn.execute(sql, (source, endpoint, status, size, latency, computed_cost))
-        conn.commit()
-        conn.close()
+        conn: Any | None = None
+        try:
+            conn = connect_db(db_path)
+            if isinstance(conn, sqlite3.Connection):
+                _ensure_sqlite_usage_schema(conn)
+                placeholder = "?"
+            else:  # Postgres
+                _ensure_postgres_usage_schema(conn)
+                placeholder = "%s"
+            values_clause = ",".join([placeholder] * 6)
+            sql = (
+                "INSERT INTO api_usage(source, endpoint, status, bytes, latency_ms, cost_usd)"
+                f" VALUES ({values_clause})"
+            )
+            conn.execute(sql, (source, endpoint, status, size, latency, computed_cost))
+            conn.commit()
+        except Exception:
+            logger.warning(
+                "Failed to record API usage metrics",
+                extra={"source": source, "endpoint": endpoint},
+                exc_info=True,
+            )
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    logger.warning(
+                        "Failed to close API usage metrics connection",
+                        extra={"source": source, "endpoint": endpoint},
+                        exc_info=True,
+                    )
 
 
 ADAPTERS: dict[str, AdapterProtocol] = {}

--- a/etl/ingest_flow.py
+++ b/etl/ingest_flow.py
@@ -471,8 +471,9 @@ async def fetch_and_store(
     adapter = adapter or get_adapter(_ADAPTER_MAP.get(jurisdiction, "edgar"))
     filings = await adapter.list_new_filings(identifier, since)
     conn = connect_db(db_path or DB_PATH)
-    original_autocommit = _enable_transactional_writes(conn)
+    original_autocommit: bool | None = None
     try:
+        original_autocommit = _enable_transactional_writes(conn)
         _ensure_filing_tables(conn)
 
         results: list[dict[str, Any]] = []

--- a/etl/ingest_flow.py
+++ b/etl/ingest_flow.py
@@ -405,6 +405,24 @@ def _rollback_quietly(conn: Any) -> None:
             logger.warning("Failed to roll back ingest transaction", exc_info=True)
 
 
+def _enable_transactional_writes(conn: Any) -> bool | None:
+    if isinstance(conn, sqlite3.Connection) or not hasattr(conn, "autocommit"):
+        return None
+    original = bool(conn.autocommit)
+    if original:
+        conn.autocommit = False
+    return original
+
+
+def _restore_autocommit_quietly(conn: Any, original: bool | None) -> None:
+    if original is None:
+        return
+    try:
+        conn.autocommit = original
+    except Exception:
+        logger.warning("Failed to restore ingest database autocommit", exc_info=True)
+
+
 def _close_quietly(conn: Any) -> None:
     close = getattr(conn, "close", None)
     if callable(close):
@@ -453,6 +471,7 @@ async def fetch_and_store(
     adapter = adapter or get_adapter(_ADAPTER_MAP.get(jurisdiction, "edgar"))
     filings = await adapter.list_new_filings(identifier, since)
     conn = connect_db(db_path or DB_PATH)
+    original_autocommit = _enable_transactional_writes(conn)
     try:
         _ensure_filing_tables(conn)
 
@@ -509,10 +528,10 @@ async def fetch_and_store(
                     parsed_rows=parsed_rows,
                     jurisdiction=jurisdiction,
                 )
-            conn.commit()
             if should_keep_results:
                 results.extend(parsed_rows)
 
+        conn.commit()
         logger.info(
             "Stored filings",
             extra={"identifier": identifier, "jurisdiction": jurisdiction, "rows": row_count},
@@ -522,6 +541,7 @@ async def fetch_and_store(
         _rollback_quietly(conn)
         raise
     finally:
+        _restore_autocommit_quietly(conn, original_autocommit)
         _close_quietly(conn)
 
 

--- a/etl/ingest_flow.py
+++ b/etl/ingest_flow.py
@@ -396,6 +396,24 @@ def _run_in_transaction(conn: Any, work: Any) -> Any:
     return work()
 
 
+def _rollback_quietly(conn: Any) -> None:
+    rollback = getattr(conn, "rollback", None)
+    if callable(rollback):
+        try:
+            rollback()
+        except Exception:
+            logger.warning("Failed to roll back ingest transaction", exc_info=True)
+
+
+def _close_quietly(conn: Any) -> None:
+    close = getattr(conn, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            logger.warning("Failed to close ingest database connection", exc_info=True)
+
+
 def _replace_holdings_rows(
     conn: Any,
     *,
@@ -435,71 +453,76 @@ async def fetch_and_store(
     adapter = adapter or get_adapter(_ADAPTER_MAP.get(jurisdiction, "edgar"))
     filings = await adapter.list_new_filings(identifier, since)
     conn = connect_db(db_path or DB_PATH)
-    _ensure_filing_tables(conn)
+    try:
+        _ensure_filing_tables(conn)
 
-    results: list[dict[str, Any]] = []
-    row_count = 0
-    max_results = int(os.getenv("MAX_RESULTS_IN_MEMORY", "100000"))
+        results: list[dict[str, Any]] = []
+        row_count = 0
+        max_results = int(os.getenv("MAX_RESULTS_IN_MEMORY", "100000"))
 
-    for filing in filings:
-        raw = await adapter.download(filing)
-        external_id = _filing_external_id(filing, jurisdiction)
-        ext = "xml" if isinstance(raw, str) else "pdf"
-        S3.put_object(
-            Bucket=BUCKET,
-            Key=f"raw/{external_id}.{ext}",
-            Body=raw,
-            ServerSideEncryption="AES256",
-        )
-        parsed_rows = await adapter.parse(raw)
-        if isinstance(raw, str):
-            store_document(raw)
-
-        manager_id = _lookup_manager_id(conn, jurisdiction, identifier)
-        if manager_id is None:
-            logger.warning(
-                "Manager not found; skipping filing",
-                extra={
-                    "jurisdiction": jurisdiction,
-                    "identifier": identifier,
-                    "external_id": external_id,
-                },
+        for filing in filings:
+            raw = await adapter.download(filing)
+            external_id = _filing_external_id(filing, jurisdiction)
+            ext = "xml" if isinstance(raw, str) else "pdf"
+            S3.put_object(
+                Bucket=BUCKET,
+                Key=f"raw/{external_id}.{ext}",
+                Body=raw,
+                ServerSideEncryption="AES256",
             )
-            continue
-        filing_id = _insert_filing(
-            conn,
-            manager_id=manager_id,
-            source=jurisdiction,
-            external_id=external_id,
-            filed_date=_filing_date(filing, jurisdiction),
-            filing_type=_filing_type(parsed_rows, filing, jurisdiction),
-            parsed_rows=parsed_rows,
-        )
+            parsed_rows = await adapter.parse(raw)
+            if isinstance(raw, str):
+                store_document(raw)
 
-        should_keep_results = row_count < max_results
-        # UK filings are metadata-driven (e.g., CS01/AR01) and should be
-        # stored as parsed payload on the filings row, not expanded holdings.
-        if jurisdiction != "uk" and _looks_like_holdings_rows(parsed_rows):
-            row_count += _replace_holdings_rows(
+            manager_id = _lookup_manager_id(conn, jurisdiction, identifier)
+            if manager_id is None:
+                logger.warning(
+                    "Manager not found; skipping filing",
+                    extra={
+                        "jurisdiction": jurisdiction,
+                        "identifier": identifier,
+                        "external_id": external_id,
+                    },
+                )
+                continue
+            filing_id = _insert_filing(
                 conn,
-                filing_id=filing_id,
                 manager_id=manager_id,
-                identifier=identifier,
+                source=jurisdiction,
                 external_id=external_id,
                 filed_date=_filing_date(filing, jurisdiction),
+                filing_type=_filing_type(parsed_rows, filing, jurisdiction),
                 parsed_rows=parsed_rows,
-                jurisdiction=jurisdiction,
             )
-        conn.commit()
-        if should_keep_results:
-            results.extend(parsed_rows)
 
-    logger.info(
-        "Stored filings",
-        extra={"identifier": identifier, "jurisdiction": jurisdiction, "rows": row_count},
-    )
-    conn.close()
-    return results
+            should_keep_results = row_count < max_results
+            # UK filings are metadata-driven (e.g., CS01/AR01) and should be
+            # stored as parsed payload on the filings row, not expanded holdings.
+            if jurisdiction != "uk" and _looks_like_holdings_rows(parsed_rows):
+                row_count += _replace_holdings_rows(
+                    conn,
+                    filing_id=filing_id,
+                    manager_id=manager_id,
+                    identifier=identifier,
+                    external_id=external_id,
+                    filed_date=_filing_date(filing, jurisdiction),
+                    parsed_rows=parsed_rows,
+                    jurisdiction=jurisdiction,
+                )
+            conn.commit()
+            if should_keep_results:
+                results.extend(parsed_rows)
+
+        logger.info(
+            "Stored filings",
+            extra={"identifier": identifier, "jurisdiction": jurisdiction, "rows": row_count},
+        )
+        return results
+    except Exception:
+        _rollback_quietly(conn)
+        raise
+    finally:
+        _close_quietly(conn)
 
 
 def _default_identifiers(jurisdiction: str) -> list[str]:

--- a/tests/test_ingest_flow.py
+++ b/tests/test_ingest_flow.py
@@ -88,6 +88,17 @@ class _MetadataOnlyAdapter:
         ]
 
 
+class _ParseFailureAdapter:
+    async def list_new_filings(self, _identifier, _since):
+        return [{"accession": "0001-24-000002", "filed": "2024-01-06"}]
+
+    async def download(self, _filing):
+        return "<xml>payload</xml>"
+
+    async def parse(self, _raw):
+        raise RuntimeError("parse failed")
+
+
 class _TransactionalConn:
     def __init__(self):
         self.transactions = 0
@@ -101,6 +112,21 @@ class _TransactionalConn:
     def execute(self, sql, params=()):
         self.sql.append((sql, tuple(params)))
         return []
+
+
+class _TrackingSqliteConn(sqlite3.Connection):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.rollback_called = False
+        self.close_called = False
+
+    def rollback(self):
+        self.rollback_called = True
+        return super().rollback()
+
+    def close(self):
+        self.close_called = True
+        return super().close()
 
 
 @pytest.mark.asyncio
@@ -136,6 +162,41 @@ async def test_fetch_and_store_us_uses_manager_cik_and_inserts_holdings(tmp_path
 
     assert filing == (1, "us", "0001-24-000001", "13F-HR")
     assert holding == (1, "0000000001", "0001-24-000001", "123456789", 1000, 50)
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_rolls_back_and_closes_when_parse_fails(tmp_path, monkeypatch):
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE managers (id INTEGER PRIMARY KEY AUTOINCREMENT, cik TEXT, registry_ids TEXT)"
+    )
+    conn.execute("INSERT INTO managers(cik, registry_ids) VALUES (?, ?)", ("0000000001", "{}"))
+    conn.commit()
+    conn.close()
+
+    tracked_conn = sqlite3.connect(db_path, factory=_TrackingSqliteConn)
+    monkeypatch.setattr(ingest_flow, "connect_db", lambda _db_path: tracked_conn)
+    monkeypatch.setattr(ingest_flow.S3, "put_object", lambda **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="parse failed"):
+        await ingest_flow.fetch_and_store.fn(
+            "0000000001",
+            "2024-01-01",
+            jurisdiction="us",
+            adapter=_ParseFailureAdapter(),
+            db_path=str(db_path),
+        )
+
+    assert tracked_conn.rollback_called is True
+    assert tracked_conn.close_called is True
+
+    probe = sqlite3.connect(db_path)
+    try:
+        probe.execute("CREATE TABLE post_failure_probe (id INTEGER PRIMARY KEY)")
+        probe.commit()
+    finally:
+        probe.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_ingest_flow.py
+++ b/tests/test_ingest_flow.py
@@ -269,6 +269,28 @@ async def test_fetch_and_store_disables_postgres_autocommit_for_unit_of_work(mon
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_store_rolls_back_and_closes_when_transaction_setup_fails(monkeypatch):
+    conn = _PostgresAutocommitConn()
+
+    def fail_transactional_writes(_conn):
+        raise RuntimeError("autocommit unavailable")
+
+    monkeypatch.setattr(ingest_flow, "connect_db", lambda _db_path: conn)
+    monkeypatch.setattr(ingest_flow, "_enable_transactional_writes", fail_transactional_writes)
+
+    with pytest.raises(RuntimeError, match="autocommit unavailable"):
+        await ingest_flow.fetch_and_store.fn(
+            "0000000001",
+            "2024-01-01",
+            jurisdiction="us",
+            adapter=_USAdapter(),
+        )
+
+    assert conn.rollbacks == 1
+    assert conn.closed is True
+
+
+@pytest.mark.asyncio
 async def test_fetch_and_store_us_replaces_existing_holdings_for_same_filing(tmp_path, monkeypatch):
     db_path = tmp_path / "dev.db"
     conn = sqlite3.connect(db_path)

--- a/tests/test_ingest_flow.py
+++ b/tests/test_ingest_flow.py
@@ -114,6 +114,28 @@ class _TransactionalConn:
         return []
 
 
+class _PostgresAutocommitConn:
+    def __init__(self):
+        self.autocommit = True
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.sql = []
+
+    def execute(self, sql, params=()):
+        self.sql.append((sql, tuple(params)))
+        return []
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
 class _TrackingSqliteConn(sqlite3.Connection):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -197,6 +219,53 @@ async def test_fetch_and_store_rolls_back_and_closes_when_parse_fails(tmp_path, 
         probe.commit()
     finally:
         probe.close()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_disables_postgres_autocommit_for_unit_of_work(monkeypatch):
+    conn = _PostgresAutocommitConn()
+    states = []
+
+    def record_ensure_tables(db_conn):
+        states.append(("ensure", db_conn.autocommit))
+
+    def record_lookup(db_conn, _jurisdiction, _identifier):
+        states.append(("lookup", db_conn.autocommit))
+        return 1
+
+    def record_insert_filing(db_conn, **_kwargs):
+        states.append(("filing", db_conn.autocommit))
+        return 10
+
+    def record_replace_holdings(db_conn, **_kwargs):
+        states.append(("holdings", db_conn.autocommit))
+        return 1
+
+    monkeypatch.setattr(ingest_flow, "connect_db", lambda _db_path: conn)
+    monkeypatch.setattr(ingest_flow, "_ensure_filing_tables", record_ensure_tables)
+    monkeypatch.setattr(ingest_flow, "_lookup_manager_id", record_lookup)
+    monkeypatch.setattr(ingest_flow, "_insert_filing", record_insert_filing)
+    monkeypatch.setattr(ingest_flow, "_replace_holdings_rows", record_replace_holdings)
+    monkeypatch.setattr(ingest_flow.S3, "put_object", lambda **_kwargs: None)
+
+    rows = await ingest_flow.fetch_and_store.fn(
+        "0000000001",
+        "2024-01-01",
+        jurisdiction="us",
+        adapter=_USAdapter(),
+    )
+
+    assert rows and rows[0]["cusip"] == "123456789"
+    assert states == [
+        ("ensure", False),
+        ("lookup", False),
+        ("filing", False),
+        ("holdings", False),
+    ]
+    assert conn.commits == 1
+    assert conn.rollbacks == 0
+    assert conn.autocommit is True
+    assert conn.closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_tracked_call.py
+++ b/tests/test_tracked_call.py
@@ -79,3 +79,30 @@ async def test_tracked_call_postgres_uses_strict_backend_safe_sql(monkeypatch):
     assert any("CREATE MATERIALIZED VIEW monthly_usage AS" in call[0] for call in dummy.executed)
     assert dummy.committed is True
     assert dummy.closed is True
+
+
+@pytest.mark.asyncio
+async def test_tracked_call_metrics_execute_failure_preserves_response_and_closes(monkeypatch):
+    class FailingMetricsConn:
+        def __init__(self):
+            self.closed = False
+
+        def execute(self, *_args, **_kwargs):
+            raise RuntimeError("metrics insert failed")
+
+        def commit(self):
+            raise AssertionError("commit should not run after execute fails")
+
+        def close(self):
+            self.closed = True
+
+    conn = FailingMetricsConn()
+    monkeypatch.setattr(base, "connect_db", lambda _db_path=None: conn)
+    monkeypatch.setattr(base, "_ensure_postgres_usage_schema", lambda _conn: None)
+
+    response = DummyResp(status_code=202, content=b"accepted")
+
+    async with tracked_call("pg", "http://pg") as log:
+        log(response)
+
+    assert conn.closed is True

--- a/tests/test_tracked_call.py
+++ b/tests/test_tracked_call.py
@@ -106,3 +106,32 @@ async def test_tracked_call_metrics_execute_failure_preserves_response_and_close
         log(response)
 
     assert conn.closed is True
+
+
+@pytest.mark.asyncio
+async def test_tracked_call_cost_callback_failure_is_non_fatal(monkeypatch):
+    class MetricsConn:
+        def __init__(self):
+            self.closed = False
+            self.executed = []
+
+        def execute(self, sql, params=()):
+            self.executed.append((sql, params))
+
+        def commit(self):
+            raise AssertionError("commit should not run after cost callback fails")
+
+        def close(self):
+            self.closed = True
+
+    conn = MetricsConn()
+    monkeypatch.setattr(base, "connect_db", lambda _db_path=None: conn)
+
+    def cost_from_response(_resp):
+        raise RuntimeError("cost calculation failed")
+
+    async with tracked_call("pg", "http://pg", cost_usd=cost_from_response) as log:
+        log(DummyResp())
+
+    assert conn.executed == []
+    assert conn.closed is False


### PR DESCRIPTION
Closes #1309

## Summary
- Isolate `tracked_call()` metrics persistence so usage-table failures log warnings without replacing the primary adapter result or exception.
- Ensure filing ingest rolls back and closes the DB connection when a post-connect failure occurs during download/parse/storage.
- Add regressions for metrics execute failures and ingest parse failures after the connection opens.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_tracked_call.py::test_tracked_call_metrics_execute_failure_preserves_response_and_closes tests/test_ingest_flow.py::test_fetch_and_store_rolls_back_and_closes_when_parse_fails -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_tracked_call.py tests/test_ingest_flow.py -q`
- `python -m ruff check adapters/base.py etl/ingest_flow.py tests/test_tracked_call.py tests/test_ingest_flow.py`
- `black --check --line-length 100 --exclude '(\.workflows-lib|node_modules)' adapters/base.py etl/ingest_flow.py tests/test_tracked_call.py tests/test_ingest_flow.py`
- `git diff --check`

Deliberate break: temporarily disabled the metrics `close()` call and confirmed `test_tracked_call_metrics_execute_failure_preserves_response_and_closes` failed on `conn.closed is True`; restored the fix and reran the full focused validation above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingestion reliability by ensuring errors trigger safe rollback and that database connections are always cleaned up.
  * Prevented partial ingestion persistence by committing only after the full ingest run completes successfully.
  * Made usage-metrics recording more resilient so request processing continues even if metrics persistence fails, with clearer warnings for diagnostics.
* **Tests**
  * Added error-path coverage to verify rollback, connection cleanup, and non-fatal handling of metrics/cost failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->