### PR TITLE
Codex bootstrap for #1280

### DIFF
--- a/agents/codex-1280.md
+++ b/agents/codex-1280.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1280 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1280 -->

### Source Issue #1280: [Audit] Add dialect contract for NLQueryChain across SQLite and Postgres

Base: main
Head: codex/issue-1280

Source: https://github.com/stranske/Manager-Database/issues/1280

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is **latent fragility with a current contract mismatch**. `NL_QUERY_SYSTEM_PROMPT` instructs the LLM to generate a PostgreSQL SELECT query (`chains/nl_query.py:21`, `chains/nl_query.py:22`), but `_execute_query()` runs the generated SQL against whichever connection is active and only special-cases statement timeout for non-SQLite connections (`chains/nl_query.py:148`, `chains/nl_query.py:150`, `chains/nl_query.py:152`, `chains/nl_query.py:154`). Unit tests execute the chain against SQLite (`tests/test_nl_query_chain.py:28`, `tests/test_nl_query_chain.py:30`, `tests/test_nl_query_chain.py:59`, `tests/test_nl_query_chain.py:63`, `tests/test_nl_query_chain.py:65`) while the Postgres integration test uses the same class (`tests/test_chain_postgres_integration.py:244`, `tests/test_chain_postgres_integration.py:250`, `tests/test_chain_postgres_integration.py:252`). Missing behavior: the chain must either generate dialect-appropriate SQL for SQLite or reject PostgreSQL-only SQL before SQLite execution.

#### Tasks
- [ ] In `chains/nl_query.py:21-34`, include the active database dialect in the prompt or make the prompt backend-neutral when the connection is SQLite.
- [ ] In `chains/nl_query.py:126-154`, add validation or translation for PostgreSQL-only constructs before executing SQL on a `sqlite3.Connection`.
- [ ] Add `tests/test_nl_query_chain.py::test_sqlite_chain_rejects_postgres_only_sql` using `FakeLLM` to return a PostgreSQL-only expression such as `ILIKE` or `date_trunc`, and assert the chain returns a controlled error without executing it on SQLite.
- [ ] Add or update a Postgres-path test, such as `tests/test_chain_postgres_integration.py::test_nl_query_postgres`, so valid Postgres SQL remains accepted when `MGRDB_PG_TEST_URL` is set.
- [ ] Document the dialect behavior in an implementation comment or test name near `chains/nl_query.py:148-154` so future edits do not erase the contract.

#### Acceptance Criteria
- [ ] Named tests pass: `python -m pytest tests/test_nl_query_chain.py::test_sqlite_chain_rejects_postgres_only_sql tests/test_nl_query_chain.py::test_run_executes_query_and_formats_small_results -q`.
- [ ] **Deliberate-break gate:** temporarily bypass the new SQLite dialect validation in `chains/nl_query.py`. `tests/test_nl_query_chain.py::test_sqlite_chain_rejects_postgres_only_sql` must FAIL because the PostgreSQL-only SQL reaches `sqlite3.Connection.execute`. Revert the break before review.
- [ ] If Postgres is available, `MGRDB_PG_TEST_URL=<url> python -m pytest tests/test_chain_postgres_integration.py::test_nl_query_postgres -q` still passes.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is **latent fragility with a current contract mismatch**. `NL_QUERY_SYSTEM_PROMPT` instructs the LLM to generate a PostgreSQL SELECT query (`chains/nl_query.py:21`, `chains/nl_query.py:22`), but `_execute_query()` runs the generated SQL against whichever connection is active and only special-cases statement timeout for non-SQLite connections (`chains/nl_query.py:148`, `chains/nl_query.py:150`, `chains/nl_query.py:152`, `chains/nl_query.py:154`). Unit tests execute the chain against SQLite (`tests/test_nl_query_chain.py:28`, `tests/test_nl_query_chain.py:30`, `tests/test_nl_query_chain.py:59`, `tests/test_nl_query_chain.py:63`, `tests/test_nl_query_chain.py:65`) while the Postgres integration test uses the same class (`tests/test_chain_postgres_integration.py:244`, `tests/test_chain_postgres_integration.py:250`, `tests/test_chain_postgres_integration.py:252`). Missing behavior: the chain must either generate dialect-appropriate SQL for SQLite or reject PostgreSQL-only SQL before SQLite execution.

## Scope

Add an explicit dialect contract for `NLQueryChain` validation/execution and tests for both SQLite and Postgres-capable paths.

## Non-Goals

- Do NOT loosen SQL safety rules in `_validate_sql()` (`chains/nl_query.py:126-141`).
- Do NOT allow mutations, multiple statements, or unknown tables.
- Do NOT make unit tests call a live LLM provider; use the existing `FakeLLM` in `tests/test_nl_query_chain.py:18-25`.
- Scaffold-only completion does NOT count: changing the prompt text without a test that exercises a PostgreSQL-only expression against SQLite is a failure of this issue.

## Tasks

- [ ] In `chains/nl_query.py:21-34`, include the active database dialect in the prompt or make the prompt backend-neutral when the connection is SQLite.
- [ ] In `chains/nl_query.py:126-154`, add validation or translation for PostgreSQL-only constructs before executing SQL on a `sqlite3.Connection`.
- [ ] Add `tests/test_nl_query_chain.py::test_sqlite_chain_rejects_postgres_only_sql` using `FakeLLM` to return a PostgreSQL-only expression such as `ILIKE` or `date_trunc`, and assert the chain returns a controlled error without executing it on SQLite.
- [ ] Add or update a Postgres-path test, such as `tests/test_chain_postgres_integration.py::test_nl_query_postgres`, so valid Postgres SQL remains accepted when `MGRDB_PG_TEST_URL` is set.
- [ ] Document the dialect behavior in an implementation comment or test name near `chains/nl_query.py:148-154` so future edits do not erase the contract.

## Acceptance Criteria

- [ ] Named tests pass: `python -m pytest tests/test_nl_query_chain.py::test_sqlite_chain_rejects_postgres_only_sql tests/test_nl_query_chain.py::test_run_executes_query_and_formats_small_results -q`.
- [ ] **Deliberate-break gate:** temporarily bypass the new SQLite dialect validation in `chains/nl_query.py`. `tests/test_nl_query_chain.py::test_sqlite_chain_rejects_postgres_only_sql` must FAIL because the PostgreSQL-only SQL reaches `sqlite3.Connection.execute`. Revert the break before review.
- [ ] If Postgres is available, `MGRDB_PG_TEST_URL=<url> python -m pytest tests/test_chain_postgres_integration.py::test_nl_query_postgres -q` still passes.

## Implementation Notes

Audit baseline: `main` at `e7e8f06a9658dbb7106da1fc3c128ecfd836c573` on 2026-06-28.

Confirmed current reproduction basis: the current prompt says PostgreSQL while the default unit fixture is SQLite.



</details>

—
PR created automatically to engage Codex.