### PR TITLE
Correct README rate-limit scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ curl -X POST "http://localhost:8000/managers" \
 curl "http://localhost:8000/health/db"
 ```
 
-**Note:** All API endpoints are subject to rate limiting. See the [API Rate Limiting documentation](docs/api_rate_limiting.md) for details on limits and how to handle rate limit responses.
+**Note:** Chat write endpoints are rate limited. See the [API Rate Limiting documentation](docs/api_rate_limiting.md) for the exact endpoint matrix and response contract.

--- a/tests/test_rate_limit_contract.py
+++ b/tests/test_rate_limit_contract.py
@@ -306,8 +306,8 @@ def test_rate_limit_document_matches_shipped_header_contract():
     assert "POST /api/chat/feedback" in doc
 
 
-def test_api_design_guidelines_do_not_claim_global_rate_limiting():
-    doc = (REPO_ROOT / "docs/api_design_guidelines.md").read_text(encoding="utf-8")
+def _assert_doc_does_not_claim_global_rate_limiting(path: str) -> str:
+    doc = (REPO_ROOT / path).read_text(encoding="utf-8")
     normalized_doc = doc.lower()
     forbidden_global_claims = [
         "all api endpoints are subject to rate limit",
@@ -319,7 +319,17 @@ def test_api_design_guidelines_do_not_claim_global_rate_limiting():
     ]
 
     assert not any(claim in normalized_doc for claim in forbidden_global_claims), (
-        "api_design_guidelines.md must delegate rate-limit scope to "
-        "api_rate_limiting.md instead of claiming all endpoints are limited."
+        f"{path} must delegate rate-limit scope to api_rate_limiting.md "
+        "instead of claiming all endpoints are limited."
     )
+    return doc
+
+
+def test_api_design_guidelines_do_not_claim_global_rate_limiting():
+    doc = _assert_doc_does_not_claim_global_rate_limiting("docs/api_design_guidelines.md")
     assert "api_rate_limiting.md" in doc
+
+
+def test_readme_does_not_claim_global_rate_limiting():
+    doc = _assert_doc_does_not_claim_global_rate_limiting("README.md")
+    assert "docs/api_rate_limiting.md" in doc


### PR DESCRIPTION
Closes #1283

## Summary
- Replace the README global rate-limit claim with chat-write endpoint scoped wording.
- Reuse the forbidden global-claim helper for docs and add README coverage.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_rate_limit_contract.py::test_readme_does_not_claim_global_rate_limiting -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_rate_limit_contract.py -q
- python -m ruff check tests/test_rate_limit_contract.py
- black --fast --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' tests/test_rate_limit_contract.py\n- git diff --check\n\n## Deliberate Break\n- Temporarily restored `All API endpoints are subject to rate limiting` in README.md and confirmed `test_readme_does_not_claim_global_rate_limiting` failed with `README.md must delegate rate-limit scope to api_rate_limiting.md`; reverted before commit.