### PR TITLE
Harden NL SQL guardrails

### DIFF
--- a/chains/nl_query.py
+++ b/chains/nl_query.py
@@ -36,7 +36,7 @@ Database schema:
 _COMMENT_BLOCK_RE = re.compile(r"/\*.*?\*/", re.S)
 _COMMENT_LINE_RE = re.compile(r"--.*?$", re.M)
 _TABLE_REF_RE = re.compile(r'\b(?:from|join)\s+"?([a-zA-Z_][\w]*)"?', re.I)
-_LIMIT_RE = re.compile(r"\blimit\s+\d+\b", re.I)
+_LIMIT_RE = re.compile(r"\blimit\s+(\d+)\b", re.I)
 _SQLITE_UNSUPPORTED_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\bilike\b", re.I), "ILIKE is PostgreSQL-only; use LIKE for SQLite"),
     (re.compile(r"\bdate_trunc\s*\(", re.I), "date_trunc() is PostgreSQL-only"),
@@ -128,7 +128,12 @@ class NLQueryChain:
         cleaned = _COMMENT_BLOCK_RE.sub(" ", sql)
         cleaned = _COMMENT_LINE_RE.sub(" ", cleaned)
         cleaned = cleaned.strip().rstrip(";").strip()
-        if not _LIMIT_RE.search(cleaned):
+        limit_match = _LIMIT_RE.search(cleaned)
+        if limit_match:
+            requested_limit = int(limit_match.group(1))
+            if requested_limit > 100:
+                cleaned = _LIMIT_RE.sub("LIMIT 100", cleaned, count=1)
+        else:
             cleaned = f"{cleaned} LIMIT 100"
         return cleaned
 
@@ -144,6 +149,8 @@ class NLQueryChain:
             if re.search(rf"\b{keyword}\b", lowered):
                 return False, f"Disallowed SQL keyword: {keyword.upper()}"
         table_refs = {match.group(1) for match in _TABLE_REF_RE.finditer(normalized)}
+        if not table_refs:
+            return False, "SELECT queries must reference at least one known application table"
         unknown_tables = sorted(table_refs - self._known_tables)
         if unknown_tables:
             return False, f"Unknown tables referenced: {', '.join(unknown_tables)}"

--- a/chains/nl_query.py
+++ b/chains/nl_query.py
@@ -37,6 +37,7 @@ _COMMENT_BLOCK_RE = re.compile(r"/\*.*?\*/", re.S)
 _COMMENT_LINE_RE = re.compile(r"--.*?$", re.M)
 _TABLE_REF_RE = re.compile(r'\b(?:from|join)\s+"?([a-zA-Z_][\w]*)"?', re.I)
 _LIMIT_RE = re.compile(r"\blimit\s+(\d+)\b", re.I)
+MAX_RESULT_ROWS = 100
 _SQLITE_UNSUPPORTED_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\bilike\b", re.I), "ILIKE is PostgreSQL-only; use LIKE for SQLite"),
     (re.compile(r"\bdate_trunc\s*\(", re.I), "date_trunc() is PostgreSQL-only"),
@@ -118,7 +119,7 @@ class NLQueryChain:
 
     def _extract_known_tables(self, schema_ddl: str) -> set[str]:
         return {
-            match.group(1)
+            match.group(1).lower()
             for match in re.finditer(
                 r"CREATE TABLE(?: IF NOT EXISTS)?\s+([a-zA-Z_][\w]*)", schema_ddl, re.I
             )
@@ -131,10 +132,10 @@ class NLQueryChain:
         limit_match = _LIMIT_RE.search(cleaned)
         if limit_match:
             requested_limit = int(limit_match.group(1))
-            if requested_limit > 100:
-                cleaned = _LIMIT_RE.sub("LIMIT 100", cleaned, count=1)
+            if requested_limit > MAX_RESULT_ROWS:
+                cleaned = _LIMIT_RE.sub(f"LIMIT {MAX_RESULT_ROWS}", cleaned, count=1)
         else:
-            cleaned = f"{cleaned} LIMIT 100"
+            cleaned = f"{cleaned} LIMIT {MAX_RESULT_ROWS}"
         return cleaned
 
     def _validate_sql(self, sql: str) -> tuple[bool, str | None]:
@@ -148,7 +149,7 @@ class NLQueryChain:
         for keyword in _DANGEROUS_KEYWORDS:
             if re.search(rf"\b{keyword}\b", lowered):
                 return False, f"Disallowed SQL keyword: {keyword.upper()}"
-        table_refs = {match.group(1) for match in _TABLE_REF_RE.finditer(normalized)}
+        table_refs = {match.group(1).lower() for match in _TABLE_REF_RE.finditer(normalized)}
         if not table_refs:
             return False, "SELECT queries must reference at least one known application table"
         unknown_tables = sorted(table_refs - self._known_tables)

--- a/tests/test_nl_query_chain.py
+++ b/tests/test_nl_query_chain.py
@@ -66,6 +66,33 @@ def test_normalize_sql_injects_limit_when_missing(sqlite_conn: sqlite3.Connectio
     )
 
 
+def test_normalize_sql_caps_existing_large_limit(sqlite_conn: sqlite3.Connection):
+    chain = NLQueryChain(db_conn=sqlite_conn)
+
+    assert (
+        chain._normalize_sql("SELECT * FROM managers LIMIT 1000000")
+        == "SELECT * FROM managers LIMIT 100"
+    )
+    assert (
+        chain._normalize_sql("SELECT * FROM managers LIMIT 25") == "SELECT * FROM managers LIMIT 25"
+    )
+
+
+def test_validate_sql_rejects_tableless_system_calls(sqlite_conn: sqlite3.Connection):
+    chain = NLQueryChain(db_conn=sqlite_conn)
+
+    is_valid, error = chain._validate_sql("SELECT pg_sleep(20)")
+
+    assert is_valid is False
+    assert error == "SELECT queries must reference at least one known application table"
+
+
+def test_validate_sql_still_allows_known_table_queries(sqlite_conn: sqlite3.Connection):
+    chain = NLQueryChain(db_conn=sqlite_conn)
+
+    assert chain._validate_sql("SELECT manager_id FROM managers LIMIT 1000000") == (True, None)
+
+
 def test_run_executes_query_and_formats_small_results(sqlite_conn: sqlite3.Connection):
     llm = FakeLLM(
         '{"sql": "SELECT manager_id, name FROM managers ORDER BY manager_id", "columns": ["manager_id", "name"]}'

--- a/tests/test_nl_query_chain.py
+++ b/tests/test_nl_query_chain.py
@@ -84,13 +84,15 @@ def test_validate_sql_rejects_tableless_system_calls(sqlite_conn: sqlite3.Connec
     is_valid, error = chain._validate_sql("SELECT pg_sleep(20)")
 
     assert is_valid is False
-    assert error == "SELECT queries must reference at least one known application table"
+    assert error is not None
+    assert "known application table" in error
 
 
 def test_validate_sql_still_allows_known_table_queries(sqlite_conn: sqlite3.Connection):
     chain = NLQueryChain(db_conn=sqlite_conn)
 
     assert chain._validate_sql("SELECT manager_id FROM managers LIMIT 1000000") == (True, None)
+    assert chain._validate_sql("SELECT manager_id FROM MANAGERS LIMIT 1000000") == (True, None)
 
 
 def test_run_executes_query_and_formats_small_results(sqlite_conn: sqlite3.Connection):


### PR DESCRIPTION
## Summary
- require NL-generated SELECT statements to reference at least one known application table
- cap existing oversized LIMIT clauses at 100 instead of preserving unsafe limits
- add regression coverage for tableless system calls, oversized LIMITs, and valid known-table queries

## Validation
- python -m pytest tests/test_nl_query_chain.py -q
- python -m ruff check chains/nl_query.py tests/test_nl_query_chain.py
- black --fast --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' chains/nl_query.py tests/test_nl_query_chain.py
- git diff --check

Closes #1312
