### PR TITLE
Fix manager seed SQLite path

### DIFF
--- a/scripts/seed_managers.py
+++ b/scripts/seed_managers.py
@@ -30,6 +30,17 @@ SEED_MANAGERS = [
     },
 ]
 
+SQLITE_MANAGER_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("lei", "TEXT"),
+    ("aliases", "TEXT NOT NULL DEFAULT '[]'"),
+    ("jurisdictions", "TEXT NOT NULL DEFAULT '[]'"),
+    ("tags", "TEXT NOT NULL DEFAULT '[]'"),
+    ("registry_ids", "TEXT NOT NULL DEFAULT '{}'"),
+    ("quality_flags", "TEXT NOT NULL DEFAULT '[]'"),
+    ("created_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP"),
+    ("updated_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP"),
+)
+
 
 def _ensure_sqlite_schema(conn: sqlite3.Connection) -> None:
     conn.execute("""
@@ -37,6 +48,7 @@ def _ensure_sqlite_schema(conn: sqlite3.Connection) -> None:
             id INTEGER PRIMARY KEY,
             name TEXT NOT NULL,
             cik TEXT,
+            lei TEXT,
             aliases TEXT NOT NULL DEFAULT '[]',
             jurisdictions TEXT NOT NULL DEFAULT '[]',
             tags TEXT NOT NULL DEFAULT '[]',
@@ -46,6 +58,12 @@ def _ensure_sqlite_schema(conn: sqlite3.Connection) -> None:
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         """)
+    existing_columns = {
+        str(row[0]) for row in conn.execute("SELECT name FROM pragma_table_info('managers')")
+    }
+    for column, definition in SQLITE_MANAGER_COLUMNS:
+        if column not in existing_columns:
+            conn.execute(f"ALTER TABLE managers ADD COLUMN {column} {definition}")
     conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_managers_cik ON managers(cik)")
 
 
@@ -57,7 +75,13 @@ def _sqlite_values(values: list[str]) -> str:
 
 def _upsert_sqlite_manager(conn: sqlite3.Connection, manager: dict[str, Any]) -> bool:
     cik = str(manager["cik"])
-    existed = conn.execute("SELECT 1 FROM managers WHERE cik = ?", (cik,)).fetchone() is not None
+    existed = (
+        conn.execute(
+            "SELECT 1 FROM managers WHERE cik = :cik",
+            {"cik": cik},
+        ).fetchone()
+        is not None
+    )
     conn.execute(
         """
         INSERT INTO managers (name, cik, aliases, jurisdictions, tags, updated_at)

--- a/scripts/seed_managers.py
+++ b/scripts/seed_managers.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
-import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
 
-import psycopg
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from adapters.base import connect_db  # noqa: E402
 
 SEED_MANAGERS = [
     {
@@ -24,39 +31,92 @@ SEED_MANAGERS = [
 ]
 
 
-def _db_url() -> str:
-    return os.getenv("DB_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
+def _ensure_sqlite_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS managers (
+            manager_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            cik TEXT UNIQUE,
+            aliases TEXT NOT NULL DEFAULT '[]',
+            jurisdictions TEXT NOT NULL DEFAULT '[]',
+            tags TEXT NOT NULL DEFAULT '[]',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """)
+
+
+def _sqlite_values(values: list[str]) -> str:
+    import json
+
+    return json.dumps(values)
+
+
+def _upsert_sqlite_manager(conn: sqlite3.Connection, manager: dict[str, Any]) -> bool:
+    cik = str(manager["cik"])
+    existed = conn.execute("SELECT 1 FROM managers WHERE cik = ?", (cik,)).fetchone() is not None
+    conn.execute(
+        """
+        INSERT INTO managers (name, cik, aliases, jurisdictions, tags, updated_at)
+        VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT(cik) DO UPDATE
+        SET name = excluded.name,
+            aliases = excluded.aliases,
+            jurisdictions = excluded.jurisdictions,
+            tags = excluded.tags,
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        (
+            manager["name"],
+            cik,
+            _sqlite_values(manager["aliases"]),
+            _sqlite_values(manager["jurisdictions"]),
+            _sqlite_values(manager["tags"]),
+        ),
+    )
+    return not existed
+
+
+def _upsert_postgres_manager(conn, manager: dict[str, Any]) -> bool:
+    row = conn.execute(
+        """
+        INSERT INTO managers (name, cik, aliases, jurisdictions, tags)
+        VALUES (%s, %s, %s, %s, %s)
+        ON CONFLICT (cik) WHERE cik IS NOT NULL DO UPDATE
+        SET name = EXCLUDED.name,
+            aliases = EXCLUDED.aliases,
+            jurisdictions = EXCLUDED.jurisdictions,
+            tags = EXCLUDED.tags,
+            updated_at = now()
+        RETURNING (xmax = 0) AS inserted
+        """,
+        (
+            manager["name"],
+            manager["cik"],
+            manager["aliases"],
+            manager["jurisdictions"],
+            manager["tags"],
+        ),
+    ).fetchone()
+    return bool(row and row[0])
 
 
 def seed_managers() -> int:
     inserted = 0
-    with psycopg.connect(_db_url()) as conn:
-        with conn.cursor() as cur:
-            for manager in SEED_MANAGERS:
-                cur.execute(
-                    """
-                    INSERT INTO managers (name, cik, aliases, jurisdictions, tags)
-                    VALUES (%s, %s, %s, %s, %s)
-                    ON CONFLICT (cik) WHERE cik IS NOT NULL DO UPDATE
-                    SET name = EXCLUDED.name,
-                        aliases = EXCLUDED.aliases,
-                        jurisdictions = EXCLUDED.jurisdictions,
-                        tags = EXCLUDED.tags,
-                        updated_at = now()
-                    RETURNING (xmax = 0) AS inserted
-                    """,
-                    (
-                        manager["name"],
-                        manager["cik"],
-                        manager["aliases"],
-                        manager["jurisdictions"],
-                        manager["tags"],
-                    ),
-                )
-                row = cur.fetchone()
-                if row and row[0]:
-                    inserted += 1
+    conn = connect_db()
+    try:
+        if isinstance(conn, sqlite3.Connection):
+            _ensure_sqlite_schema(conn)
+            upsert = _upsert_sqlite_manager
+        else:
+            upsert = _upsert_postgres_manager
+
+        for manager in SEED_MANAGERS:
+            if upsert(conn, manager):
+                inserted += 1
         conn.commit()
+    finally:
+        conn.close()
     return inserted
 
 

--- a/scripts/seed_managers.py
+++ b/scripts/seed_managers.py
@@ -34,16 +34,19 @@ SEED_MANAGERS = [
 def _ensure_sqlite_schema(conn: sqlite3.Connection) -> None:
     conn.execute("""
         CREATE TABLE IF NOT EXISTS managers (
-            manager_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            id INTEGER PRIMARY KEY,
             name TEXT NOT NULL,
-            cik TEXT UNIQUE,
+            cik TEXT,
             aliases TEXT NOT NULL DEFAULT '[]',
             jurisdictions TEXT NOT NULL DEFAULT '[]',
             tags TEXT NOT NULL DEFAULT '[]',
+            registry_ids TEXT NOT NULL DEFAULT '{}',
+            quality_flags TEXT NOT NULL DEFAULT '[]',
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         """)
+    conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_managers_cik ON managers(cik)")
 
 
 def _sqlite_values(values: list[str]) -> str:
@@ -107,14 +110,15 @@ def seed_managers() -> int:
     try:
         if isinstance(conn, sqlite3.Connection):
             _ensure_sqlite_schema(conn)
-            upsert = _upsert_sqlite_manager
+            for manager in SEED_MANAGERS:
+                if _upsert_sqlite_manager(conn, manager):
+                    inserted += 1
+            conn.commit()
         else:
-            upsert = _upsert_postgres_manager
-
-        for manager in SEED_MANAGERS:
-            if upsert(conn, manager):
-                inserted += 1
-        conn.commit()
+            with conn.transaction():
+                for manager in SEED_MANAGERS:
+                    if _upsert_postgres_manager(conn, manager):
+                        inserted += 1
     finally:
         conn.close()
     return inserted

--- a/tests/test_seed_managers.py
+++ b/tests/test_seed_managers.py
@@ -96,6 +96,41 @@ def test_seed_managers_uses_sqlite_when_db_url_unset(tmp_path, monkeypatch) -> N
     assert json.loads(rows[1][3]) == ["us"]
 
 
+def test_seed_managers_adds_cik_index_to_existing_sqlite_table(tmp_path, monkeypatch) -> None:
+    sm = _load_seed_module()
+    db_path = tmp_path / "local.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("""
+            CREATE TABLE managers (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                cik TEXT,
+                aliases TEXT NOT NULL DEFAULT '[]',
+                jurisdictions TEXT NOT NULL DEFAULT '[]',
+                tags TEXT NOT NULL DEFAULT '[]'
+            )
+            """)
+        conn.commit()
+    finally:
+        conn.close()
+    monkeypatch.delenv("DB_URL", raising=False)
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    inserted = sm.seed_managers()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        indexes = {row[1] for row in conn.execute("PRAGMA index_list(managers)").fetchall()}
+        rows = conn.execute("SELECT cik FROM managers ORDER BY cik").fetchall()
+    finally:
+        conn.close()
+
+    assert inserted == len(sm.SEED_MANAGERS)
+    assert "idx_managers_cik" in indexes
+    assert [row[0] for row in rows] == ["0001434997", "0001791786"]
+
+
 def test_seed_managers_keeps_postgres_upsert_contract(monkeypatch) -> None:
     sm = _load_seed_module()
     rows_by_cik: dict[str, dict[str, object]] = {}

--- a/tests/test_seed_managers.py
+++ b/tests/test_seed_managers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -38,9 +39,13 @@ class _FakePostgresResult:
 
 
 class _FakePostgresConnection:
-    def __init__(self, rows_by_cik: dict[str, dict[str, object]], commits: list[int]) -> None:
+    def __init__(
+        self,
+        rows_by_cik: dict[str, dict[str, object]],
+        transactions: list[str],
+    ) -> None:
         self._rows_by_cik = rows_by_cik
-        self._commits = commits
+        self._transactions = transactions
         self.closed = False
 
     def execute(self, query: str, params: tuple[object, ...]) -> _FakePostgresResult:
@@ -48,8 +53,13 @@ class _FakePostgresConnection:
         result.execute(query, params)
         return result
 
-    def commit(self) -> None:
-        self._commits.append(1)
+    @contextmanager
+    def transaction(self):
+        self._transactions.append("begin")
+        try:
+            yield
+        finally:
+            self._transactions.append("end")
 
     def close(self) -> None:
         self.closed = True
@@ -71,9 +81,13 @@ def test_seed_managers_uses_sqlite_when_db_url_unset(tmp_path, monkeypatch) -> N
         rows = conn.execute(
             "SELECT name, cik, aliases, jurisdictions, tags FROM managers ORDER BY cik"
         ).fetchall()
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(managers)").fetchall()}
+        indexes = {row[1] for row in conn.execute("PRAGMA index_list(managers)").fetchall()}
     finally:
         conn.close()
 
+    assert "id" in columns
+    assert "idx_managers_cik" in indexes
     assert [row[0] for row in rows] == [
         "SIR Capital Management L.P.",
         "Elliott Investment Management L.P.",
@@ -85,11 +99,11 @@ def test_seed_managers_uses_sqlite_when_db_url_unset(tmp_path, monkeypatch) -> N
 def test_seed_managers_keeps_postgres_upsert_contract(monkeypatch) -> None:
     sm = _load_seed_module()
     rows_by_cik: dict[str, dict[str, object]] = {}
-    commits: list[int] = []
+    transactions: list[str] = []
     connections: list[_FakePostgresConnection] = []
 
     def _fake_connect_db() -> _FakePostgresConnection:
-        conn = _FakePostgresConnection(rows_by_cik, commits)
+        conn = _FakePostgresConnection(rows_by_cik, transactions)
         connections.append(conn)
         return conn
 
@@ -102,5 +116,5 @@ def test_seed_managers_keeps_postgres_upsert_contract(monkeypatch) -> None:
     assert first_inserted == len(sm.SEED_MANAGERS)
     assert second_inserted == 0
     assert len(rows_by_cik) == len(sm.SEED_MANAGERS)
-    assert len(commits) == 2
+    assert transactions == ["begin", "end", "begin", "end"]
     assert all(conn.closed for conn in connections)

--- a/tests/test_seed_managers.py
+++ b/tests/test_seed_managers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import sqlite3
 from pathlib import Path
 
 
@@ -13,19 +15,14 @@ def _load_seed_module():
     return module
 
 
-class _FakeCursor:
+class _FakePostgresResult:
     def __init__(self, rows_by_cik: dict[str, dict[str, object]]) -> None:
         self._rows_by_cik = rows_by_cik
         self._last_row: tuple[bool] | None = None
 
-    def __enter__(self) -> _FakeCursor:
-        return self
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        return None
-
     def execute(self, query: str, params: tuple[object, ...]) -> None:
         assert "ON CONFLICT (cik) WHERE cik IS NOT NULL DO UPDATE" in query
+        assert "VALUES (%s, %s, %s, %s, %s)" in query
         cik = str(params[1])
         inserted = cik not in self._rows_by_cik
         self._rows_by_cik[cik] = {
@@ -40,33 +37,63 @@ class _FakeCursor:
         return self._last_row
 
 
-class _FakeConnection:
+class _FakePostgresConnection:
     def __init__(self, rows_by_cik: dict[str, dict[str, object]], commits: list[int]) -> None:
         self._rows_by_cik = rows_by_cik
         self._commits = commits
+        self.closed = False
 
-    def __enter__(self) -> _FakeConnection:
-        return self
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        return None
-
-    def cursor(self) -> _FakeCursor:
-        return _FakeCursor(self._rows_by_cik)
+    def execute(self, query: str, params: tuple[object, ...]) -> _FakePostgresResult:
+        result = _FakePostgresResult(self._rows_by_cik)
+        result.execute(query, params)
+        return result
 
     def commit(self) -> None:
         self._commits.append(1)
 
+    def close(self) -> None:
+        self.closed = True
 
-def test_seed_managers_is_idempotent(monkeypatch) -> None:
+
+def test_seed_managers_uses_sqlite_when_db_url_unset(tmp_path, monkeypatch) -> None:
+    sm = _load_seed_module()
+    db_path = tmp_path / "local.db"
+    monkeypatch.delenv("DB_URL", raising=False)
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    first_inserted = sm.seed_managers()
+    second_inserted = sm.seed_managers()
+
+    assert first_inserted == len(sm.SEED_MANAGERS)
+    assert second_inserted == 0
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT name, cik, aliases, jurisdictions, tags FROM managers ORDER BY cik"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert [row[0] for row in rows] == [
+        "SIR Capital Management L.P.",
+        "Elliott Investment Management L.P.",
+    ]
+    assert json.loads(rows[0][2]) == ["Standard Investment Research"]
+    assert json.loads(rows[1][3]) == ["us"]
+
+
+def test_seed_managers_keeps_postgres_upsert_contract(monkeypatch) -> None:
     sm = _load_seed_module()
     rows_by_cik: dict[str, dict[str, object]] = {}
     commits: list[int] = []
+    connections: list[_FakePostgresConnection] = []
 
-    def _fake_connect(_db_url: str) -> _FakeConnection:
-        return _FakeConnection(rows_by_cik, commits)
+    def _fake_connect_db() -> _FakePostgresConnection:
+        conn = _FakePostgresConnection(rows_by_cik, commits)
+        connections.append(conn)
+        return conn
 
-    monkeypatch.setattr(sm.psycopg, "connect", _fake_connect)
+    monkeypatch.setattr(sm, "connect_db", _fake_connect_db)
     monkeypatch.setenv("DB_URL", "postgresql://example:example@localhost:5432/postgres")
 
     first_inserted = sm.seed_managers()
@@ -76,3 +103,4 @@ def test_seed_managers_is_idempotent(monkeypatch) -> None:
     assert second_inserted == 0
     assert len(rows_by_cik) == len(sm.SEED_MANAGERS)
     assert len(commits) == 2
+    assert all(conn.closed for conn in connections)


### PR DESCRIPTION
Closes #1303

## Summary
- Route `scripts/seed_managers.py` through `adapters.base.connect_db()` so `DB_PATH` SQLite seeding works when `DB_URL` is unset.
- Keep the Postgres upsert path when `DB_URL` is set, while using backend-aware placeholders and values.
- Add focused tests for SQLite idempotent seeding and the retained Postgres upsert contract.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_seed_managers.py -q`
- `python -m ruff check scripts/seed_managers.py tests/test_seed_managers.py`
- `black --fast --check --line-length 100 --exclude '(\\\\.workflows-lib|node_modules)' scripts/seed_managers.py tests/test_seed_managers.py`\n- `git diff --check`\n\n## Deliberate Break\n- Temporarily restored the old hardcoded `psycopg.connect(os.getenv("DB_URL", "postgresql://postgres:postgres@localhost:5432/postgres"))` path and confirmed `test_seed_managers_uses_sqlite_when_db_url_unset` failed by attempting localhost Postgres instead of using `DB_PATH`; restored the fix before commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seeding now supports both SQLite and Postgres, automatically selecting the correct backend.
  * SQLite bootstrap now ensures required tables/columns and adds the CIK index; seeded JSON fields are stored in JSON-encoded form.
  * Seeding uses backend-appropriate upsert logic and continues reporting an inserted/updated count.

* **Bug Fixes**
  * Improved idempotency so repeated runs don’t create duplicates.
  * Enhanced transaction/connection handling for consistent commit and cleanup.

* **Tests**
  * Expanded SQLite validation (schema/index artifacts and JSON contents).
  * Strengthened Postgres contract checks using new fakes and lifecycle assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->