### PR TITLE
Align PR Gate with main CI contract

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -68,9 +68,10 @@ jobs:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
       python-versions: '["3.12", "3.13"]'
-      coverage-min: "0"  # Temporarily disabled - pre-existing low coverage
-      typecheck: false  # Disabled until mypy config issues resolved
-      format_check: false  # Using ruff for formatting
+      coverage: true
+      coverage-min: "75"
+      typecheck: true
+      format_check: true
       pytest_markers: "not nightly"  # Skip nightly integration tests
       working-directory: "."
       artifact-prefix: "gate-"

--- a/chains/nl_query.py
+++ b/chains/nl_query.py
@@ -41,7 +41,10 @@ _SQLITE_UNSUPPORTED_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\bilike\b", re.I), "ILIKE is PostgreSQL-only; use LIKE for SQLite"),
     (re.compile(r"\bdate_trunc\s*\(", re.I), "date_trunc() is PostgreSQL-only"),
     (re.compile(r"::\s*[a-zA-Z_][\w]*", re.I), "PostgreSQL cast syntax is not valid SQLite"),
-    (re.compile(r"\bto_(?:char|date|timestamp)\s*\(", re.I), "to_* date functions are PostgreSQL-only"),
+    (
+        re.compile(r"\bto_(?:char|date|timestamp)\s*\(", re.I),
+        "to_* date functions are PostgreSQL-only",
+    ),
 )
 _DANGEROUS_KEYWORDS = {
     "insert",
@@ -176,7 +179,9 @@ class NLQueryChain:
         try:
             is_valid_dialect, dialect_error = self._validate_sql_for_connection(sql, conn)
             if not is_valid_dialect:
-                raise ValueError(dialect_error or "SQL dialect is incompatible with active database")
+                raise ValueError(
+                    dialect_error or "SQL dialect is incompatible with active database"
+                )
             if self._connection_dialect(conn) != "sqlite":
                 conn.execute("SET statement_timeout TO 10000")
             cursor = conn.execute(sql)

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import types
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any, cast
 
@@ -36,7 +37,7 @@ def feedback_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 @pytest.fixture(autouse=True)
-def clear_rate_limiter() -> None:
+def clear_rate_limiter() -> Generator[None, None, None]:
     chat_api_module.CHAT_RATE_LIMITER.clear()
     chat_api_module.CHAT_IP_RATE_LIMITER.clear()
     yield

--- a/tests/test_gate_workflow_contract.py
+++ b/tests/test_gate_workflow_contract.py
@@ -32,8 +32,8 @@ def test_pr_gate_python_ci_matches_main_ci_contract() -> None:
     assert pr_python["coverage"] == main_python["coverage"]
     assert _numeric(pr_python["coverage-min"]) >= _numeric(main_python["coverage-min"])
 
-    if "format_check" in pr_python:
-        assert pr_python["format_check"] is not False
+    assert "format_check" in pr_python, "format_check input missing from pr-00-gate.yml python-ci"
+    assert pr_python["format_check"] is True
 
 
 def test_gate_summary_depends_on_python_ci() -> None:

--- a/tests/test_gate_workflow_contract.py
+++ b/tests/test_gate_workflow_contract.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _workflow(path: str) -> dict:
+    return yaml.safe_load((REPO_ROOT / path).read_text(encoding="utf-8"))
+
+
+def _numeric(value: object) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise AssertionError(f"Expected numeric workflow value, got {value!r}") from exc
+
+
+def test_pr_gate_python_ci_matches_main_ci_contract() -> None:
+    pr_gate = _workflow(".github/workflows/pr-00-gate.yml")
+    main_ci = _workflow(".github/workflows/ci.yml")
+
+    pr_python = pr_gate["jobs"]["python-ci"]["with"]
+    main_python = main_ci["jobs"]["python"]["with"]
+
+    assert pr_python["typecheck"] is True
+    assert pr_python["typecheck"] == main_python["typecheck"]
+    assert pr_python["coverage"] is True
+    assert pr_python["coverage"] == main_python["coverage"]
+    assert _numeric(pr_python["coverage-min"]) >= _numeric(main_python["coverage-min"])
+
+    if "format_check" in pr_python:
+        assert pr_python["format_check"] is not False
+
+
+def test_gate_summary_depends_on_python_ci() -> None:
+    pr_gate = _workflow(".github/workflows/pr-00-gate.yml")
+
+    summary_needs = pr_gate["jobs"]["summary"]["needs"]
+
+    assert "detect" in summary_needs
+    assert "python-ci" in summary_needs

--- a/tests/test_gate_workflow_contract.py
+++ b/tests/test_gate_workflow_contract.py
@@ -1,15 +1,18 @@
 from pathlib import Path
+from typing import Any, cast
 
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def _workflow(path: str) -> dict:
-    return yaml.safe_load((REPO_ROOT / path).read_text(encoding="utf-8"))
+def _workflow(path: str) -> dict[str, Any]:
+    return cast(dict[str, Any], yaml.safe_load((REPO_ROOT / path).read_text(encoding="utf-8")))
 
 
 def _numeric(value: object) -> float:
+    if not isinstance(value, (str, bytes, bytearray, int, float)):
+        raise AssertionError(f"Expected numeric workflow value, got {value!r}")
     try:
         return float(value)
     except (TypeError, ValueError) as exc:

--- a/tests/test_nl_query_chain.py
+++ b/tests/test_nl_query_chain.py
@@ -85,7 +85,7 @@ def test_sqlite_chain_rejects_postgres_only_sql():
     conn = sqlite3.connect(":memory:", factory=TrackingConnection)
     conn.execute("CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT, cik TEXT)")
     conn.execute("INSERT INTO managers(manager_id, name, cik) VALUES (1, 'Elliott', '0001791786')")
-    llm = FakeLLM("{\"sql\": \"SELECT manager_id FROM managers WHERE name ILIKE '%elliott%'\"}")
+    llm = FakeLLM('{"sql": "SELECT manager_id FROM managers WHERE name ILIKE \'%elliott%\'"}')
     chain = NLQueryChain(llm=llm, db_conn=conn)
 
     with pytest.raises(ValueError, match="ILIKE is PostgreSQL-only"):

--- a/tests/test_resolve_mypy_pin.py
+++ b/tests/test_resolve_mypy_pin.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import builtins
 from pathlib import Path
+from types import ModuleType
+from typing import Any
 
 import pytest
 
@@ -40,10 +42,16 @@ python_version = '3.10'
     )
     real_import = builtins.__import__
 
-    def import_without_tomlkit(name: str, *args: object, **kwargs: object) -> object:
+    def import_without_tomlkit(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
         if name == "tomlkit":
             raise ImportError("tomlkit intentionally unavailable")
-        return real_import(name, *args, **kwargs)
+        return real_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", import_without_tomlkit)
 

--- a/tests/test_schema_postgres_bootstrap.py
+++ b/tests/test_schema_postgres_bootstrap.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any, cast
 from urllib.parse import quote
 
 import pytest
@@ -239,6 +240,9 @@ def _reset_schema(conn, schema_name: str) -> None:
 
 
 def _catalog_snapshot(conn) -> dict[str, set[tuple[str, ...]]]:
+    def row_tuple(row: tuple[Any, ...]) -> tuple[str, ...]:
+        return tuple("" if value is None else str(value) for value in row)
+
     def normalize_sql(value: str | None, schema_name: str) -> str:
         if value is None:
             return ""
@@ -261,7 +265,7 @@ def _catalog_snapshot(conn) -> dict[str, set[tuple[str, ...]]]:
             """,
             (list(IGNORED_PARITY_TABLES),),
         )
-        tables = {(row[0],) for row in cur.fetchall()}
+        tables = {row_tuple(row) for row in cur.fetchall()}
 
         cur.execute(
             """
@@ -286,7 +290,7 @@ def _catalog_snapshot(conn) -> dict[str, set[tuple[str, ...]]]:
             (list(IGNORED_PARITY_TABLES),),
         )
         columns = {
-            (row[0], row[1], row[2], row[3], row[4], normalize_sql(row[5], schema_name))
+            row_tuple((*row[:5], normalize_sql(cast(str | None, row[5]), schema_name)))
             for row in cur.fetchall()
         }
 
@@ -303,7 +307,10 @@ def _catalog_snapshot(conn) -> dict[str, set[tuple[str, ...]]]:
             """,
             (list(IGNORED_PARITY_TABLES),),
         )
-        indexes = {(row[0], row[1], normalize_sql(row[2], schema_name)) for row in cur.fetchall()}
+        indexes = {
+            row_tuple((*row[:2], normalize_sql(cast(str | None, row[2]), schema_name)))
+            for row in cur.fetchall()
+        }
 
         cur.execute(
             """
@@ -321,7 +328,8 @@ def _catalog_snapshot(conn) -> dict[str, set[tuple[str, ...]]]:
             (list(IGNORED_PARITY_TABLES),),
         )
         constraints = {
-            (row[0], row[1], normalize_sql(row[2], schema_name)) for row in cur.fetchall()
+            row_tuple((*row[:2], normalize_sql(cast(str | None, row[2]), schema_name)))
+            for row in cur.fetchall()
         }
 
         cur.execute("""
@@ -330,7 +338,10 @@ def _catalog_snapshot(conn) -> dict[str, set[tuple[str, ...]]]:
              WHERE schemaname = current_schema()
              ORDER BY matviewname
             """)
-        matviews = {(row[0], normalize_sql(row[1], schema_name)) for row in cur.fetchall()}
+        matviews = {
+            row_tuple((row[0], normalize_sql(cast(str | None, row[1]), schema_name)))
+            for row in cur.fetchall()
+        }
 
     return {
         "tables": tables,

--- a/tests/web/test_wasm_static_routes.py
+++ b/tests/web/test_wasm_static_routes.py
@@ -5,13 +5,15 @@ import functools
 import http.server
 import socketserver
 import threading
+from collections.abc import Iterator
+from pathlib import Path
 from urllib.request import urlopen
 
 from scripts.build_wasm_demo import STATIC_ROUTE_PATHS, build_wasm_demo
 
 
 @contextlib.contextmanager
-def _static_server(directory):
+def _static_server(directory: Path) -> Iterator[str]:
     handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=directory)
     with socketserver.TCPServer(("127.0.0.1", 0), handler) as server:
         thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -39,14 +41,14 @@ def test_wasm_demo_static_routes_serve_stlite_shell(tmp_path) -> None:
 
     with _static_server(web_dir) as base_url:
         for route in ("index.html", *(f"{path}/" for path in STATIC_ROUTE_PATHS)):
-            status, body = _fetch_text(f"{base_url}/{route}")
+            status, text_body = _fetch_text(f"{base_url}/{route}")
             assert status == 200
-            assert "Manager-Database Offline Demo" in body
-            assert "stlite.js" in body
-            assert "Error response" not in body
-        status, body = _fetch_bytes(f"{base_url}/wasm_app.py")
+            assert "Manager-Database Offline Demo" in text_body
+            assert "stlite.js" in text_body
+            assert "Error response" not in text_body
+        status, bytes_body = _fetch_bytes(f"{base_url}/wasm_app.py")
         assert status == 200
-        assert b"Offline stlite entrypoint" in body
+        assert b"Offline stlite entrypoint" in bytes_body
 
 
 def test_wasm_demo_static_route_entrypoints_use_parent_base(tmp_path) -> None:


### PR DESCRIPTION
Closes #1273

## Summary
- enable coverage, the 75% floor, type checking, and format checking in the PR Gate Python CI caller
- add a workflow contract test that compares PR Gate settings against main CI and keeps the Gate summary dependent on Python CI

## Validation
- python -m pytest tests/test_gate_workflow_contract.py -q
- deliberate-break: setting Gate typecheck back to false fails tests/test_gate_workflow_contract.py::test_pr_gate_python_ci_matches_main_ci_contract
- python -m black --check tests/test_gate_workflow_contract.py
- python -m ruff check tests/test_gate_workflow_contract.py
- git diff --check

## Notes
- AGENTS.md marks pr-00-gate.yml as a create-only local consumer gate, so this change stays in Manager-Database rather than changing synced Workflows sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strengthened the pull request check pipeline with enforced test coverage (minimum 75%), static type checking, and formatting validation.
  * Added automated validation to keep workflow gate configuration consistent with the main CI contract.

* **Tests**
  * Added coverage tests to ensure the pull request gate matches the expected CI job settings and declares required job dependencies.
  * Updated NL query chain test data to preserve the same SQLite/PostgreSQL rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->