### PR TITLE
Add NL query dialect contract

### DIFF
--- a/chains/nl_query.py
+++ b/chains/nl_query.py
@@ -19,7 +19,7 @@ from tools.llm_provider import (
 )
 
 NL_QUERY_SYSTEM_PROMPT = """You are a SQL query generator for a financial manager database.
-Given a natural language question, generate a PostgreSQL SELECT query.
+Given a natural language question, generate a {dialect_name} SELECT query.
 
 IMPORTANT RULES:
 1. Generate ONLY SELECT queries — never INSERT, UPDATE, DELETE, DROP, ALTER, or TRUNCATE.
@@ -37,6 +37,12 @@ _COMMENT_BLOCK_RE = re.compile(r"/\*.*?\*/", re.S)
 _COMMENT_LINE_RE = re.compile(r"--.*?$", re.M)
 _TABLE_REF_RE = re.compile(r'\b(?:from|join)\s+"?([a-zA-Z_][\w]*)"?', re.I)
 _LIMIT_RE = re.compile(r"\blimit\s+\d+\b", re.I)
+_SQLITE_UNSUPPORTED_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bilike\b", re.I), "ILIKE is PostgreSQL-only; use LIKE for SQLite"),
+    (re.compile(r"\bdate_trunc\s*\(", re.I), "date_trunc() is PostgreSQL-only"),
+    (re.compile(r"::\s*[a-zA-Z_][\w]*", re.I), "PostgreSQL cast syntax is not valid SQLite"),
+    (re.compile(r"\bto_(?:char|date|timestamp)\s*\(", re.I), "to_* date functions are PostgreSQL-only"),
+)
 _DANGEROUS_KEYWORDS = {
     "insert",
     "update",
@@ -140,6 +146,25 @@ class NLQueryChain:
             return False, f"Unknown tables referenced: {', '.join(unknown_tables)}"
         return True, None
 
+    def _connection_dialect(self, conn: Any | None = None) -> str:
+        if isinstance(conn if conn is not None else self.db, sqlite3.Connection):
+            return "sqlite"
+        return "postgresql"
+
+    def _dialect_prompt_label(self) -> str:
+        if self._connection_dialect() == "sqlite":
+            return "SQLite-compatible"
+        return "PostgreSQL-compatible"
+
+    def _validate_sql_for_connection(self, sql: str, conn: Any) -> tuple[bool, str | None]:
+        """Reject dialect-specific SQL before it reaches the active connection."""
+        if self._connection_dialect(conn) != "sqlite":
+            return True, None
+        for pattern, message in _SQLITE_UNSUPPORTED_PATTERNS:
+            if pattern.search(sql):
+                return False, message
+        return True, None
+
     def _acquire_connection(self):
         if self.db is not None:
             return self.db, False
@@ -149,7 +174,10 @@ class NLQueryChain:
         """Execute a validated SQL query and return rows as dictionaries."""
         conn, should_close = self._acquire_connection()
         try:
-            if not isinstance(conn, sqlite3.Connection):
+            is_valid_dialect, dialect_error = self._validate_sql_for_connection(sql, conn)
+            if not is_valid_dialect:
+                raise ValueError(dialect_error or "SQL dialect is incompatible with active database")
+            if self._connection_dialect(conn) != "sqlite":
                 conn.execute("SET statement_timeout TO 10000")
             cursor = conn.execute(sql)
             description = cursor.description or []
@@ -202,7 +230,10 @@ class NLQueryChain:
 
     def _prompt_text(self, question: str, context: dict[str, Any] | None = None) -> str:
         return (
-            NL_QUERY_SYSTEM_PROMPT.format(schema_ddl=self._schema_ddl)
+            NL_QUERY_SYSTEM_PROMPT.format(
+                dialect_name=self._dialect_prompt_label(),
+                schema_ddl=self._schema_ddl,
+            )
             + "\n"
             + self._context_prompt(context)
             + f"Question: {question}\n"

--- a/tests/test_nl_query_chain.py
+++ b/tests/test_nl_query_chain.py
@@ -25,6 +25,16 @@ class FakeLLM:
         return FakeResponse(self._response_text)
 
 
+class TrackingConnection(sqlite3.Connection):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.executed_sql: list[str] = []
+
+    def execute(self, sql: str, parameters=(), /):
+        self.executed_sql.append(sql)
+        return super().execute(sql, parameters)
+
+
 @pytest.fixture()
 def sqlite_conn() -> Generator[sqlite3.Connection, None, None]:
     conn = sqlite3.connect(":memory:")
@@ -68,6 +78,21 @@ def test_run_executes_query_and_formats_small_results(sqlite_conn: sqlite3.Conne
     assert result["sql"].endswith("LIMIT 100")
     assert "Returned 1 row(s)." in result["answer"]
     assert llm.prompts and "Database schema:" in llm.prompts[0]
+    assert "SQLite-compatible SELECT query" in llm.prompts[0]
+
+
+def test_sqlite_chain_rejects_postgres_only_sql():
+    conn = sqlite3.connect(":memory:", factory=TrackingConnection)
+    conn.execute("CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT, cik TEXT)")
+    conn.execute("INSERT INTO managers(manager_id, name, cik) VALUES (1, 'Elliott', '0001791786')")
+    llm = FakeLLM("{\"sql\": \"SELECT manager_id FROM managers WHERE name ILIKE '%elliott%'\"}")
+    chain = NLQueryChain(llm=llm, db_conn=conn)
+
+    with pytest.raises(ValueError, match="ILIKE is PostgreSQL-only"):
+        chain.run("Find Elliott")
+
+    assert not any("ILIKE" in statement for statement in conn.executed_sql)
+    conn.close()
 
 
 def test_format_results_summarizes_large_result_sets(sqlite_conn: sqlite3.Connection):


### PR DESCRIPTION
Closes #1280

## Summary
- Make the NL query prompt describe the active connection dialect instead of always asking for PostgreSQL.
- Reject PostgreSQL-only SQL constructs before executing against SQLite.
- Add a SQLite regression test proving `ILIKE` does not reach `sqlite3.Connection.execute`.

## Validation
- `python -m pytest tests/test_nl_query_chain.py::test_sqlite_chain_rejects_postgres_only_sql tests/test_nl_query_chain.py::test_run_executes_query_and_formats_small_results -q`
- `python -m pytest tests/test_nl_query_chain.py -q`
- `python -m pytest tests/test_chain_postgres_integration.py::test_nl_query_postgres -q` (skipped without `MGRDB_PG_TEST_URL`)
- `python -m ruff check chains/nl_query.py tests/test_nl_query_chain.py`
- Deliberate-break gate: temporarily disabled the SQLite dialect pattern guard; the new test failed because `ILIKE` reached SQLite and raised `sqlite3.OperationalError`; reverted the break before commit.
