### PR TITLE
Fail fast for Postgres DB_URL without psycopg

### DIFF
--- a/adapters/base.py
+++ b/adapters/base.py
@@ -52,7 +52,17 @@ def connect_db(
     url = os.getenv("DB_URL")
     retries, retry_delay = _db_retry_config(retries, retry_delay)
     attempt = 0
-    if url and psycopg and url.startswith("postgres"):
+    if url:
+        if not url.startswith("postgres"):
+            raise RuntimeError(
+                "Unsupported DB_URL scheme; unset DB_URL for SQLite or use a postgres:///"
+                "postgresql:// URL."
+            )
+        if psycopg is None:
+            raise RuntimeError(
+                "DB_URL is configured for Postgres, but psycopg is not installed. "
+                "Install psycopg[binary] or unset DB_URL for SQLite."
+            )
         # psycopg connections require autocommit for DDL during tests.
         # Allow health checks to cap connection time.
         connect_kwargs: dict[str, Any] = {"autocommit": True}

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -55,8 +55,8 @@ def connect_db(
     if url:
         if not url.startswith("postgres"):
             raise RuntimeError(
-                "Unsupported DB_URL scheme; unset DB_URL for SQLite or use a postgres:///"
-                "postgresql:// URL."
+                "Unsupported DB_URL scheme; unset DB_URL for SQLite or use a "
+                "postgres:// or postgresql:// URL."
             )
         if psycopg is None:
             raise RuntimeError(

--- a/tests/test_adapter_base.py
+++ b/tests/test_adapter_base.py
@@ -101,9 +101,13 @@ def test_connect_db_rejects_unsupported_db_url_scheme(tmp_path, monkeypatch):
     monkeypatch.setenv("DB_PATH", str(env_path))
     monkeypatch.setenv("DB_URL", "mysql://user@localhost/db")
 
-    with pytest.raises(RuntimeError, match="Unsupported DB_URL scheme"):
+    with pytest.raises(RuntimeError) as exc_info:
         connect_db()
 
+    assert str(exc_info.value) == (
+        "Unsupported DB_URL scheme; unset DB_URL for SQLite or use a "
+        "postgres:// or postgresql:// URL."
+    )
     assert not env_path.exists()
 
 

--- a/tests/test_adapter_base.py
+++ b/tests/test_adapter_base.py
@@ -84,16 +84,27 @@ def test_connect_db_uses_env_db_path(tmp_path, monkeypatch):
     assert env_path.exists()
 
 
-def test_connect_db_falls_back_when_postgres_unavailable(tmp_path, monkeypatch):
-    env_path = tmp_path / "fallback.db"
+def test_connect_db_postgres_url_requires_psycopg_without_sqlite_fallback(tmp_path, monkeypatch):
+    env_path = tmp_path / "should-not-exist.db"
     monkeypatch.setenv("DB_PATH", str(env_path))
-    monkeypatch.setenv("DB_URL", "postgres://user@localhost/db")
+    monkeypatch.setenv("DB_URL", "postgresql://user@localhost/db")
     monkeypatch.setattr(base, "psycopg", None)
-    conn = connect_db()
-    try:
-        assert isinstance(conn, sqlite3.Connection)
-    finally:
-        conn.close()
+
+    with pytest.raises(RuntimeError, match="psycopg is not installed"):
+        connect_db()
+
+    assert not env_path.exists()
+
+
+def test_connect_db_rejects_unsupported_db_url_scheme(tmp_path, monkeypatch):
+    env_path = tmp_path / "should-not-exist.db"
+    monkeypatch.setenv("DB_PATH", str(env_path))
+    monkeypatch.setenv("DB_URL", "mysql://user@localhost/db")
+
+    with pytest.raises(RuntimeError, match="Unsupported DB_URL scheme"):
+        connect_db()
+
+    assert not env_path.exists()
 
 
 def test_connect_db_postgres_retries_and_timeout(monkeypatch):


### PR DESCRIPTION
Closes #1301

## Summary
- Treat a non-empty `DB_URL` as authoritative instead of falling through to SQLite.
- Raise a clear configuration error when Postgres is configured but `psycopg` is unavailable.
- Reject unsupported `DB_URL` schemes explicitly and keep SQLite behavior for unset `DB_URL`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_adapter_base.py::test_connect_db_postgres_url_requires_psycopg_without_sqlite_fallback tests/test_adapter_base.py::test_connect_db_rejects_unsupported_db_url_scheme tests/test_adapter_base.py::test_connect_db_uses_env_db_path -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin tests/test_adapter_base.py -q`
- `python -m ruff check adapters/base.py tests/test_adapter_base.py`
- `black --fast --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' adapters/base.py tests/test_adapter_base.py`\n- `git diff --check`\n\n## Deliberate Break\n- Temporarily restored the old `if url and psycopg and url.startswith("postgres")` branch and confirmed `test_connect_db_postgres_url_requires_psycopg_without_sqlite_fallback` failed because no `RuntimeError` was raised. Restored the fix before commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling for environment-based configuration.
  * Clear errors are now shown when a Postgres URL is used without the required driver installed.
  * Unsupported database URL schemes now fail fast instead of silently falling back.
  * SQLite files are no longer created in these invalid configuration cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->