### PR TITLE
Codex bootstrap for #1283

### DIFF
--- a/agents/codex-1283.md
+++ b/agents/codex-1283.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1283 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1283 -->

### Source Issue #1283: [Audit] Correct README global API rate-limit claim

Base: main
Head: codex/issue-1283

Source: https://github.com/stranske/Manager-Database/issues/1283

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is a **current documentation contract mismatch**. The top-level README says all API endpoints are subject to rate limiting (`README.md:36`). The detailed rate-limit docs say `/chat`, `/managers`, `/api/managers/bulk`, `/api/data`, and health endpoints are unlimited (`docs/api_rate_limiting.md:35`, `docs/api_rate_limiting.md:37`, `docs/api_rate_limiting.md:38`, `docs/api_rate_limiting.md:39`, `docs/api_rate_limiting.md:40`, `docs/api_rate_limiting.md:41`) and explicitly state other routes are not rate limited unless they call the chat limiter (`docs/api_rate_limiting.md:43`, `docs/api_rate_limiting.md:44`). Existing contract tests prevent this global claim in API design guidelines (`tests/test_rate_limit_contract.py:174-190`) but not in `README.md`. Missing behavior: public docs should describe the actual limited route set.

#### Tasks
- [ ] In `README.md:36`, replace the global rate-limit claim with wording that says chat endpoints are rate limited and points to `docs/api_rate_limiting.md` for the exact matrix.
- [ ] In `tests/test_rate_limit_contract.py:161-190`, add `test_readme_does_not_claim_global_rate_limiting` or extend the existing forbidden-claim helper to scan `README.md` as well as `docs/api_design_guidelines.md`.
- [ ] Keep the detailed endpoint matrix in `docs/api_rate_limiting.md:35-44` unchanged unless actual API behavior has changed.

#### Acceptance Criteria
- [ ] Named test passes: `python -m pytest tests/test_rate_limit_contract.py::test_readme_does_not_claim_global_rate_limiting -q`.
- [ ] **Deliberate-break gate:** temporarily restore `README.md:36` to `All API endpoints are subject to rate limiting`. The new README contract test must FAIL and name `README.md`. Revert the break before review.
- [ ] `python -m pytest tests/test_rate_limit_contract.py -q` passes.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is a **current documentation contract mismatch**. The top-level README says all API endpoints are subject to rate limiting (`README.md:36`). The detailed rate-limit docs say `/chat`, `/managers`, `/api/managers/bulk`, `/api/data`, and health endpoints are unlimited (`docs/api_rate_limiting.md:35`, `docs/api_rate_limiting.md:37`, `docs/api_rate_limiting.md:38`, `docs/api_rate_limiting.md:39`, `docs/api_rate_limiting.md:40`, `docs/api_rate_limiting.md:41`) and explicitly state other routes are not rate limited unless they call the chat limiter (`docs/api_rate_limiting.md:43`, `docs/api_rate_limiting.md:44`). Existing contract tests prevent this global claim in API design guidelines (`tests/test_rate_limit_contract.py:174-190`) but not in `README.md`. Missing behavior: public docs should describe the actual limited route set.

## Scope

Fix the top-level README wording and extend the rate-limit contract test to include README coverage.

## Non-Goals

- Do NOT change limiter behavior in `api/chat.py` in this docs-only issue.
- Do NOT add rate limiting to currently unlimited endpoints just to match the README.
- Do NOT remove the link from `README.md` to `docs/api_rate_limiting.md`.
- Scaffold-only completion does NOT count: changing the README without adding a regression test for the global-claim wording is a failure of this issue.

## Tasks

- [ ] In `README.md:36`, replace the global rate-limit claim with wording that says chat endpoints are rate limited and points to `docs/api_rate_limiting.md` for the exact matrix.
- [ ] In `tests/test_rate_limit_contract.py:161-190`, add `test_readme_does_not_claim_global_rate_limiting` or extend the existing forbidden-claim helper to scan `README.md` as well as `docs/api_design_guidelines.md`.
- [ ] Keep the detailed endpoint matrix in `docs/api_rate_limiting.md:35-44` unchanged unless actual API behavior has changed.

## Acceptance Criteria

- [ ] Named test passes: `python -m pytest tests/test_rate_limit_contract.py::test_readme_does_not_claim_global_rate_limiting -q`.
- [ ] **Deliberate-break gate:** temporarily restore `README.md:36` to `All API endpoints are subject to rate limiting`. The new README contract test must FAIL and name `README.md`. Revert the break before review.
- [ ] `python -m pytest tests/test_rate_limit_contract.py -q` passes.

## Implementation Notes

Audit baseline: `main` at `e7e8f06a9658dbb7106da1fc3c128ecfd836c573` on 2026-06-28.

Confirmed current reproduction: `README.md:36` contains the forbidden global claim today while `docs/api_rate_limiting.md:35-44` lists narrower behavior.



</details>

—
PR created automatically to engage Codex.