### PR TITLE
Follow up numeric trust-boundary verifier concerns

### DIFF
--- a/adapters/edgar.py
+++ b/adapters/edgar.py
@@ -28,11 +28,15 @@ logger = logging.getLogger(__name__)
 
 def _parse_edgar_min_request_interval(raw: str | None) -> float:
     try:
+        # Keep the upper bound conservative enough to catch poisoned config while allowing
+        # deliberately slow SEC pacing in local/operator environments.
         parsed = parse_finite_float(raw or "0.11", min_value=0.0, max_value=10.0, allow_none=False)
     except (TypeError, ValueError):
         logger.warning("Invalid EDGAR_MIN_REQUEST_INTERVAL; using default", extra={"value": raw})
         return 0.11
-    assert parsed is not None
+    if parsed is None:  # Defensive only; allow_none=False should already reject this.
+        logger.warning("Missing EDGAR_MIN_REQUEST_INTERVAL; using default", extra={"value": raw})
+        return 0.11
     return parsed
 
 

--- a/alerts/models.py
+++ b/alerts/models.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from utils.numeric import parse_finite_float
+
 ALERT_EVENT_TYPES = (
     "new_filing",
     "large_delta",
@@ -21,6 +23,13 @@ ALERT_CHANNELS = ("email", "slack", "streamlit")
 _CHANNEL_ALIASES = {
     "in_app": "streamlit",
     "webhook": "slack",
+}
+_NUMERIC_CONDITION_BOUNDS: dict[str, tuple[float | None, float | None]] = {
+    "value_usd_gt": (0.0, None),
+    "time_window_hours": (0.0, None),
+    "min_ownership_pct": (0.0, 100.0),
+    "min_delta_pct": (0.0, 100.0),
+    "threshold_crossed": (0.0, 100.0),
 }
 
 
@@ -45,6 +54,26 @@ def normalize_channels(channels: list[str]) -> list[str]:
     if not normalized:
         raise ValueError("At least one delivery channel is required.")
     return normalized
+
+
+def validate_condition_json(condition: dict[str, Any]) -> dict[str, Any]:
+    """Reject invalid numeric alert-rule definitions before persistence."""
+    for key, bounds in _NUMERIC_CONDITION_BOUNDS.items():
+        if key not in condition:
+            continue
+        min_value, max_value = bounds
+        try:
+            parse_finite_float(
+                condition[key],
+                min_value=min_value,
+                max_value=max_value,
+                allow_none=False,
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid numeric alert condition for {key}: {condition[key]!r}"
+            ) from exc
+    return condition
 
 
 class AlertRuleBase(BaseModel):
@@ -79,6 +108,11 @@ class AlertRuleBase(BaseModel):
 class AlertRuleCreate(AlertRuleBase):
     """Payload for creating an alert rule."""
 
+    @field_validator("condition_json")
+    @classmethod
+    def _validate_condition_json(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_condition_json(value)
+
 
 class AlertRuleUpdate(BaseModel):
     """Patch payload for an existing alert rule."""
@@ -106,6 +140,13 @@ class AlertRuleUpdate(BaseModel):
         if value is None:
             return value
         return normalize_channels(value)
+
+    @field_validator("condition_json")
+    @classmethod
+    def _validate_condition_json(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        if value is None:
+            return value
+        return validate_condition_json(value)
 
 
 class AlertRule(AlertRuleBase):

--- a/tests/test_alerts_api.py
+++ b/tests/test_alerts_api.py
@@ -178,6 +178,41 @@ def test_alert_rule_crud_and_soft_delete(tmp_path, monkeypatch):
     assert post_delete.json()["enabled"] is False
 
 
+def test_alert_rule_create_rejects_non_finite_numeric_condition(tmp_path, monkeypatch):
+    db_path = tmp_path / "alerts.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    payload = _create_rule_payload()
+    payload["condition_json"] = {"value_usd_gt": "nan"}
+
+    response = asyncio.run(_request("POST", "/api/alerts/rules", json=payload))
+
+    assert response.status_code == 400
+    assert "Invalid numeric alert condition" in response.text
+
+
+def test_alert_rule_update_rejects_out_of_range_numeric_condition(tmp_path, monkeypatch):
+    db_path = tmp_path / "alerts.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    create_response = asyncio.run(
+        _request("POST", "/api/alerts/rules", json=_create_rule_payload())
+    )
+    assert create_response.status_code == 201
+    rule_id = create_response.json()["rule_id"]
+
+    response = asyncio.run(
+        _request(
+            "PUT",
+            f"/api/alerts/rules/{rule_id}",
+            json={"condition_json": {"min_ownership_pct": 101}},
+        )
+    )
+
+    assert response.status_code == 400
+    assert "Invalid numeric alert condition" in response.text
+
+
 def test_alert_rule_soft_delete_preserves_history(tmp_path, monkeypatch):
     db_path = tmp_path / "alerts.db"
     monkeypatch.setenv("DB_PATH", str(db_path))

--- a/tests/test_edgar_integration.py
+++ b/tests/test_edgar_integration.py
@@ -339,6 +339,13 @@ async def test_outbound_request_rate_governor(monkeypatch):
     assert sleep_calls == []
 
 
+def test_edgar_min_request_interval_rejects_non_finite_config(caplog):
+    caplog.set_level("WARNING")
+
+    assert edgar._parse_edgar_min_request_interval("inf") == 0.11
+    assert "Invalid EDGAR_MIN_REQUEST_INTERVAL" in caplog.text
+
+
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_malformed_data_handling(monkeypatch, tmp_path):


### PR DESCRIPTION
Follow-up for #1299 after PR #1329 verifier CONCERNS.

This addresses the bounded verifier gaps that remained after the merge:
- reject non-finite/out-of-range numeric alert rule definitions at create/update time
- keep stored legacy invalid rules readable so runtime evaluation can quarantine them
- add focused EDGAR interval fallback coverage and remove the parser assert smell

Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_alerts_api.py::test_alert_rule_create_rejects_non_finite_numeric_condition tests/test_alerts_api.py::test_alert_rule_update_rejects_out_of_range_numeric_condition tests/test_edgar_integration.py::test_edgar_min_request_interval_rejects_non_finite_config tests/test_alert_engine.py::test_alert_engine_ignores_non_finite_numeric_rule_values tests/test_activism_detection.py::test_detect_events_ignores_non_finite_ownership tests/test_activism_detection.py::test_detect_events_rejects_invalid_threshold_env tests/test_conviction_flow.py::test_compute_conviction_scores_rejects_non_finite_values tests/test_search.py::test_score_result_clamps_non_finite_rank_and_distance -q` -> 8 passed
- `python -m ruff check alerts/models.py adapters/edgar.py tests/test_alerts_api.py tests/test_edgar_integration.py` -> passed
- `black --fast --check --line-length 100 --exclude '(\.workflows-lib|node_modules)' alerts/models.py adapters/edgar.py tests/test_alerts_api.py tests/test_edgar_integration.py` -> passed
- `git diff --check` -> passed

Source issue remains open until this follow-up merges and receives durable verifier PASS.