### PR TITLE
Codex bootstrap for #1303

### DIFF
--- a/agents/codex-1303.md
+++ b/agents/codex-1303.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1303 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1303 -->

### Source Issue #1303: [Audit] make db-seed (seed_managers.py) is Postgres-only; breaks SQLite local dev

Base: main
Head: codex/issue-1303

Source: https://github.com/stranske/Manager-Database/issues/1303

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`make db-seed` cannot seed a local SQLite dev database, contradicting the dual-dialect design the rest of the app follows.

- `Makefile` `db-seed:` runs `python scripts/seed_managers.py`.
- `scripts/seed_managers.py:28` hardcodes a Postgres default: `return os.getenv("DB_URL", "postgresql://postgres:postgres@localhost:5432/postgres")`, and `:33` connects with `psycopg.connect(_db_url())` directly. It never consults `DB_PATH` and has no SQLite branch (unlike `adapters/base.py` `connect_db()`, which the rest of the app uses).

**Reproduced (audit):** with `DB_URL` unset and `DB_PATH` set to a local SQLite file, `python scripts/seed_managers.py` fails with `psycopg.OperationalError: connection ... port 5432 ... Connection refused` instead of seeding SQLite. So a developer following the local SQLite path cannot seed managers.

#### Tasks
- [ ] Refactor `scripts/seed_managers.py` to obtain its connection via `adapters.base.connect_db()` (or equivalent) so it uses SQLite (`DB_PATH`) when `DB_URL` is unset and Postgres when set. Ensure the seed SQL uses backend-aware placeholders/DDL consistent with the dialect-portability gate.

#### Acceptance Criteria
- [ ] **New test (currently failing):** with `DB_URL` unset and `DB_PATH` a temp SQLite file, running the seed entrypoint creates/populates the `managers` table in that SQLite file (no Postgres connection attempted).
- [ ] Postgres seeding still works when `DB_URL` is set.
- [ ] **Deliberate-break demonstration:** reverting to the hardcoded Postgres `DB_URL` default fails the SQLite seed test; restoring the `connect_db()` route passes.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

`make db-seed` cannot seed a local SQLite dev database, contradicting the dual-dialect design the rest of the app follows.

- `Makefile` `db-seed:` runs `python scripts/seed_managers.py`.
- `scripts/seed_managers.py:28` hardcodes a Postgres default: `return os.getenv("DB_URL", "postgresql://postgres:postgres@localhost:5432/postgres")`, and `:33` connects with `psycopg.connect(_db_url())` directly. It never consults `DB_PATH` and has no SQLite branch (unlike `adapters/base.py` `connect_db()`, which the rest of the app uses).

**Reproduced (audit):** with `DB_URL` unset and `DB_PATH` set to a local SQLite file, `python scripts/seed_managers.py` fails with `psycopg.OperationalError: connection ... port 5432 ... Connection refused` instead of seeding SQLite. So a developer following the local SQLite path cannot seed managers.

## Scope

Make `seed_managers.py` honor the same connection contract as the rest of the app (SQLite via `DB_PATH` when `DB_URL` is unset).

## Non-Goals

- Do NOT change Postgres seeding behavior when `DB_URL` is set.
- Do NOT duplicate connection logic — route through `adapters.base.connect_db()`.

## Tasks

- [ ] Refactor `scripts/seed_managers.py` to obtain its connection via `adapters.base.connect_db()` (or equivalent) so it uses SQLite (`DB_PATH`) when `DB_URL` is unset and Postgres when set. Ensure the seed SQL uses backend-aware placeholders/DDL consistent with the dialect-portability gate.

## Acceptance Criteria

- [ ] **New test (currently failing):** with `DB_URL` unset and `DB_PATH` a temp SQLite file, running the seed entrypoint creates/populates the `managers` table in that SQLite file (no Postgres connection attempted).
- [ ] Postgres seeding still works when `DB_URL` is set.
- [ ] **Deliberate-break demonstration:** reverting to the hardcoded Postgres `DB_URL` default fails the SQLite seed test; restoring the `connect_db()` route passes.

## Implementation Notes

Audit baseline: `main` @ `e5764a5` on 2026-06-28. Reproduced by running the seed under `DB_PATH` (SQLite) with `DB_URL` unset → psycopg/5432 failure. Source: `seed_managers.py:28,33`. Note `scripts/seed_universe.py` / `scripts/resolve_aliases.py` ARE dialect-aware (per `docs/reports/dialect_portability_audit.md`) — `seed_managers.py` is the outlier.



</details>

—
PR created automatically to engage Codex.