### PR TITLE
Codex bootstrap for #1312

### DIFF
--- a/agents/codex-1312.md
+++ b/agents/codex-1312.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1312 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1312 -->

### Source Issue #1312: [Audit] NL->SQL validator allows tableless system calls (pg_sleep) and uncapped LIMIT

Base: main
Head: codex/issue-1312

Source: https://github.com/stranske/Manager-Database/issues/1312

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The NL→SQL guardrail in `chains/nl_query.py` has two gaps (related to but distinct from the dialect-contract issue #1280 — this is the resource/safety angle):

- `_validate_sql()` (~line 137) only rejects statements whose `FROM`/`JOIN` table refs aren't in the known-tables set. A **tableless** statement like `SELECT pg_sleep(20)` has no table refs → passes validation (unless the function name happens to be a dangerous keyword).
- `_normalize_sql()` (~line 122) only **appends** `LIMIT 100` when no limit is present; it never **caps** an existing large limit, so a generated `... LIMIT 100000000` runs as-is. The Postgres `statement_timeout` (~line 153) mitigates but doesn't remove the availability/resource risk.

#### Tasks
- [ ] In `_validate_sql()`, require ≥1 known application-table reference; reject system/catalog/function-only SQL (`pg_*`, `sqlite_*`, `pragma`, `information_schema`, and function-only `SELECT`s unless explicitly allowlisted).
- [ ] In `_normalize_sql()`, parse any existing `LIMIT` and clamp it to the configured maximum before execution.

#### Acceptance Criteria
- [ ] **New tests (currently failing):** `_validate_sql("SELECT pg_sleep(20)")` returns invalid; `_normalize_sql("SELECT * FROM managers LIMIT 1000000")` returns a query capped at the configured max (e.g. 100).
- [ ] Valid known-table queries still pass.
- [ ] **Deliberate-break demonstration:** reverting either guard makes its test pass the dangerous input; restoring blocks/caps it.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

The NL→SQL guardrail in `chains/nl_query.py` has two gaps (related to but distinct from the dialect-contract issue #1280 — this is the resource/safety angle):

- `_validate_sql()` (~line 137) only rejects statements whose `FROM`/`JOIN` table refs aren't in the known-tables set. A **tableless** statement like `SELECT pg_sleep(20)` has no table refs → passes validation (unless the function name happens to be a dangerous keyword).
- `_normalize_sql()` (~line 122) only **appends** `LIMIT 100` when no limit is present; it never **caps** an existing large limit, so a generated `... LIMIT 100000000` runs as-is. The Postgres `statement_timeout` (~line 153) mitigates but doesn't remove the availability/resource risk.

## Scope

Require at least one known application-table reference and cap any existing LIMIT.

## Non-Goals

- Do NOT duplicate #1280's dialect-contract work; coordinate if both land.
- Do NOT block legitimate multi-table read queries over known tables.

## Tasks

- [ ] In `_validate_sql()`, require ≥1 known application-table reference; reject system/catalog/function-only SQL (`pg_*`, `sqlite_*`, `pragma`, `information_schema`, and function-only `SELECT`s unless explicitly allowlisted).
- [ ] In `_normalize_sql()`, parse any existing `LIMIT` and clamp it to the configured maximum before execution.

## Acceptance Criteria

- [ ] **New tests (currently failing):** `_validate_sql("SELECT pg_sleep(20)")` returns invalid; `_normalize_sql("SELECT * FROM managers LIMIT 1000000")` returns a query capped at the configured max (e.g. 100).
- [ ] Valid known-table queries still pass.
- [ ] **Deliberate-break demonstration:** reverting either guard makes its test pass the dangerous input; restoring blocks/caps it.

## Implementation Notes

Audit baseline: `main` @ `e5764a5` on 2026-06-28. Source-verified at `chains/nl_query.py:122,137`.



</details>

—
PR created automatically to engage Codex.