### PR TITLE
Align config and migration consistency

### DIFF
--- a/adapters/base.py
+++ b/adapters/base.py
@@ -22,6 +22,7 @@ else:  # pragma: no cover - imported above when available
     psycopg = _psycopg
 
 logger = logging.getLogger(__name__)
+DEFAULT_SQLITE_DB_PATH = "manager_database.db"
 
 
 class AdapterProtocol(Protocol):
@@ -255,7 +256,7 @@ async def tracked_call(
     db_path:
         Optional path to a database. If ``DB_URL`` is set and points to
         a Postgres instance, that URL is used instead; otherwise defaults
-        to ``DB_PATH`` or ``dev.db``.
+        to ``DB_PATH`` or ``manager_database.db``.
     cost_usd:
         Optional per-call cost. A ``float`` is recorded directly; a callable is
         invoked with the logged response and must return a ``float`` (e.g. a

--- a/adapters/edgar.py
+++ b/adapters/edgar.py
@@ -44,6 +44,7 @@ EDGAR_MIN_REQUEST_INTERVAL: float = _parse_edgar_min_request_interval(
     os.getenv("EDGAR_MIN_REQUEST_INTERVAL")
 )
 _last_edgar_request_at: float | None = None
+_edgar_request_lock = asyncio.Lock()
 
 
 async def _request_with_retry(
@@ -57,11 +58,12 @@ async def _request_with_retry(
 ) -> httpx.Response:
     global _last_edgar_request_at
 
-    if _last_edgar_request_at is not None and EDGAR_MIN_REQUEST_INTERVAL > 0:
-        elapsed = monotonic() - _last_edgar_request_at
-        if elapsed < EDGAR_MIN_REQUEST_INTERVAL:
-            await asyncio.sleep(EDGAR_MIN_REQUEST_INTERVAL - elapsed)
-    _last_edgar_request_at = monotonic()
+    async with _edgar_request_lock:
+        if _last_edgar_request_at is not None and EDGAR_MIN_REQUEST_INTERVAL > 0:
+            elapsed = monotonic() - _last_edgar_request_at
+            if elapsed < EDGAR_MIN_REQUEST_INTERVAL:
+                await asyncio.sleep(EDGAR_MIN_REQUEST_INTERVAL - elapsed)
+        _last_edgar_request_at = monotonic()
 
     for attempt in range(1, max_retries + 1):
         try:

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -3,6 +3,7 @@ from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
 
+from adapters.base import DEFAULT_SQLITE_DB_PATH
 from alembic import context
 
 # this is the Alembic Config object, which provides
@@ -35,7 +36,7 @@ def get_database_url() -> str:
     if ini_url and ini_url != "driver://user:pass@localhost/dbname":
         return ini_url
 
-    return "sqlite:///./manager_database.db"
+    return f"sqlite:///./{DEFAULT_SQLITE_DB_PATH}"
 
 
 def run_migrations_offline() -> None:

--- a/alembic/versions/001_canonical_schema.py
+++ b/alembic/versions/001_canonical_schema.py
@@ -239,7 +239,7 @@ def upgrade() -> None:
     # ── materialized views (Postgres) / regular views (SQLite) ─
     if pg:
         op.execute("""
-            CREATE MATERIALIZED VIEW monthly_usage AS
+            CREATE MATERIALIZED VIEW IF NOT EXISTS monthly_usage AS
             SELECT date_trunc('month', ts) AS month,
                    source,
                    count(*) AS calls,
@@ -249,7 +249,7 @@ def upgrade() -> None:
             GROUP BY 1, 2
         """)
         op.execute("""
-            CREATE MATERIALIZED VIEW mv_daily_report AS
+            CREATE MATERIALIZED VIEW IF NOT EXISTS mv_daily_report AS
             SELECT
                 d.report_date,
                 m.manager_id,

--- a/alembic/versions/006_activism_events.py
+++ b/alembic/versions/006_activism_events.py
@@ -55,12 +55,12 @@ def upgrade() -> None:
     op.create_index("idx_activism_events_date", "activism_events", [sa.text("detected_at DESC")])
     op.create_index("idx_activism_events_cusip", "activism_events", ["subject_cusip"])
     op.execute(
-        "CREATE UNIQUE INDEX idx_activism_events_unique_base "
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_activism_events_unique_base "
         "ON activism_events (manager_id, filing_id, event_type) "
         "WHERE threshold_crossed IS NULL"
     )
     op.execute(
-        "CREATE UNIQUE INDEX idx_activism_events_unique_threshold "
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_activism_events_unique_threshold "
         "ON activism_events (manager_id, filing_id, event_type, threshold_crossed) "
         "WHERE threshold_crossed IS NOT NULL"
     )

--- a/alerts/channels.py
+++ b/alerts/channels.py
@@ -47,6 +47,11 @@ def _warn_skip(channel: str, reason: str) -> DeliveryResult:
     return DeliveryResult(channel=channel, success=True, skipped=True, error_message=reason)
 
 
+def resolve_slack_webhook_url() -> str:
+    """Return the configured Slack webhook using alert-specific then legacy names."""
+    return (os.getenv("ALERT_SLACK_WEBHOOK_URL") or os.getenv("SLACK_WEBHOOK_URL") or "").strip()
+
+
 def _build_email_message(
     alert: FiredAlert,
     *,
@@ -215,7 +220,7 @@ class SlackChannel(NotificationChannel):
         timeout_seconds: float = 10.0,
         min_interval_seconds: float = 1.0,
     ) -> None:
-        self.webhook_url = (webhook_url or os.getenv("ALERT_SLACK_WEBHOOK_URL") or "").strip()
+        self.webhook_url = (webhook_url or resolve_slack_webhook_url() or "").strip()
         self.timeout_seconds = timeout_seconds
         self.min_interval_seconds = min_interval_seconds
         self._lock = asyncio.Lock()
@@ -223,7 +228,10 @@ class SlackChannel(NotificationChannel):
 
     async def deliver(self, alert: FiredAlert) -> DeliveryResult:
         if not self.webhook_url:
-            return _warn_skip(self.channel_name, "ALERT_SLACK_WEBHOOK_URL is not configured")
+            return _warn_skip(
+                self.channel_name,
+                "ALERT_SLACK_WEBHOOK_URL/SLACK_WEBHOOK_URL is not configured",
+            )
 
         payload = format_slack_blocks(alert)
         await self._respect_rate_limit()

--- a/alerts/channels.py
+++ b/alerts/channels.py
@@ -49,7 +49,11 @@ def _warn_skip(channel: str, reason: str) -> DeliveryResult:
 
 def resolve_slack_webhook_url() -> str:
     """Return the configured Slack webhook using alert-specific then legacy names."""
-    return (os.getenv("ALERT_SLACK_WEBHOOK_URL") or os.getenv("SLACK_WEBHOOK_URL") or "").strip()
+    for env_name in ("ALERT_SLACK_WEBHOOK_URL", "SLACK_WEBHOOK_URL"):
+        webhook_url = (os.getenv(env_name) or "").strip()
+        if webhook_url:
+            return webhook_url
+    return ""
 
 
 def _build_email_message(

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-DEFAULT_DB_PATH = "dev.db"
+DEFAULT_DB_PATH = "manager_database.db"
 DEFAULT_CACHE_TTL_SECONDS = 60
 DEFAULT_CACHE_MAX_ITEMS = 512
 

--- a/etl/activism_flow.py
+++ b/etl/activism_flow.py
@@ -12,6 +12,7 @@ from prefect.schedules import Cron
 
 from adapters import edgar
 from adapters.base import (
+    DEFAULT_SQLITE_DB_PATH,
     connect_db,
     get_placeholder,
     is_postgres,
@@ -35,8 +36,8 @@ logger = logging.getLogger(__name__)
 
 ACTIVISM_FORMS = ["SC 13D", "SC 13D/A", "SC 13G", "SC 13G/A"]
 ACTIVISM_FLOW_NIGHTLY_CRON = os.getenv("ACTIVISM_FLOW_CRON", "0 4 * * *")
-ACTIVISM_FLOW_TIMEZONE = os.getenv("ACTIVISM_FLOW_TIMEZONE", "UTC")
-DB_PATH = os.getenv("DB_PATH", "dev.db")
+ACTIVISM_FLOW_TIMEZONE = os.getenv("ACTIVISM_FLOW_TIMEZONE", os.getenv("TZ", "UTC"))
+DB_PATH = os.getenv("DB_PATH", DEFAULT_SQLITE_DB_PATH)
 
 
 def _ensure_activism_filings_table(conn: Any) -> None:

--- a/etl/edgar_flow.py
+++ b/etl/edgar_flow.py
@@ -13,7 +13,13 @@ from typing import Any, cast
 from prefect import flow, task
 
 import etl.ingest_flow as ingest_module
-from adapters.base import connect_db, get_adapter, get_placeholder, get_table_columns
+from adapters.base import (
+    DEFAULT_SQLITE_DB_PATH,
+    connect_db,
+    get_adapter,
+    get_placeholder,
+    get_table_columns,
+)
 from alerts.integration import build_new_filing_event, fire_alerts_for_event
 from etl.logging_setup import configure_logging, log_outcome
 
@@ -42,7 +48,7 @@ def store_document(
 RAW_DIR = ingest_module.RAW_DIR
 S3 = ingest_module.S3
 BUCKET = ingest_module.BUCKET
-DB_PATH = os.getenv("DB_PATH", "dev.db")
+DB_PATH = os.getenv("DB_PATH", DEFAULT_SQLITE_DB_PATH)
 ADAPTER = get_adapter("edgar")
 
 configure_logging("edgar_flow")

--- a/etl/ingest_flow.py
+++ b/etl/ingest_flow.py
@@ -14,6 +14,7 @@ import boto3
 from prefect import flow, task
 
 from adapters.base import (
+    DEFAULT_SQLITE_DB_PATH,
     connect_db,
     get_adapter,
     get_placeholder,
@@ -55,10 +56,10 @@ S3 = boto3.client(
     endpoint_url=os.getenv("MINIO_ENDPOINT", "http://localhost:9000"),
     aws_access_key_id=os.getenv("MINIO_ROOT_USER", "minio"),
     aws_secret_access_key=os.getenv("MINIO_ROOT_PASSWORD", "minio123"),
-    region_name="us-east-1",
+    region_name=os.getenv("MINIO_REGION", "us-east-1"),
 )
 BUCKET = os.getenv("MINIO_BUCKET", "filings")
-DB_PATH = os.getenv("DB_PATH", "dev.db")
+DB_PATH = os.getenv("DB_PATH", DEFAULT_SQLITE_DB_PATH)
 
 _ADAPTER_MAP = {"us": "edgar", "uk": "uk", "ca": "canada", "sg": "mas", "au": "asic"}
 _IDENTIFIER_ENV = {

--- a/etl/summariser_flow.py
+++ b/etl/summariser_flow.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
-import os
 
 import pandas as pd
 import requests  # type: ignore
 from prefect import flow, task
 
 from adapters.base import connect_db, tracked_call
+from alerts.channels import resolve_slack_webhook_url
 from etl.daily_diff_flow import _placeholder
 from etl.logging_setup import configure_logging, log_outcome
 
@@ -36,7 +36,7 @@ async def summarise(date: str) -> str:
         conn.close()
     change_count = int(df["change_count"].iloc[0])
     summary = f"{change_count} changes on {date}"
-    webhook = os.getenv("SLACK_WEBHOOK_URL")
+    webhook = resolve_slack_webhook_url()
     if webhook:
         # log Slack webhook usage to api_usage table
         async with tracked_call("slack", webhook) as log:

--- a/tests/test_config_migration_consistency.py
+++ b/tests/test_config_migration_consistency.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import httpx
+import pytest
+
+from adapters import base, edgar
+from alerts.channels import SlackChannel, resolve_slack_webhook_url
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _source(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_connect_db_and_alembic_share_default_sqlite_path(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class DummyConnection:
+        pass
+
+    def fake_connect(path, **kwargs):
+        captured["path"] = path
+        captured["kwargs"] = kwargs
+        return DummyConnection()
+
+    monkeypatch.delenv("DB_URL", raising=False)
+    monkeypatch.delenv("DB_PATH", raising=False)
+    monkeypatch.setattr(sqlite3, "connect", fake_connect)
+
+    assert base.connect_db(connect_timeout=2, retries=0).__class__ is DummyConnection
+    assert captured == {"path": base.DEFAULT_SQLITE_DB_PATH, "kwargs": {"timeout": 2}}
+    assert base.DEFAULT_SQLITE_DB_PATH == "manager_database.db"
+    assert "sqlite:///./{DEFAULT_SQLITE_DB_PATH}" in _source("alembic/env.py")
+
+
+def test_migration_postgres_ddl_is_idempotent():
+    canonical = _source("alembic/versions/001_canonical_schema.py")
+    activism = _source("alembic/versions/006_activism_events.py")
+
+    assert "CREATE MATERIALIZED VIEW IF NOT EXISTS monthly_usage AS" in canonical
+    assert "CREATE MATERIALIZED VIEW IF NOT EXISTS mv_daily_report AS" in canonical
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_activism_events_unique_base" in activism
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_activism_events_unique_threshold" in activism
+
+
+def test_env_defaults_are_shared_for_region_slack_and_timezone(monkeypatch):
+    monkeypatch.delenv("ALERT_SLACK_WEBHOOK_URL", raising=False)
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/legacy")
+
+    assert resolve_slack_webhook_url() == "https://hooks.slack.test/legacy"
+    assert SlackChannel().webhook_url == "https://hooks.slack.test/legacy"
+
+    ingest_source = _source("etl/ingest_flow.py")
+    activism_source = _source("etl/activism_flow.py")
+    assert 'region_name=os.getenv("MINIO_REGION", "us-east-1")' in ingest_source
+    assert 'os.getenv("ACTIVISM_FLOW_TIMEZONE", os.getenv("TZ", "UTC"))' in activism_source
+
+
+@pytest.mark.asyncio
+async def test_edgar_request_spacing_lock_prevents_overlapping_sleeps(monkeypatch):
+    sleep_calls: list[float] = []
+    active_sleeps = 0
+    max_active_sleeps = 0
+    real_sleep = asyncio.sleep
+
+    @asynccontextmanager
+    async def fake_tracked_call(source, url):
+        _ = (source, url)
+
+        def log(response):
+            _ = response
+
+        yield log
+
+    class DummyClient:
+        async def get(self, url, headers=None, params=None):
+            _ = (headers, params)
+            return httpx.Response(200, request=httpx.Request("GET", url), text="ok")
+
+    async def fake_sleep(delay):
+        nonlocal active_sleeps, max_active_sleeps
+        sleep_calls.append(delay)
+        active_sleeps += 1
+        max_active_sleeps = max(max_active_sleeps, active_sleeps)
+        await real_sleep(0)
+        active_sleeps -= 1
+
+    monkeypatch.setattr(edgar, "tracked_call", fake_tracked_call)
+    monkeypatch.setattr(edgar.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(edgar, "EDGAR_MIN_REQUEST_INTERVAL", 0.5)
+    monkeypatch.setattr(edgar, "_last_edgar_request_at", 100.0)
+    monkeypatch.setattr(edgar, "_edgar_request_lock", asyncio.Lock())
+
+    times = iter([100.0, 100.5, 100.5, 101.0])
+    monkeypatch.setattr(edgar, "monotonic", lambda: next(times))
+
+    await asyncio.gather(
+        edgar._request_with_retry(DummyClient(), "https://example.test/a", {}, source="test"),
+        edgar._request_with_retry(DummyClient(), "https://example.test/b", {}, source="test"),
+    )
+
+    assert sleep_calls == [0.5, 0.5]
+    assert max_active_sleeps == 1

--- a/tests/test_config_migration_consistency.py
+++ b/tests/test_config_migration_consistency.py
@@ -62,6 +62,14 @@ def test_env_defaults_are_shared_for_region_slack_and_timezone(monkeypatch):
     assert 'os.getenv("ACTIVISM_FLOW_TIMEZONE", os.getenv("TZ", "UTC"))' in activism_source
 
 
+def test_slack_webhook_falls_back_when_alert_specific_value_is_blank(monkeypatch):
+    monkeypatch.setenv("ALERT_SLACK_WEBHOOK_URL", "   ")
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", " https://hooks.slack.test/legacy ")
+
+    assert resolve_slack_webhook_url() == "https://hooks.slack.test/legacy"
+    assert SlackChannel().webhook_url == "https://hooks.slack.test/legacy"
+
+
 @pytest.mark.asyncio
 async def test_edgar_request_spacing_lock_prevents_overlapping_sleeps(monkeypatch):
     sleep_calls: list[float] = []


### PR DESCRIPTION
Closes #1317

## Summary
- serialize EDGAR request pacing behind a shared async lock and unify SQLite defaults with Alembic
- make Postgres materialized-view and activism unique-index migration SQL idempotent
- align MinIO region, Slack webhook fallback, and activism timezone env resolution
- add focused regression coverage for the config/migration consistency contracts

## Validation
- python -m pytest tests/test_config_migration_consistency.py tests/test_adapter_base.py tests/test_alert_channels.py tests/test_summariser.py tests/test_edgar_integration.py::test_rate_limit_handling tests/test_edgar_integration.py::test_outbound_request_rate_governor tests/test_edgar_integration.py::test_edgar_min_request_interval_rejects_non_finite_config -q
- python -m ruff check adapters/base.py adapters/edgar.py alembic/env.py alembic/versions/001_canonical_schema.py alembic/versions/006_activism_events.py alerts/channels.py etl/ingest_flow.py etl/edgar_flow.py etl/activism_flow.py etl/summariser_flow.py tests/test_config_migration_consistency.py
- python -m black --fast --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' adapters/base.py adapters/edgar.py alembic/env.py alembic/versions/001_canonical_schema.py alembic/versions/006_activism_events.py alerts/channels.py etl/ingest_flow.py etl/edgar_flow.py etl/activism_flow.py etl/summariser_flow.py tests/test_config_migration_consistency.py\n- git diff --check\n\n## Deliberate break\n- Temporarily changed DEFAULT_SQLITE_DB_PATH back to dev.db; tests/test_config_migration_consistency.py::test_connect_db_and_alembic_share_default_sqlite_path failed, then passed after restoring the fix.