### PR TITLE
Remove Postgres DDL from store_document runtime

### DIFF
--- a/embeddings.py
+++ b/embeddings.py
@@ -83,6 +83,23 @@ def _postgres_columns(conn: Any, table: str) -> set[str]:
     return {str(row[0]) for row in rows}
 
 
+def _postgres_documents_contract(columns: set[str]) -> tuple[str, str]:
+    id_col = "doc_id" if "doc_id" in columns else "id" if "id" in columns else ""
+    text_col = "text" if "text" in columns else "content" if "content" in columns else ""
+    required = {"embedding", "sha256"}
+    missing = sorted(required - columns)
+    if not id_col:
+        missing.append("doc_id or id")
+    if not text_col:
+        missing.append("text or content")
+    if missing:
+        raise RuntimeError(
+            "Postgres documents schema is not migrated; missing required columns: "
+            + ", ".join(missing)
+        )
+    return id_col, text_col
+
+
 def store_document(
     text: str,
     db_path: str | None = None,
@@ -108,24 +125,12 @@ def store_document(
     if is_pg:
         if register_vector:
             register_vector(conn)
-        conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
-        conn.execute("""CREATE TABLE IF NOT EXISTS documents (
-                doc_id bigserial PRIMARY KEY,
-                manager_id bigint REFERENCES managers(manager_id),
-                kind text NOT NULL DEFAULT 'note',
-                filename text,
-                sha256 text,
-                text text,
-                embedding vector(384),
-                created_at timestamptz DEFAULT now()
-            )""")
-        conn.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_sha256_unique "
-            "ON documents (sha256) WHERE sha256 IS NOT NULL"
-        )
         columns = _postgres_columns(conn, "documents")
-        id_col = "doc_id" if "doc_id" in columns else "id"
-        text_col = "text" if "text" in columns else "content"
+        try:
+            id_col, text_col = _postgres_documents_contract(columns)
+        except RuntimeError:
+            conn.close()
+            raise
         emb_vec = _pgvector_embedding(text)
         emb = Vector(emb_vec) if register_vector else emb_vec
         insert_cols: list[str] = []
@@ -152,7 +157,7 @@ def store_document(
                 f"INSERT INTO documents({', '.join(insert_cols)}) "
                 f"VALUES ({placeholders}) "
                 "ON CONFLICT (sha256) WHERE sha256 IS NOT NULL DO NOTHING "
-                "RETURNING doc_id"
+                f"RETURNING {id_col}"
             ),
             tuple(insert_values),
         )

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -2,6 +2,8 @@ import sqlite3
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from embeddings import (
@@ -392,6 +394,8 @@ def test_store_and_search_pgvector(monkeypatch):
 
 
 def test_store_document_postgres_uses_dialect_specific_schema_and_insert(monkeypatch):
+    ddl_prefixes = ("CREATE EXTENSION", "CREATE TABLE", "CREATE UNIQUE INDEX")
+
     class Connection:
         def __init__(self):
             self.info = object()
@@ -399,6 +403,7 @@ def test_store_document_postgres_uses_dialect_specific_schema_and_insert(monkeyp
 
         def execute(self, sql, params=None):
             _assert_postgres_safe(sql)
+            assert not sql.strip().upper().startswith(ddl_prefixes)
             self.executed.append((sql, params))
             if "information_schema.columns" in sql:
                 return type(
@@ -434,11 +439,41 @@ def test_store_document_postgres_uses_dialect_specific_schema_and_insert(monkeyp
     assert store_document("dialect branch", "ignored.db") == 9
 
     executed_sql = "\n".join(sql for sql, _params in conn.executed)
-    assert "doc_id bigserial PRIMARY KEY" in executed_sql
+    assert "information_schema.columns" in executed_sql
+    assert "doc_id bigserial PRIMARY KEY" not in executed_sql
+    assert "CREATE EXTENSION" not in executed_sql
+    assert "CREATE UNIQUE INDEX" not in executed_sql
     assert "ON CONFLICT (sha256) WHERE sha256 IS NOT NULL DO NOTHING" in executed_sql
     assert "AUTOINCREMENT" not in executed_sql
     assert "PRAGMA table_info" not in executed_sql
     assert "INSERT OR IGNORE" not in executed_sql
+
+
+def test_store_document_postgres_requires_migrated_documents_schema(monkeypatch):
+    class Connection:
+        def __init__(self):
+            self.info = object()
+            self.closed = False
+
+        def execute(self, sql, params=None):
+            _assert_postgres_safe(sql)
+            if "information_schema.columns" in sql:
+                return type("Result", (), {"fetchall": lambda self: [("doc_id",), ("text",)]})()
+            return type("Result", (), {"fetchall": lambda self: []})()
+
+        def commit(self):
+            raise AssertionError("commit should not run when schema validation fails")
+
+        def close(self):
+            self.closed = True
+
+    conn = Connection()
+    monkeypatch.setattr("embeddings.connect_db", lambda _path=None: conn)
+    monkeypatch.setattr("embeddings.register_vector", None)
+
+    with pytest.raises(RuntimeError, match="Postgres documents schema is not migrated"):
+        store_document("dialect branch", "ignored.db")
+    assert conn.closed is True
 
 
 def test_store_document_pgvector_conflict_returns_existing(monkeypatch):


### PR DESCRIPTION
Closes #1281

## Summary
- remove Postgres extension/table/index DDL from the `store_document()` runtime path
- validate the migrated Postgres `documents` schema through `information_schema` before inserting
- keep SQLite document-store bootstrap behavior intact and add tests that fail if Postgres runtime DDL returns

## Validation
- `python -m pytest tests/test_embeddings.py::test_store_document_postgres_uses_dialect_specific_schema_and_insert tests/test_embeddings.py::test_store_document_postgres_requires_migrated_documents_schema tests/test_schema_postgres_bootstrap.py::test_split_sql_statements_parses_schema_sql tests/test_embeddings.py::test_store_document_creates_sha256_unique_index_sqlite tests/test_embeddings.py::test_store_document_sqlite_create_table_uses_autoincrement -q`
- `python -m ruff check embeddings.py tests/test_embeddings.py`
- Deliberate-break: temporarily reintroduced `CREATE EXTENSION IF NOT EXISTS vector` in the Postgres branch and confirmed `test_store_document_postgres_uses_dialect_specific_schema_and_insert` fails, then reverted before commit.
