### PR TITLE
Resolve manager id column in ETL readers

### DIFF
--- a/adapters/base.py
+++ b/adapters/base.py
@@ -124,16 +124,19 @@ def get_table_columns(conn: Any, table_name: str) -> set[str]:
     """Return table column names for SQLite or Postgres."""
     try:
         if is_sqlite(conn):
-            escaped_table = table_name.replace("'", "''")
-            rows = conn.execute(f"SELECT name FROM pragma_table_info('{escaped_table}')").fetchall()
-            return {str(row[0]) for row in rows}
+            rows = conn.execute(
+                "SELECT name FROM pragma_table_info(:table_name)",
+                {"table_name": table_name},
+            ).fetchall()
+            return {str(row[0]) for row in rows if row and row[0] is not None}
         rows = conn.execute(
             "SELECT column_name FROM information_schema.columns "
             "WHERE table_schema = current_schema() AND table_name = %s",
             (table_name,),
         ).fetchall()
-        return {str(row[0]) for row in rows}
+        return {str(row[0]) for row in rows if row and row[0] is not None}
     except Exception:
+        logger.debug("Failed to introspect columns for table %s", table_name, exc_info=True)
         return set()
 
 
@@ -147,6 +150,13 @@ def manager_id_column(conn: Any, *, require_table: bool = False) -> str | None:
     if "id" in columns:
         return "id"
     return None
+
+
+def resolve_manager_id_column(conn: Any) -> str:
+    """Return the manager primary-key column with a dialect fallback."""
+    if not is_sqlite(conn):
+        return "manager_id"
+    return manager_id_column(conn) or "id"
 
 
 def _ensure_sqlite_usage_schema(conn: sqlite3.Connection) -> None:

--- a/api/managers.py
+++ b/api/managers.py
@@ -18,7 +18,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from adapters.base import connect_db
-from adapters.base import manager_id_column as shared_manager_id_column
+from adapters.base import resolve_manager_id_column as shared_manager_id_column
 from api.cache import cache_query, invalidate_cache_prefix
 from api.models import (
     BulkImportFailure,
@@ -161,9 +161,7 @@ def _ensure_manager_table(conn) -> None:
 
 def _manager_id_column(conn) -> str:
     """Return the manager primary-key column for the active database backend."""
-    if not isinstance(conn, sqlite3.Connection):
-        return "manager_id"
-    return shared_manager_id_column(conn) or "id"
+    return shared_manager_id_column(conn)
 
 
 def _json_array(raw: object) -> list[str]:

--- a/diff_holdings.py
+++ b/diff_holdings.py
@@ -7,7 +7,7 @@ import sys
 import time
 from typing import Any
 
-from adapters.base import connect_db
+from adapters.base import connect_db, resolve_manager_id_column
 from tools.registry import run_contract_fields
 from tools.run_contract import RunResult
 
@@ -66,8 +66,9 @@ def _resolve_manager_id(identifier: int | str, conn: Any) -> int:
 
     cik = identifier.strip()
     ph = _placeholder(conn)
+    id_column = resolve_manager_id_column(conn)
     row = conn.execute(
-        f"SELECT manager_id FROM managers WHERE cik = {ph} LIMIT 1",
+        f"SELECT {id_column} FROM managers WHERE cik = {ph} LIMIT 1",
         (cik,),
     ).fetchone()
     if row is not None:

--- a/etl/activism_flow.py
+++ b/etl/activism_flow.py
@@ -11,7 +11,13 @@ from prefect import flow, task
 from prefect.schedules import Cron
 
 from adapters import edgar
-from adapters.base import connect_db, get_placeholder, is_postgres, is_sqlite
+from adapters.base import (
+    connect_db,
+    get_placeholder,
+    is_postgres,
+    is_sqlite,
+    resolve_manager_id_column,
+)
 from alerts.integration import fire_alerts_for_event
 from etl.activism_detection import (
     ALERT_EVENT_TYPE,
@@ -97,8 +103,9 @@ def _ensure_activism_filings_table(conn: Any) -> None:
 
 def _load_manager_row(conn: Any, manager_id: int) -> tuple[str, str] | None:
     ph = get_placeholder(conn)
+    id_column = resolve_manager_id_column(conn)
     row = conn.execute(
-        f"SELECT name, cik FROM managers WHERE manager_id = {ph} LIMIT 1",
+        f"SELECT name, cik FROM managers WHERE {id_column} = {ph} LIMIT 1",
         (manager_id,),
     ).fetchone()
     if not row or not row[1]:
@@ -107,8 +114,9 @@ def _load_manager_row(conn: Any, manager_id: int) -> tuple[str, str] | None:
 
 
 def _all_manager_ids(conn: Any) -> list[int]:
+    id_column = resolve_manager_id_column(conn)
     rows = conn.execute(
-        "SELECT manager_id FROM managers WHERE cik IS NOT NULL ORDER BY manager_id"
+        f"SELECT {id_column} FROM managers WHERE cik IS NOT NULL ORDER BY {id_column}"
     ).fetchall()
     return [int(row[0]) for row in rows if row and row[0] is not None]
 

--- a/etl/daily_diff_flow.py
+++ b/etl/daily_diff_flow.py
@@ -11,7 +11,13 @@ from typing import Any
 from prefect import flow, task
 from prefect.schedules import Cron
 
-from adapters.base import connect_db, get_placeholder, is_postgres, is_sqlite
+from adapters.base import (
+    connect_db,
+    get_placeholder,
+    is_postgres,
+    is_sqlite,
+    resolve_manager_id_column,
+)
 from alerts.integration import evaluate_and_record_alerts
 from alerts.models import AlertEvent
 from diff_holdings import diff_holdings
@@ -128,7 +134,8 @@ def _refresh_matview(conn: Any) -> None:
 
 def _fetch_all_manager_ids(conn: Any) -> list[int]:
     """Return all manager_ids from the managers table."""
-    rows = conn.execute("SELECT manager_id FROM managers ORDER BY manager_id").fetchall()
+    id_column = resolve_manager_id_column(conn)
+    rows = conn.execute(f"SELECT {id_column} FROM managers ORDER BY {id_column}").fetchall()
     return [r[0] for r in rows]
 
 

--- a/etl/news_flow.py
+++ b/etl/news_flow.py
@@ -11,7 +11,7 @@ from typing import Any
 from prefect import flow, task
 
 from adapters import news
-from adapters.base import connect_db, get_placeholder, is_sqlite
+from adapters.base import connect_db, get_placeholder, is_sqlite, resolve_manager_id_column
 from alerts.integration import fire_alerts_for_event
 from alerts.models import AlertEvent
 from etl.logging_setup import configure_logging, log_outcome
@@ -67,7 +67,8 @@ def _normalize_aliases(raw_aliases: Any) -> list[str]:
 @task
 def match_entities(items: list[dict[str, Any]], conn: Any) -> list[dict[str, Any]]:
     """Link news items to managers by name/alias substring matching."""
-    rows = conn.execute("SELECT manager_id, name, aliases FROM managers").fetchall()
+    id_column = resolve_manager_id_column(conn)
+    rows = conn.execute(f"SELECT {id_column}, name, aliases FROM managers").fetchall()
 
     manager_terms: list[tuple[int, list[str]]] = []
     for manager_id, name, aliases in rows:

--- a/tests/test_etl_flows_additional.py
+++ b/tests/test_etl_flows_additional.py
@@ -6,9 +6,13 @@ from datetime import date
 
 import pytest
 
+import diff_holdings as diff_holdings_module
+import etl.activism_flow as activism_flow
 import etl.daily_diff_flow as daily_flow
 import etl.edgar_flow as edgar_flow
+import etl.news_flow as news_flow
 import etl.summariser_flow as summariser_flow
+from api import managers as managers_api
 
 
 def seed_daily_diffs(db_path, rows):
@@ -46,6 +50,39 @@ def seed_manager(db_path, cik, manager_id=1):
     )
     conn.commit()
     conn.close()
+
+
+def test_etl_manager_id_readers_support_api_created_sqlite_schema(tmp_path):
+    db_path = tmp_path / "api-created.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        managers_api._ensure_manager_table(conn)
+        manager_id = managers_api._insert_manager(
+            conn,
+            managers_api.ManagerCreate(
+                name="Elliott Investment Management L.P.",
+                cik="0001791786",
+                aliases=["Elliott"],
+                jurisdictions=["us"],
+            ),
+        )
+
+        matched = news_flow.match_entities.fn(
+            [{"headline": "Elliott files new position", "body_snippet": ""}],
+            conn,
+        )
+
+        assert manager_id == 1
+        assert matched[0]["manager_id"] == manager_id
+        assert daily_flow._fetch_all_manager_ids(conn) == [manager_id]
+        assert diff_holdings_module._resolve_manager_id("0001791786", conn) == manager_id
+        assert activism_flow._all_manager_ids(conn) == [manager_id]
+        assert activism_flow._load_manager_row(conn, manager_id) == (
+            "Elliott Investment Management L.P.",
+            "0001791786",
+        )
+    finally:
+        conn.close()
 
 
 # Fixed date for deterministic flow defaults.


### PR DESCRIPTION
Closes #1302

## Summary
- add a shared manager-id column resolver for SQLite/Postgres manager schemas
- use the resolver in ETL/news/daily diff/activism/diff holdings manager lookups
- add a regression test for the API-created SQLite managers table using `id`

## Validation
- `python -m pytest tests/test_etl_flows_additional.py::test_etl_manager_id_readers_support_api_created_sqlite_schema -q`
- `python -m pytest tests/test_etl_flows_additional.py tests/test_daily_diff.py tests/test_edgar_flow.py::test_fetch_and_store_uses_postgres_safe_persistence tests/test_edgar_flow.py::test_replace_holdings_for_filing_uses_postgres_transaction -q`
- `python -m ruff check adapters/base.py etl/news_flow.py etl/daily_diff_flow.py etl/activism_flow.py diff_holdings.py tests/test_etl_flows_additional.py`
- `black --fast --check --line-length 100 --exclude "(\.workflows-lib|node_modules)" adapters/base.py etl/news_flow.py etl/daily_diff_flow.py etl/activism_flow.py diff_holdings.py tests/test_etl_flows_additional.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manager lookups so they work across different database backends, including SQLite.
  * Fixed several data retrieval paths to use the correct manager identifier column automatically.
  * Improved entity matching and report generation when manager records use different ID formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->