### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,48 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/getting-started/configure-coderabbit
+# Fleet default, synced from stranske/Workflows (templates/consumer-repo/.coderabbit.yaml).
+# Tuned for the stranske autonomous-agent fleet:
+#   - assertive review of substantial agent-authored PRs
+#   - advisory / non-gating, matching the fleet rule that review never blocks a merge
+#   - maintenance-bot PRs and generated sync/draft PRs do not spend review budget
+#   - a workflow-injection guard, since workflow YAML is synced across consumer repos
+language: en-US
+reviews:
+  profile: assertive
+  request_changes_workflow: false      # advisory: never auto-block a merge (fleet rule)
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false                      # opener creates drafts; review when marked ready
+    # Skip automatic-review budget on maintenance-bot PRs (dependency bumps, CI/version
+    # syncs). agents-workflows-bot is intentionally NOT listed — it authors substantial
+    # agent code PRs (e.g. "Agent belt for #N") that should still be reviewed.
+    ignore_usernames:
+      - "renovate[bot]"
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+      - "stranske-keepalive[bot]"
+    # Also skip generated maintenance / sync PRs by title and by negative label.
+    ignore_title_keywords:
+      - "chore: sync workflow templates"
+      - "sync workflow templates"
+    labels:
+      - "!sync"
+      - "!workflow:source-sync"
+      - "!workflow:source-maintenance"
+      - "!consumer-sync"
+      - "!integration-sync"
+      - "!workflows-sync"
+      - "!template-sync"
+  path_filters:
+    - "!**/*.lock"
+    - "!**/vendor/**"
+    - "!**/.workflows-lib/**"
+  path_instructions:
+    - path: ".github/workflows/**"
+      instructions: >-
+        Flag template-injection, unpinned third-party actions, and spoofable bot-actor
+        checks — this workflow YAML is synced across consumer repos, so one bug
+        replicates fleet-wide.
+chat:
+  auto_reply: true

--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -1283,7 +1283,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
-            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -1354,7 +1353,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
-            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -1553,7 +1551,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
-            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/runtime_ac_merge_guard.js
             .github/scripts/token_load_balancer.js

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -111,7 +111,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           steps.eligibility.outputs.should-run == 'true' &&
           steps.api_client_base.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@a525e6e3e2431d302073de65723c6e022f4b02fa" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@a0bf67ebf03ca6767607b6da335fd21a88ebf787" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
@@ -180,7 +180,7 @@ jobs:
           steps.eligibility.outputs.should-run == 'true' &&
           github.event_name == 'pull_request' &&
           steps.api_client_head.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@a525e6e3e2431d302073de65723c6e022f4b02fa" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@a0bf67ebf03ca6767607b6da335fd21a88ebf787" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}

--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
+        uses: anthropics/claude-code-action@4633baf5267540f3f8cb58b684f79901d564c280 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -842,12 +842,9 @@ def evaluate_pr_multiple(
 ) -> list[EvaluationResult]:
     change_type = _classify_change_type(_bounded_diff_for_classification(diff))
     runner = ComparisonRunner.from_environment(context, diff, model1, model2)
-    families = {_provider_family(provider) for _, provider, _ in runner.clients}
-    if len(runner.clients) < 2 or len(families) < 2:
-        result = _fallback_evaluation(
-            "unverified: compare mode requires two cross-family verifier judges; "
-            f"available families: {', '.join(sorted(families)) or 'none'}."
-        )
+    is_valid, error_message = _validate_comparison_clients(runner.clients)
+    if not is_valid:
+        result = _fallback_evaluation(error_message)
         result.change_type = change_type
         return [result]
     results: list[EvaluationResult] = []
@@ -867,6 +864,47 @@ def _provider_family(provider: str) -> str:
     if "anthropic" in label or "claude" in label:
         return "anthropic"
     return label.split("/", 1)[0].strip() or "unknown"
+
+
+def _get_provider_families(clients: list[tuple[object, str, str]]) -> set[str]:
+    """Extract the set of unique provider families from a list of clients.
+
+    Args:
+        clients: List of (client, provider, model) tuples.
+
+    Returns:
+        Set of provider family names (e.g., {"openai", "anthropic"}).
+    """
+    return {_provider_family(provider) for _, provider, _ in clients}
+
+
+def _validate_comparison_clients(clients: list[tuple[object, str, str]]) -> tuple[bool, str]:
+    """Validate that client list is sufficient for cross-family comparison.
+
+    Args:
+        clients: List of (client, provider, model) tuples.
+
+    Returns:
+        Tuple of (is_valid, error_message).
+        is_valid is True if there are >= 2 clients from >= 2 different provider families.
+        error_message describes the reason if validation fails.
+    """
+    families = _get_provider_families(clients)
+    if len(clients) < 2:
+        family_str = ", ".join(sorted(families)) or "none"
+        return (
+            False,
+            f"unverified: compare mode requires two cross-family verifier judges; "
+            f"available families: {family_str}.",
+        )
+    if len(families) < 2:
+        family_str = ", ".join(sorted(families)) or "none"
+        return (
+            False,
+            f"unverified: compare mode requires two cross-family verifier judges; "
+            f"available families: {family_str}.",
+        )
+    return True, ""
 
 
 def _normalize_text(text: str) -> str:

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -130,6 +130,10 @@ def _provider_instruction_path(workspace: Path, provider: str) -> Path:
     return workspace / ".github" / "claude" / "AGENT_INSTRUCTIONS.md"
 
 
+def _repository_guidance_path(workspace: Path) -> Path:
+    return workspace / "AGENTS.md"
+
+
 def _prompt_output_name(provider: str, pr_number: str | int | None) -> str:
     suffix = f"-{pr_number}" if pr_number not in (None, "") else ""
     return f"{provider}-prompt{suffix}.md"
@@ -488,6 +492,10 @@ def assemble_prompt(
 
     if appendix:
         parts.extend(["\n\n## Run context\n", appendix.rstrip()])
+
+    repository_guidance = _repository_guidance_path(workspace)
+    if repository_guidance.is_file():
+        parts.extend(["\n\n## Repository Guidance\n", _read_text(repository_guidance).rstrip()])
 
     reference_summary = workspace / ".reference" / "REFERENCE_PACKS.md"
     if reference_summary.is_file():

--- a/scripts/validate_run_contract.py
+++ b/scripts/validate_run_contract.py
@@ -261,6 +261,20 @@ def validate_envelope(
     return report
 
 
+def _find_participant(registry: dict[str, Any], repo: str) -> dict[str, Any] | None:
+    """Look up a participant by repo in the registry. Returns None if not found."""
+    return _find_entry(registry, repo)
+
+
+def _is_missing_envelope_a_failure(entry: dict[str, Any] | None) -> bool:
+    """Decide whether a missing envelope should fail (True) or skip (False).
+
+    An emitting or conformant participant MUST have an envelope; all others
+    (absent, candidate, none, planned) are opt-in skip.
+    """
+    return entry is not None and entry.get("status") in EMITTING_STATUSES
+
+
 def missing_envelope_report(registry: dict[str, Any], repo: str, run_json: Path) -> Report:
     """Decide what a MISSING run envelope means for ``repo``.
 
@@ -274,10 +288,10 @@ def missing_envelope_report(registry: dict[str, Any], repo: str, run_json: Path)
     is never failed just for lacking an envelope) without silencing a real
     regression in an active participant.
     """
-    entry = _find_entry(registry, repo)
+    entry = _find_participant(registry, repo)
     report = Report(repo=repo, role=entry.get("role", "") if entry else "")
-    is_active_participant = entry is not None and entry.get("status") in EMITTING_STATUSES
-    if is_active_participant:
+
+    if _is_missing_envelope_a_failure(entry):
         assert entry is not None
         report.fail(
             f"{repo} is an active backplane participant "
@@ -406,9 +420,11 @@ def _self_smoke(schema_dir: Path, registry_path: Path) -> int:
                     True,
                 )
             )
+        # Unsafe raw payload fixtures must fail without echoing sensitive values.
         for inv in (
             "missing_cost.json",
             "unsafe_rows_inline.json",
+            "unsafe_prompt_inline.json",
             "artifact_not_in_manifest.json",
             "bad_identity_ref.json",
         ):

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Model-registry freshness gate.
+
+Offline, deterministic, stdlib-only. Detects when the canonical LLM model
+configuration has drifted into staleness so old models do not get stuck as the
+primary ones indefinitely. It does NOT change model selection — it only reports.
+
+Inputs (defaults resolve relative to the repo root):
+  - config/model_registry.json  : curated models with per-tier quality scores.
+  - config/llm_slots.json        : provider/model slot pins consumed by
+                                   tools/llm_registry.py.
+
+Findings:
+  review_overdue : registry `review_by` (or `last_updated` + --max-age-days) is
+                   in the past relative to --today. The registry is hand-curated;
+                   without a periodic review, new GA models never enter it.
+  blocked_pin    : a slot pins a model the registry marks `blocked: true`.
+  unknown_pin    : a slot pins a model absent from the registry.
+  dominated_pin  : a slot pins a model whose best per-tier quality is strictly
+                   lower than another non-blocked model from the SAME provider in
+                   the registry — i.e. the registry's own data already says a
+                   better model exists, but the pin keeps the old one primary.
+
+Exit codes: 0 = fresh, 1 = stale findings, 2 = config/usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
+DEFAULT_SLOTS_PATH = _REPO_ROOT / "config" / "llm_slots.json"
+DEFAULT_MAX_AGE_DAYS = 60
+
+
+def _normalize_provider(provider: str) -> str:
+    p = (provider or "").strip().lower()
+    if p in {"anthropic", "claude"}:
+        return "anthropic"
+    if p in {"openai", "azure-openai"}:
+        return "openai"
+    if p in {"github", "github-models", "github_models"}:
+        return "github"
+    return p
+
+
+def _headline_quality(entry: dict[str, Any]) -> float:
+    quality = entry.get("quality") or {}
+    values = [float(v) for v in quality.values() if isinstance(v, (int, float))]
+    return max(values) if values else 0.0
+
+
+def _normalize_tier(value: str) -> str:
+    return value.strip().upper()
+
+
+def _parse_date(value: str) -> _dt.date:
+    return _dt.date.fromisoformat(str(value).strip())
+
+
+def evaluate(
+    registry: dict[str, Any],
+    slots: dict[str, Any],
+    *,
+    today: _dt.date,
+    max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+) -> list[dict[str, str]]:
+    """Return a list of finding dicts (empty == fresh). Pure function."""
+    findings: list[dict[str, str]] = []
+
+    models = registry.get("models") or []
+    # Index by (provider, model_id).
+    by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    by_provider: dict[str, list[dict[str, Any]]] = {}
+    for m in models:
+        prov = _normalize_provider(str(m.get("provider", "")))
+        mid = str(m.get("model_id", "")).strip()
+        if not mid:
+            continue
+        by_key[(prov, mid)] = m
+        by_provider.setdefault(prov, []).append(m)
+
+    # 1. review_overdue -------------------------------------------------------
+    review_by_raw = registry.get("review_by")
+    try:
+        if review_by_raw:
+            review_by = _parse_date(review_by_raw)
+        else:
+            last_updated = registry.get("last_updated")
+            if not last_updated:
+                findings.append(
+                    {
+                        "kind": "review_overdue",
+                        "detail": "registry has neither `review_by` nor `last_updated`; "
+                        "cannot prove freshness.",
+                    }
+                )
+                review_by = None
+            else:
+                review_by = _parse_date(last_updated) + _dt.timedelta(days=max_age_days)
+    except ValueError as exc:
+        findings.append({"kind": "review_overdue", "detail": f"unparseable date: {exc}"})
+        review_by = None
+
+    if review_by is not None and review_by < today:
+        days = (today - review_by).days
+        findings.append(
+            {
+                "kind": "review_overdue",
+                "detail": f"model registry review is overdue by {days} day(s) "
+                f"(review_by={review_by.isoformat()}, today={today.isoformat()}). "
+                "Re-check provider model lists and refresh quality scores.",
+            }
+        )
+
+    # Slot pins ---------------------------------------------------------------
+    for slot in slots.get("slots") or []:
+        name = str(slot.get("name", "?"))
+        prov = _normalize_provider(str(slot.get("provider", "")))
+        model = str(slot.get("model", "")).strip()
+        if not model:
+            # Tier-derived slot: model comes from the registry at runtime — this is
+            # the non-ossifying shape, nothing to flag here.
+            continue
+        entry = by_key.get((prov, model))
+        if entry is None:
+            findings.append(
+                {
+                    "kind": "unknown_pin",
+                    "detail": f"slot {name!r} pins {prov}/{model} which is absent from "
+                    "the model registry (cannot verify it is current or unblocked).",
+                }
+            )
+            continue
+        if entry.get("blocked"):
+            findings.append(
+                {
+                    "kind": "blocked_pin",
+                    "detail": f"slot {name!r} pins {prov}/{model} which is marked "
+                    "blocked in the registry.",
+                }
+            )
+            continue
+        tier = _normalize_tier(str(slot.get("quality_tier", "")))
+
+        def _slot_quality(model_entry: dict[str, Any], slot_tier: str = tier) -> float:
+            if not slot_tier:
+                return _headline_quality(model_entry)
+            quality = model_entry.get("quality") or {}
+            value = quality.get(slot_tier)
+            return float(value) if isinstance(value, (int, float)) else float("-inf")
+
+        pinned_q = _slot_quality(entry)
+        better = [
+            m
+            for m in by_provider.get(prov, [])
+            if not m.get("blocked") and _slot_quality(m) > pinned_q
+        ]
+        if better:
+            best = max(better, key=_slot_quality)
+            findings.append(
+                {
+                    "kind": "dominated_pin",
+                    "detail": f"slot {name!r} pins {prov}/{model} "
+                    f"(quality {pinned_q:.2f}) but the registry rates "
+                    f"{prov}/{best.get('model_id')} higher "
+                    f"({_slot_quality(best):.2f}); the pin keeps an older model primary.",
+                }
+            )
+
+    return findings
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Model-registry freshness gate.")
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY_PATH)
+    parser.add_argument("--slots", type=Path, default=DEFAULT_SLOTS_PATH)
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=DEFAULT_MAX_AGE_DAYS,
+        help="Used only when the registry has no explicit `review_by`.",
+    )
+    parser.add_argument(
+        "--today",
+        type=str,
+        default=None,
+        help="ISO date override (testing); defaults to system date.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON.")
+    args = parser.parse_args(argv)
+
+    try:
+        registry = _load_json(args.registry)
+        slots = _load_json(args.slots)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"config error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        today = _parse_date(args.today) if args.today else _dt.date.today()
+    except ValueError as exc:
+        print(f"config error: {exc}", file=sys.stderr)
+        return 2
+    findings = evaluate(registry, slots, today=today, max_age_days=args.max_age_days)
+
+    if args.json:
+        print(json.dumps({"fresh": not findings, "findings": findings}, indent=2))
+    else:
+        if not findings:
+            print("Model registry is fresh: no stale or dominated pins.")
+        else:
+            print(f"Model registry freshness: {len(findings)} finding(s):")
+            for f in findings:
+                print(f"  [{f['kind']}] {f['detail']}")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -105,7 +105,7 @@ def load_model_registry() -> list[ModelRegistryEntry]:
         quality = {
             str(tier).upper(): float(score)
             for tier, score in quality_payload.items()
-            if isinstance(score, int | float)
+            if isinstance(score, (int, float)) and not isinstance(score, bool)
         }
         entries.append(
             ModelRegistryEntry(
@@ -229,12 +229,21 @@ def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
 
     registry = load_model_registry()
     slots: list[SlotDefinition] = []
+    fallback_by_position = dict(enumerate(fallback_slots, start=1))
+    fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
     for idx, entry in enumerate(_slot_entries(payload, path), start=1):
         provider = normalize_provider(str(entry.get("provider", "")))
         model = str(entry.get("model", "")).strip()
         tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()
         if provider and not model and tier:
             model = select_model_for_tier(provider=provider, tier=tier, registry=registry) or ""
+        if provider and not model:
+            fallback_slot = fallback_by_position.get(idx)
+            if fallback_slot and fallback_slot.provider != provider:
+                fallback_slot = fallback_by_provider.get(provider)
+            fallback_slot = fallback_slot or fallback_by_provider.get(provider)
+            if fallback_slot and fallback_slot.provider == provider:
+                model = fallback_slot.model
         if not provider or not model:
             continue
         if is_model_blocked(provider, model, registry=registry):


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-81-gate-followups.yml: Gate followups hub - consolidates keepalive and autofix followups
- agents-guard.yml: Agents guard - enforces agents workflow protections (Health 45)
- maint-76-claude-code-review.yml: Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch
- runner_lib/ (1 files): Shared runner prompt assembly, output parsing, and dispatch debounce helpers
- pr_verifier.py: PR verifier - validates PR changes against acceptance criteria
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement
- check_model_registry_freshness.py: Model-registry freshness gate - offline check that flags stale/blocked/dominated model pins so old models do not get stuck as primary
- validate_run_contract.py: Validates a repo's emitted run-contract/v1 run envelope (producer/bridge) or ingested satellite object (consumer) against the canonical Workflows schemas + opt-in participant registry. Offline/deterministic; opt-in skip for non-participants. Synced so participants can validate locally and the reusable conformance gate can invoke it.
- .coderabbit.yaml: CodeRabbit auto-review config - skips maintenance-bot PRs (renovate/dependabot/github-actions/keepalive) and generated sync/draft PRs, while keeping substantial agent-authored PR reviews enabled. Advisory/non-gating per fleet rule.

### Files Skipped
- .github/workflows/pr-00-gate.yml: Maintains a fully custom Gate workflow; never overwrite (replaces the hard-coded custom_gate_repos list in maint-68).
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `5afdb2a6a222d9834f0a62886ea60ab272405796`
**Template hash:** `1f5f5737bf2c`
**Sync branch:** `sync/workflows-1f5f5737bf2c`
**Consumer repo:** `stranske/Manager-Database`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Manager-Database","source_repository":"stranske/Workflows","source_sha":"5afdb2a6a222d9834f0a62886ea60ab272405796","template_hash":"1f5f5737bf2c","sync_branch":"sync/workflows-1f5f5737bf2c","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"28421592809","run_attempt":"1","changes_count":9} -->