### PR TITLE
Surface chat chain load failures

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -1257,7 +1257,10 @@ def _health_summary_timeout_seconds() -> float:
 
 def _chat_chain_health_payload() -> tuple[dict[str, int | bool], str | None]:
     """Report whether production chat chains are importable."""
-    if _chat_zone_disabled() or _chat_chain_fallback_enabled():
+    fallback_enabled = _chat_chain_fallback_enabled()
+    if _chat_zone_disabled():
+        return {"healthy": True, "available": True, "fallback_enabled": fallback_enabled}, None
+    if fallback_enabled:
         return {"healthy": True, "available": True, "fallback_enabled": True}, None
 
     for chain_name, (module_path, class_name) in DIRECT_CHAIN_PATHS.items():

--- a/api/chat.py
+++ b/api/chat.py
@@ -366,6 +366,22 @@ DIRECT_CHAIN_PATHS = {
 SQLITE_TABLE_INFO_SQL = "SELECT name FROM pragma_table_info(?)"
 
 
+class ChainUnavailableError(RuntimeError):
+    """Raised when a requested chat chain cannot be loaded safely."""
+
+
+def _chat_chain_fallback_enabled() -> bool:
+    """Return True when deterministic chain stubs are explicitly allowed."""
+    return os.getenv("CHAT_CHAIN_FALLBACK_MODE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "dev",
+        "offline",
+        "stlite",
+    }
+
+
 def _read_positive_int_env(name: str, default: int) -> int:
     raw_value = os.getenv(name)
     if raw_value is None:
@@ -687,8 +703,26 @@ def _build_chain(chain_name: str, client_info: Any):
     try:
         module = importlib.import_module(module_path)
         chain_cls = getattr(module, class_name)
-    except Exception:
-        return FALLBACK_CHAINS[chain_name]()
+    except (ModuleNotFoundError, AttributeError) as exc:
+        if _chat_chain_fallback_enabled():
+            logger.warning(
+                "Using explicit chat chain fallback for %s after load failure",
+                chain_name,
+                exc_info=True,
+            )
+            return FALLBACK_CHAINS[chain_name]()
+        logger.exception("Chat chain %s is unavailable", chain_name)
+        raise ChainUnavailableError(f"Chat chain '{chain_name}' is unavailable") from exc
+    except Exception as exc:
+        if _chat_chain_fallback_enabled():
+            logger.warning(
+                "Using explicit chat chain fallback for %s after import error",
+                chain_name,
+                exc_info=True,
+            )
+            return FALLBACK_CHAINS[chain_name]()
+        logger.exception("Chat chain %s failed during import", chain_name)
+        raise ChainUnavailableError(f"Chat chain '{chain_name}' failed during import") from exc
 
     db_conn = connect_db()
     try:
@@ -1082,6 +1116,20 @@ async def chat_api(request: ChatRequest, raw_request: Request) -> ChatResponse:
             status_code=400,
             detail=f"Input rejected: {reason_text}",
         ) from exc
+    except ChainUnavailableError as exc:
+        logger.error("Chat chain unavailable: %s", exc, exc_info=True)
+        _record_chat_fleet_safe(
+            request_id=request_id,
+            endpoint=endpoint_path,
+            chain=chain_used,
+            session_id=session_id,
+            provider=provider_name,
+            model=model_name,
+            latency_ms=int((time.perf_counter() - started) * 1000),
+            http_status=503,
+            error_category="chain_unavailable",
+        )
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     except HTTPException as exc:
         _record_chat_fleet_safe(
             request_id=request_id,
@@ -1205,6 +1253,23 @@ def _health_summary_timeout_seconds() -> float:
     """Return the timeout budget for /health dependency checks."""
     timeout = float(os.getenv("HEALTH_SUMMARY_TIMEOUT_S", "0.2"))
     return max(min(timeout, 0.2), 0.05)
+
+
+def _chat_chain_health_payload() -> tuple[dict[str, int | bool], str | None]:
+    """Report whether production chat chains are importable."""
+    if _chat_zone_disabled() or _chat_chain_fallback_enabled():
+        return {"healthy": True, "available": True, "fallback_enabled": True}, None
+
+    for chain_name, (module_path, class_name) in DIRECT_CHAIN_PATHS.items():
+        try:
+            module = importlib.import_module(module_path)
+            getattr(module, class_name)
+        except Exception as exc:
+            return (
+                {"healthy": False, "available": False, "fallback_enabled": False},
+                f"{chain_name}: {_format_dependency_error(exc)}",
+            )
+    return {"healthy": True, "available": True, "fallback_enabled": False}, None
 
 
 async def _run_dependency_check(
@@ -1341,6 +1406,8 @@ async def health_app():
             "minio": minio_payload,
             "redis": redis_payload,
         }
+        chat_chains_payload, chat_chains_reason = _chat_chain_health_payload()
+        components["chat_chains"] = chat_chains_payload
         failed_checks = {}
         if not db_payload["healthy"]:
             failed_checks["database"] = db_reason or "unhealthy"
@@ -1348,12 +1415,15 @@ async def health_app():
             failed_checks["minio"] = minio_reason or "unhealthy"
         if redis_payload.get("enabled", True) and not redis_payload["healthy"]:
             failed_checks["redis"] = redis_reason or "unhealthy"
+        if not chat_chains_payload["healthy"]:
+            failed_checks["chat_chains"] = chat_chains_reason or "unhealthy"
         redis_healthy = redis_payload["healthy"] if redis_payload.get("enabled", True) else True
         healthy = (
             app_payload["healthy"]
             and db_payload["healthy"]
             and minio_payload["healthy"]
             and redis_healthy
+            and chat_chains_payload["healthy"]
         )
         payload = {
             "healthy": healthy,
@@ -1654,12 +1724,17 @@ async def health_detailed():
             "minio": minio_payload,
             "redis": redis_payload,
         }
+        chat_chains_payload, chat_chains_reason = _chat_chain_health_payload()
+        if chat_chains_reason:
+            chat_chains_payload["reason_present"] = True
+        components["chat_chains"] = chat_chains_payload
         redis_healthy = redis_payload["healthy"] if redis_payload["enabled"] else True
         healthy = (
             app_payload["healthy"]
             and db_payload["healthy"]
             and minio_payload["healthy"]
             and redis_healthy
+            and chat_chains_payload["healthy"]
         )
         payload = {
             "healthy": healthy,

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -141,7 +141,13 @@ def test_chat_api_surfaces_rag_import_failure_in_production(monkeypatch):
     monkeypatch.setattr(chat_api_module, "connect_db", lambda *args, **kwargs: FakeConn())
     monkeypatch.setattr(chat_api_module, "_build_chat_client_info", lambda: object())
 
-    response = asyncio.run(_request("POST", "/api/chat", json={"question": "Find recent activism"}))
+    response = asyncio.run(
+        _request(
+            "POST",
+            "/api/chat",
+            json={"chain": "rag_search", "question": "Find recent activism"},
+        )
+    )
 
     assert response.status_code == 503
     assert "rag_search" in response.json()["detail"]
@@ -163,7 +169,13 @@ def test_chat_api_explicit_offline_fallback_keeps_stub_available(monkeypatch):
     monkeypatch.setattr(chat_api_module, "connect_db", lambda *args, **kwargs: FakeConn())
     monkeypatch.setattr(chat_api_module, "_build_chat_client_info", lambda: object())
 
-    response = asyncio.run(_request("POST", "/api/chat", json={"question": "Find recent activism"}))
+    response = asyncio.run(
+        _request(
+            "POST",
+            "/api/chat",
+            json={"chain": "rag_search", "question": "Find recent activism"},
+        )
+    )
 
     assert response.status_code == 200
     assert response.json()["chain_used"] == "rag_search"
@@ -188,6 +200,16 @@ def test_chain_health_reports_import_failures(monkeypatch):
 
     assert payload == {"healthy": False, "available": False, "fallback_enabled": False}
     assert reason == "rag_search: boom"
+
+
+def test_chain_health_zone_disabled_preserves_fallback_state(monkeypatch):
+    monkeypatch.setenv("LLM_ZONE", "disabled")
+    monkeypatch.delenv("CHAT_CHAIN_FALLBACK_MODE", raising=False)
+
+    payload, reason = chat_api_module._chat_chain_health_payload()
+
+    assert payload == {"healthy": True, "available": True, "fallback_enabled": False}
+    assert reason is None
 
 
 def test_direct_endpoint_returns_500_for_unexpected_chain_errors(monkeypatch):

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -125,6 +125,71 @@ def test_chat_api_returns_500_for_unexpected_chain_errors(monkeypatch):
     assert response.json()["detail"] == "Research assistant error. Check server logs."
 
 
+def test_chat_api_surfaces_rag_import_failure_in_production(monkeypatch):
+    class FakeConn:
+        def close(self) -> None:
+            return None
+
+    def _import_module(name: str):
+        if name == "chains.rag_search":
+            raise RuntimeError("boom")
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.delenv("CHAT_CHAIN_FALLBACK_MODE", raising=False)
+    monkeypatch.delenv("LLM_ZONE", raising=False)
+    monkeypatch.setattr(chat_api_module.importlib, "import_module", _import_module)
+    monkeypatch.setattr(chat_api_module, "connect_db", lambda *args, **kwargs: FakeConn())
+    monkeypatch.setattr(chat_api_module, "_build_chat_client_info", lambda: object())
+
+    response = asyncio.run(_request("POST", "/api/chat", json={"question": "Find recent activism"}))
+
+    assert response.status_code == 503
+    assert "rag_search" in response.json()["detail"]
+
+
+def test_chat_api_explicit_offline_fallback_keeps_stub_available(monkeypatch):
+    class FakeConn:
+        def close(self) -> None:
+            return None
+
+    def _import_module(name: str):
+        if name == "chains.rag_search":
+            raise RuntimeError("boom")
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setenv("CHAT_CHAIN_FALLBACK_MODE", "offline")
+    monkeypatch.delenv("LLM_ZONE", raising=False)
+    monkeypatch.setattr(chat_api_module.importlib, "import_module", _import_module)
+    monkeypatch.setattr(chat_api_module, "connect_db", lambda *args, **kwargs: FakeConn())
+    monkeypatch.setattr(chat_api_module, "_build_chat_client_info", lambda: object())
+
+    response = asyncio.run(_request("POST", "/api/chat", json={"question": "Find recent activism"}))
+
+    assert response.status_code == 200
+    assert response.json()["chain_used"] == "rag_search"
+    assert response.json()["answer"] == "Search results for: Find recent activism"
+
+
+def test_chain_health_reports_import_failures(monkeypatch):
+    def _import_module(name: str):
+        if name == "chains.rag_search":
+            raise RuntimeError("boom")
+        return SimpleNamespace(
+            FilingSummaryChain=object,
+            HoldingsAnalysisChain=object,
+            NLQueryChain=object,
+        )
+
+    monkeypatch.delenv("CHAT_CHAIN_FALLBACK_MODE", raising=False)
+    monkeypatch.delenv("LLM_ZONE", raising=False)
+    monkeypatch.setattr(chat_api_module.importlib, "import_module", _import_module)
+
+    payload, reason = chat_api_module._chat_chain_health_payload()
+
+    assert payload == {"healthy": False, "available": False, "fallback_enabled": False}
+    assert reason == "rag_search: boom"
+
+
 def test_direct_endpoint_returns_500_for_unexpected_chain_errors(monkeypatch):
     async def _raise_runtime(*_args, **_kwargs):
         raise RuntimeError("direct chain blew up")


### PR DESCRIPTION
Closes #1311

## Summary
- fail closed when chat chain imports or class resolution crash outside explicit offline fallback mode
- keep deterministic stubs available only behind `CHAT_CHAIN_FALLBACK_MODE=offline`/dev-style values
- include chat-chain import availability in `/health` and `/health/detailed`

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_chat_api.py -q`
- deliberate-break runtime check: old unconditional fallback returns `200 Search results for: Find recent activism`
- `python -m ruff check api/chat.py tests/test_chat_api.py`
- `python -m black --check api/chat.py tests/test_chat_api.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat requests now return a clear service-unavailable response when a required chat component can’t load in production.
  * Added safer fallback behavior so chat can continue using a local stub when offline fallback mode is enabled.
  * Health checks now report chat component availability more accurately, helping surface failures earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->