### PR TITLE
Codex bootstrap for #1301

### DIFF
--- a/agents/codex-1301.md
+++ b/agents/codex-1301.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1301 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1301 -->

### Source Issue #1301: [Audit] connect_db silently falls back to SQLite when psycopg missing despite Postgres DB_URL

Base: main
Head: codex/issue-1301

Source: https://github.com/stranske/Manager-Database/issues/1301

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`connect_db()` can silently write to local SQLite when the deployment is configured for Postgres.

`adapters/base.py:49-67`: the Postgres branch is only taken when `DB_URL` is set, starts with `postgres`, AND the optional `psycopg` import succeeded (`:52` `if url and psycopg and url.startswith("postgres")`). If `DB_URL=postgresql://...` is present but `psycopg` is `None` (missing/broken install), control falls through to `:67` `path = db_path or os.getenv("DB_PATH", "dev.db")` and opens SQLite — with no error.

**Failure mode:** a Postgres-configured production/staging node with a broken `psycopg` install writes to a local `dev.db` file. Split-brain data; operators believe `DB_URL` took effect when it didn't; packaging failures are hidden. (Mitigated only when `psycopg[binary]` is correctly installed per `requirements.txt`.)

#### Tasks
- [ ] In `adapters/base.py:49-67`, if `DB_URL` starts with `postgres` and `psycopg is None`, raise a clear configuration error (with an install hint) instead of falling through to SQLite.
- [ ] Reject unsupported non-empty `DB_URL` schemes explicitly rather than ignoring them.

#### Acceptance Criteria
- [ ] **New test (currently failing):** with `DB_URL=postgresql://example/db`, `DB_PATH` pointed at a temp path, and `adapters.base.psycopg` monkeypatched to `None`, `connect_db()` raises and does NOT create/open the SQLite file.
- [ ] SQLite path still works when `DB_URL` is unset.
- [ ] **Deliberate-break demonstration:** reverting to the silent fallback makes the new test fail (SQLite file created); restoring the raise passes.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

`connect_db()` can silently write to local SQLite when the deployment is configured for Postgres.

`adapters/base.py:49-67`: the Postgres branch is only taken when `DB_URL` is set, starts with `postgres`, AND the optional `psycopg` import succeeded (`:52` `if url and psycopg and url.startswith("postgres")`). If `DB_URL=postgresql://...` is present but `psycopg` is `None` (missing/broken install), control falls through to `:67` `path = db_path or os.getenv("DB_PATH", "dev.db")` and opens SQLite — with no error.

**Failure mode:** a Postgres-configured production/staging node with a broken `psycopg` install writes to a local `dev.db` file. Split-brain data; operators believe `DB_URL` took effect when it didn't; packaging failures are hidden. (Mitigated only when `psycopg[binary]` is correctly installed per `requirements.txt`.)

## Scope

Treat an explicit Postgres `DB_URL` as authoritative: never silently downgrade to SQLite.

## Non-Goals

- Do NOT remove the legitimate SQLite path used when `DB_URL` is unset (local/CI).
- Do NOT change retry/timeout behavior.

## Tasks

- [ ] In `adapters/base.py:49-67`, if `DB_URL` starts with `postgres` and `psycopg is None`, raise a clear configuration error (with an install hint) instead of falling through to SQLite.
- [ ] Reject unsupported non-empty `DB_URL` schemes explicitly rather than ignoring them.

## Acceptance Criteria

- [ ] **New test (currently failing):** with `DB_URL=postgresql://example/db`, `DB_PATH` pointed at a temp path, and `adapters.base.psycopg` monkeypatched to `None`, `connect_db()` raises and does NOT create/open the SQLite file.
- [ ] SQLite path still works when `DB_URL` is unset.
- [ ] **Deliberate-break demonstration:** reverting to the silent fallback makes the new test fail (SQLite file created); restoring the raise passes.

## Implementation Notes

Audit baseline: `main` @ `e5764a5` on 2026-06-28. Source-verified at `adapters/base.py:49-67`. (cursor config audit independently flagged this as a MINOR; codex graded BLOCKER — the split-brain data risk justifies treating it as a P1 correctness fix.)



</details>

—
PR created automatically to engage Codex.