### PR TITLE
Codex bootstrap for #1281

### DIFF
--- a/agents/codex-1281.md
+++ b/agents/codex-1281.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1281 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1281 -->

### Source Issue #1281: [Audit] Remove Postgres DDL from store_document runtime path

Base: main
Head: codex/issue-1281

Source: https://github.com/stranske/Manager-Database/issues/1281

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is **latent operational fragility**. The canonical schema owns Postgres extension/table/index creation (`schema.sql:5`, `schema.sql:6`, `schema.sql:163`, `schema.sql:170`, `schema.sql:174`, `schema.sql:175`), and the repo has a Postgres bootstrap smoke around `schema.sql` (`tests/test_schema_postgres_bootstrap.py:216`). But the runtime document store path still executes Postgres DDL: `CREATE EXTENSION IF NOT EXISTS vector`, `CREATE TABLE IF NOT EXISTS documents`, and `CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_sha256_unique` inside `store_document()` (`embeddings.py:108`, `embeddings.py:111`, `embeddings.py:112`, `embeddings.py:122`, `embeddings.py:123`, `embeddings.py:124`). Missing behavior: app runtime should use an already-migrated schema and fail clearly if it is missing, rather than requiring elevated DDL privileges during document upload/ingest.

#### Tasks
- [ ] In `embeddings.py:108-125`, remove Postgres `CREATE EXTENSION`, `CREATE TABLE`, and `CREATE UNIQUE INDEX` execution from `store_document()`.
- [ ] In `embeddings.py:126-130`, validate required Postgres columns using `_postgres_columns()` and raise a clear migration/schema error if `documents` is missing required columns.
- [ ] Update `tests/test_embeddings.py::test_store_document_postgres_uses_dialect_specific_schema_and_insert` so the fake Postgres connection asserts no DDL statements are executed before insert/select.
- [ ] Keep `tests/test_schema_postgres_bootstrap.py::test_schema_sql_bootstraps_clean_postgres` as the schema-creation gate.
- [ ] Confirm `search_documents()` still uses the existing Postgres vector query path at `embeddings.py:260-262`.

#### Acceptance Criteria
- [ ] Named tests pass: `python -m pytest tests/test_embeddings.py::test_store_document_postgres_uses_dialect_specific_schema_and_insert tests/test_schema_postgres_bootstrap.py::test_split_sql_statements_parses_schema_sql -q`.
- [ ] **Deliberate-break gate:** temporarily add `conn.execute("CREATE EXTENSION IF NOT EXISTS vector")` back to the Postgres branch of `store_document()`. The updated `tests/test_embeddings.py::test_store_document_postgres_uses_dialect_specific_schema_and_insert` must FAIL because Postgres runtime DDL was observed. Revert the break before review.
- [ ] SQLite document-store tests still pass: `python -m pytest tests/test_embeddings.py::test_store_document_creates_sha256_unique_index_sqlite tests/test_embeddings.py::test_store_document_sqlite_create_table_uses_autoincrement -q`.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is **latent operational fragility**. The canonical schema owns Postgres extension/table/index creation (`schema.sql:5`, `schema.sql:6`, `schema.sql:163`, `schema.sql:170`, `schema.sql:174`, `schema.sql:175`), and the repo has a Postgres bootstrap smoke around `schema.sql` (`tests/test_schema_postgres_bootstrap.py:216`). But the runtime document store path still executes Postgres DDL: `CREATE EXTENSION IF NOT EXISTS vector`, `CREATE TABLE IF NOT EXISTS documents`, and `CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_sha256_unique` inside `store_document()` (`embeddings.py:108`, `embeddings.py:111`, `embeddings.py:112`, `embeddings.py:122`, `embeddings.py:123`, `embeddings.py:124`). Missing behavior: app runtime should use an already-migrated schema and fail clearly if it is missing, rather than requiring elevated DDL privileges during document upload/ingest.

## Scope

For Postgres connections only, move `store_document()` to a no-DDL runtime path that validates required schema and uses DML. Preserve SQLite's local bootstrap behavior for tests/dev databases.

## Non-Goals

- Do NOT remove SQLite bootstrap DDL from `embeddings.py:172-188`; local SQLite tests rely on it.
- Do NOT change vector dimensions or embedding semantics in this issue.
- Do NOT remove `schema.sql` extension/table/index definitions.
- Scaffold-only completion does NOT count: moving the DDL strings to another runtime helper that `store_document()` still calls for Postgres is a failure of this issue.

## Tasks

- [ ] In `embeddings.py:108-125`, remove Postgres `CREATE EXTENSION`, `CREATE TABLE`, and `CREATE UNIQUE INDEX` execution from `store_document()`.
- [ ] In `embeddings.py:126-130`, validate required Postgres columns using `_postgres_columns()` and raise a clear migration/schema error if `documents` is missing required columns.
- [ ] Update `tests/test_embeddings.py::test_store_document_postgres_uses_dialect_specific_schema_and_insert` so the fake Postgres connection asserts no DDL statements are executed before insert/select.
- [ ] Keep `tests/test_schema_postgres_bootstrap.py::test_schema_sql_bootstraps_clean_postgres` as the schema-creation gate.
- [ ] Confirm `search_documents()` still uses the existing Postgres vector query path at `embeddings.py:260-262`.

## Acceptance Criteria

- [ ] Named tests pass: `python -m pytest tests/test_embeddings.py::test_store_document_postgres_uses_dialect_specific_schema_and_insert tests/test_schema_postgres_bootstrap.py::test_split_sql_statements_parses_schema_sql -q`.
- [ ] **Deliberate-break gate:** temporarily add `conn.execute("CREATE EXTENSION IF NOT EXISTS vector")` back to the Postgres branch of `store_document()`. The updated `tests/test_embeddings.py::test_store_document_postgres_uses_dialect_specific_schema_and_insert` must FAIL because Postgres runtime DDL was observed. Revert the break before review.
- [ ] SQLite document-store tests still pass: `python -m pytest tests/test_embeddings.py::test_store_document_creates_sha256_unique_index_sqlite tests/test_embeddings.py::test_store_document_sqlite_create_table_uses_autoincrement -q`.

## Implementation Notes

Audit baseline: `main` at `e7e8f06a9658dbb7106da1fc3c128ecfd836c573` on 2026-06-28.

Confirmed current reproduction: `embeddings.py:111-124` executes Postgres DDL from the runtime storage function today.



</details>

—
PR created automatically to engage Codex.