### PR TITLE
Cap ingest return rows in memory

### DIFF
--- a/etl/ingest_flow.py
+++ b/etl/ingest_flow.py
@@ -449,6 +449,25 @@ def _replace_holdings_rows(
     return int(_run_in_transaction(conn, _work))
 
 
+def _max_results_in_memory() -> int:
+    raw_value = os.getenv("MAX_RESULTS_IN_MEMORY", "100000")
+    try:
+        max_results = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid MAX_RESULTS_IN_MEMORY; using default",
+            extra={"value": raw_value, "default": 100000},
+        )
+        return 100000
+    if max_results < 1:
+        logger.warning(
+            "MAX_RESULTS_IN_MEMORY must be positive; using default",
+            extra={"value": raw_value, "default": 100000},
+        )
+        return 100000
+    return max_results
+
+
 @task
 async def fetch_and_store(
     identifier: str,
@@ -468,7 +487,7 @@ async def fetch_and_store(
 
         results: list[dict[str, Any]] = []
         row_count = 0
-        max_results = int(os.getenv("MAX_RESULTS_IN_MEMORY", "100000"))
+        max_results = _max_results_in_memory()
 
         for filing in filings:
             raw = await adapter.download(filing)
@@ -505,7 +524,7 @@ async def fetch_and_store(
                 parsed_rows=parsed_rows,
             )
 
-            should_keep_results = row_count < max_results
+            remaining_results = max(0, max_results - len(results))
             # UK filings are metadata-driven (e.g., CS01/AR01) and should be
             # stored as parsed payload on the filings row, not expanded holdings.
             if jurisdiction != "uk" and _looks_like_holdings_rows(parsed_rows):
@@ -519,8 +538,8 @@ async def fetch_and_store(
                     parsed_rows=parsed_rows,
                     jurisdiction=jurisdiction,
                 )
-            if should_keep_results:
-                results.extend(parsed_rows)
+            if remaining_results:
+                results.extend(parsed_rows[:remaining_results])
 
         conn.commit()
         logger.info(

--- a/tests/test_ingest_flow.py
+++ b/tests/test_ingest_flow.py
@@ -22,6 +22,28 @@ class _USAdapter:
         ]
 
 
+class _LargeUSAdapter:
+    def __init__(self, row_count):
+        self.row_count = row_count
+
+    async def list_new_filings(self, _cik, _since):
+        return [{"accession": "0001-24-999999", "filed": "2024-01-05"}]
+
+    async def download(self, _filing):
+        return "<xml>large</xml>"
+
+    async def parse(self, _raw):
+        return [
+            {
+                "nameOfIssuer": f"Example Corp {index}",
+                "cusip": f"12345{index:04d}",
+                "value": index,
+                "sshPrnamt": index + 1,
+            }
+            for index in range(self.row_count)
+        ]
+
+
 class _UKAdapter:
     async def list_new_filings(self, company_number, since):
         return [{"transaction_id": "txn-1", "date": "2024-02-03"}]
@@ -184,6 +206,64 @@ async def test_fetch_and_store_us_uses_manager_cik_and_inserts_holdings(tmp_path
 
     assert filing == (1, "us", "0001-24-000001", "13F-HR")
     assert holding == (1, "0000000001", "0001-24-000001", "123456789", 1000, 50)
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_caps_single_large_filing_return_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE managers (id INTEGER PRIMARY KEY AUTOINCREMENT, cik TEXT, registry_ids TEXT)"
+    )
+    conn.execute("INSERT INTO managers(cik, registry_ids) VALUES (?, ?)", ("0000000001", "{}"))
+    conn.commit()
+    conn.close()
+
+    max_results = 3
+    monkeypatch.setenv("MAX_RESULTS_IN_MEMORY", str(max_results))
+    monkeypatch.setattr(ingest_flow.S3, "put_object", lambda **_kwargs: None)
+    monkeypatch.setattr(ingest_flow, "store_document", lambda _raw: None)
+
+    rows = await ingest_flow.fetch_and_store.fn(
+        "0000000001",
+        "2024-01-01",
+        jurisdiction="us",
+        adapter=_LargeUSAdapter(max_results + 1),
+        db_path=str(db_path),
+    )
+
+    assert len(rows) == max_results
+
+    conn = sqlite3.connect(db_path)
+    holdings_count = conn.execute("SELECT COUNT(*) FROM holdings").fetchone()[0]
+    conn.close()
+    assert holdings_count == max_results + 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_ignores_invalid_max_results_env(tmp_path, monkeypatch):
+    db_path = tmp_path / "dev.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE managers (id INTEGER PRIMARY KEY AUTOINCREMENT, cik TEXT, registry_ids TEXT)"
+    )
+    conn.execute("INSERT INTO managers(cik, registry_ids) VALUES (?, ?)", ("0000000001", "{}"))
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("MAX_RESULTS_IN_MEMORY", "not-an-int")
+    monkeypatch.setattr(ingest_flow.S3, "put_object", lambda **_kwargs: None)
+    monkeypatch.setattr(ingest_flow, "store_document", lambda _raw: None)
+
+    rows = await ingest_flow.fetch_and_store.fn(
+        "0000000001",
+        "2024-01-01",
+        jurisdiction="us",
+        adapter=_USAdapter(),
+        db_path=str(db_path),
+    )
+
+    assert rows and rows[0]["cusip"] == "123456789"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1315

## Summary
- Validate MAX_RESULTS_IN_MEMORY and fall back to the default on invalid or non-positive values
- Slice returned parsed rows to the remaining in-memory budget while preserving full DB persistence
- Add regressions for a single oversized filing and invalid env config

## Validation
- python -m pytest tests/test_ingest_flow.py -q
- python -m ruff check etl/ingest_flow.py tests/test_ingest_flow.py
- black --fast --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' etl/ingest_flow.py tests/test_ingest_flow.py\n- git diff --check\n- Deliberate break: restoring results.extend(parsed_rows) made test_fetch_and_store_caps_single_large_filing_return_rows fail with 4 rows returned for max 3\n