### PR TITLE
Address chat config verifier gaps

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -8,7 +8,6 @@ import hmac
 import importlib
 import json
 import logging
-import math
 import os
 import time
 import uuid
@@ -36,6 +35,7 @@ from api.managers import router as managers_router
 from api.memory_profiler import start_memory_profiler, stop_memory_profiler
 from api.search import SearchEntityType, SearchResult, universal_search
 from api.signals import router as signals_router
+from config import load_runtime_config
 from llm.langsmith_fleet import (
     ChatFleetContext,
     TokenUsage,
@@ -372,7 +372,7 @@ class ChainUnavailableError(RuntimeError):
 
 def _chat_chain_fallback_enabled() -> bool:
     """Return True when deterministic chain stubs are explicitly allowed."""
-    return os.getenv("CHAT_CHAIN_FALLBACK_MODE", "").strip().lower() in {
+    return load_runtime_config().chat_chain_fallback_mode.strip().lower() in {
         "1",
         "true",
         "yes",
@@ -382,39 +382,7 @@ def _chat_chain_fallback_enabled() -> bool:
     }
 
 
-def _read_positive_int_env(name: str, default: int) -> int:
-    raw_value = os.getenv(name)
-    if raw_value is None:
-        return default
-    try:
-        value = int(raw_value)
-    except ValueError:
-        logger.warning("Invalid %s=%r; using default %s", name, raw_value, default)
-        return default
-    if value <= 0 or not math.isfinite(value):
-        logger.warning("Invalid %s=%r; using default %s", name, raw_value, default)
-        return default
-    return value
-
-
-def _read_positive_float_env(name: str, default: float) -> float:
-    raw_value = os.getenv(name)
-    if raw_value is None:
-        return default
-    try:
-        value = float(raw_value)
-    except ValueError:
-        logger.warning("Invalid %s=%r; using default %s", name, raw_value, default)
-        return default
-    if value <= 0 or not math.isfinite(value):
-        logger.warning("Invalid %s=%r; using default %s", name, raw_value, default)
-        return default
-    return value
-
-
-_CHAT_RATE_LIMIT_PER_MINUTE = _read_positive_int_env("CHAT_RATE_LIMIT_PER_MINUTE", 10)
-_CHAT_RATE_LIMIT_WINDOW_SECONDS = _read_positive_float_env("CHAT_RATE_LIMIT_WINDOW_SECONDS", 60.0)
-_CHAT_SESSION_COOKIE_NAME = os.getenv("CHAT_SESSION_COOKIE_NAME", "session_id")
+_CHAT_SESSION_COOKIE_NAME = load_runtime_config().chat_session_cookie_name
 
 
 class InMemoryChatRateLimiter:
@@ -446,9 +414,10 @@ class InMemoryChatRateLimiter:
 
 
 def _build_chat_rate_limiter() -> InMemoryChatRateLimiter:
+    config = load_runtime_config()
     return InMemoryChatRateLimiter(
-        max_requests=_read_positive_int_env("CHAT_RATE_LIMIT_PER_MINUTE", 10),
-        window_seconds=_read_positive_float_env("CHAT_RATE_LIMIT_WINDOW_SECONDS", 60.0),
+        max_requests=config.chat_rate_limit_per_minute,
+        window_seconds=config.chat_rate_limit_window_seconds,
     )
 
 
@@ -462,7 +431,7 @@ def _sign_chat_session_id(session_id: str, secret: str) -> str:
 
 
 def _verified_chat_session_cookie(raw_value: str | None) -> str | None:
-    secret = os.getenv("CHAT_SESSION_COOKIE_SECRET")
+    secret = load_runtime_config().chat_session_cookie_secret
     if not raw_value or not secret:
         return None
     try:
@@ -521,7 +490,7 @@ def _load_prompt_injection_error_class() -> type[Exception]:
     try:
         module = importlib.import_module("llm.injection")
         return module.PromptInjectionError
-    except Exception:
+    except (ModuleNotFoundError, AttributeError):
         return _PromptInjectionError
 
 
@@ -565,7 +534,7 @@ def _chat_zone_disabled() -> bool:
     503. This is the single LLM-boundary switch documented in
     ``docs/deploy/INTERNAL_HOSTING.md``.
     """
-    return os.getenv("LLM_ZONE", "").strip().lower() == "disabled"
+    return load_runtime_config().llm_zone.strip().lower() == "disabled"
 
 
 def _manager_id_column(conn: Any) -> str:
@@ -662,8 +631,8 @@ def _classify_intent(question: str) -> str:
         chain_name = classify_intent(question)
         if chain_name in DIRECT_CHAIN_PATHS:
             return chain_name
-    except Exception:
-        pass
+    except (ModuleNotFoundError, AttributeError, TypeError, ValueError):
+        logger.debug("Intent classifier unavailable; using deterministic fallback", exc_info=True)
 
     lowered = question.lower()
     if "sql" in lowered or "query" in lowered or "database" in lowered:

--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from dataclasses import dataclass
 
@@ -32,7 +33,7 @@ def _positive_float_env(name: str, default: float) -> float:
         value = float(raw_value)
     except ValueError:
         return default
-    return value if value > 0 else default
+    return value if math.isfinite(value) and value > 0 else default
 
 
 @dataclass(frozen=True)

--- a/config.py
+++ b/config.py
@@ -8,6 +8,9 @@ from dataclasses import dataclass
 DEFAULT_DB_PATH = "manager_database.db"
 DEFAULT_CACHE_TTL_SECONDS = 60
 DEFAULT_CACHE_MAX_ITEMS = 512
+DEFAULT_CHAT_RATE_LIMIT_PER_MINUTE = 10
+DEFAULT_CHAT_RATE_LIMIT_WINDOW_SECONDS = 60.0
+DEFAULT_CHAT_SESSION_COOKIE_NAME = "session_id"
 
 
 def _positive_int_env(name: str, default: int) -> int:
@@ -21,6 +24,17 @@ def _positive_int_env(name: str, default: int) -> int:
     return value if value > 0 else default
 
 
+def _positive_float_env(name: str, default: float) -> float:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        value = float(raw_value)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
 @dataclass(frozen=True)
 class RuntimeConfig:
     db_url: str | None
@@ -28,6 +42,12 @@ class RuntimeConfig:
     cache_ttl_seconds: int
     cache_max_items: int
     redis_url: str | None
+    chat_chain_fallback_mode: str
+    chat_rate_limit_per_minute: int
+    chat_rate_limit_window_seconds: float
+    chat_session_cookie_name: str
+    chat_session_cookie_secret: str | None
+    llm_zone: str
 
 
 def load_runtime_config() -> RuntimeConfig:
@@ -37,4 +57,16 @@ def load_runtime_config() -> RuntimeConfig:
         cache_ttl_seconds=_positive_int_env("CACHE_TTL_SECONDS", DEFAULT_CACHE_TTL_SECONDS),
         cache_max_items=_positive_int_env("CACHE_MAX_ITEMS", DEFAULT_CACHE_MAX_ITEMS),
         redis_url=os.getenv("REDIS_URL"),
+        chat_chain_fallback_mode=os.getenv("CHAT_CHAIN_FALLBACK_MODE", ""),
+        chat_rate_limit_per_minute=_positive_int_env(
+            "CHAT_RATE_LIMIT_PER_MINUTE", DEFAULT_CHAT_RATE_LIMIT_PER_MINUTE
+        ),
+        chat_rate_limit_window_seconds=_positive_float_env(
+            "CHAT_RATE_LIMIT_WINDOW_SECONDS", DEFAULT_CHAT_RATE_LIMIT_WINDOW_SECONDS
+        ),
+        chat_session_cookie_name=os.getenv(
+            "CHAT_SESSION_COOKIE_NAME", DEFAULT_CHAT_SESSION_COOKIE_NAME
+        ),
+        chat_session_cookie_secret=os.getenv("CHAT_SESSION_COOKIE_SECRET"),
+        llm_zone=os.getenv("LLM_ZONE", ""),
     )

--- a/tests/test_config_hygiene.py
+++ b/tests/test_config_hygiene.py
@@ -43,7 +43,19 @@ def _has_external_callers(name: str, definition_path: str) -> bool:
 
 
 def test_runtime_config_centralizes_db_and_cache_defaults(monkeypatch):
-    for name in ("DB_URL", "DB_PATH", "CACHE_TTL_SECONDS", "CACHE_MAX_ITEMS", "REDIS_URL"):
+    for name in (
+        "DB_URL",
+        "DB_PATH",
+        "CACHE_TTL_SECONDS",
+        "CACHE_MAX_ITEMS",
+        "REDIS_URL",
+        "CHAT_CHAIN_FALLBACK_MODE",
+        "CHAT_RATE_LIMIT_PER_MINUTE",
+        "CHAT_RATE_LIMIT_WINDOW_SECONDS",
+        "CHAT_SESSION_COOKIE_NAME",
+        "CHAT_SESSION_COOKIE_SECRET",
+        "LLM_ZONE",
+    ):
         monkeypatch.delenv(name, raising=False)
 
     config = load_runtime_config()
@@ -53,26 +65,95 @@ def test_runtime_config_centralizes_db_and_cache_defaults(monkeypatch):
     assert config.cache_ttl_seconds == DEFAULT_CACHE_TTL_SECONDS
     assert config.cache_max_items == DEFAULT_CACHE_MAX_ITEMS
     assert config.redis_url is None
+    assert config.chat_chain_fallback_mode == ""
+    assert config.chat_rate_limit_per_minute == 10
+    assert config.chat_rate_limit_window_seconds == 60.0
+    assert config.chat_session_cookie_name == "session_id"
+    assert config.chat_session_cookie_secret is None
+    assert config.llm_zone == ""
 
 
 def test_runtime_config_uses_positive_cache_env_values(monkeypatch):
     monkeypatch.setenv("CACHE_TTL_SECONDS", "7")
     monkeypatch.setenv("CACHE_MAX_ITEMS", "11")
+    monkeypatch.setenv("CHAT_RATE_LIMIT_PER_MINUTE", "13")
+    monkeypatch.setenv("CHAT_RATE_LIMIT_WINDOW_SECONDS", "2.5")
+    monkeypatch.setenv("CHAT_SESSION_COOKIE_NAME", "research_session")
+    monkeypatch.setenv("CHAT_SESSION_COOKIE_SECRET", "secret")
+    monkeypatch.setenv("CHAT_CHAIN_FALLBACK_MODE", "offline")
+    monkeypatch.setenv("LLM_ZONE", "disabled")
 
     config = load_runtime_config()
 
     assert config.cache_ttl_seconds == 7
     assert config.cache_max_items == 11
+    assert config.chat_rate_limit_per_minute == 13
+    assert config.chat_rate_limit_window_seconds == 2.5
+    assert config.chat_session_cookie_name == "research_session"
+    assert config.chat_session_cookie_secret == "secret"
+    assert config.chat_chain_fallback_mode == "offline"
+    assert config.llm_zone == "disabled"
 
 
 def test_runtime_config_falls_back_for_bad_cache_env_values(monkeypatch):
     monkeypatch.setenv("CACHE_TTL_SECONDS", "not-int")
     monkeypatch.setenv("CACHE_MAX_ITEMS", "-1")
+    monkeypatch.setenv("CHAT_RATE_LIMIT_PER_MINUTE", "not-int")
+    monkeypatch.setenv("CHAT_RATE_LIMIT_WINDOW_SECONDS", "-1")
 
     config = load_runtime_config()
 
     assert config.cache_ttl_seconds == DEFAULT_CACHE_TTL_SECONDS
     assert config.cache_max_items == DEFAULT_CACHE_MAX_ITEMS
+    assert config.chat_rate_limit_per_minute == 10
+    assert config.chat_rate_limit_window_seconds == 60.0
+
+
+def test_chat_config_helpers_use_runtime_config(monkeypatch):
+    from api import chat as chat_module
+
+    monkeypatch.setenv("CHAT_CHAIN_FALLBACK_MODE", "offline")
+    monkeypatch.setenv("LLM_ZONE", "disabled")
+    monkeypatch.setenv("CHAT_RATE_LIMIT_PER_MINUTE", "3")
+    monkeypatch.setenv("CHAT_RATE_LIMIT_WINDOW_SECONDS", "4.5")
+
+    limiter = chat_module._build_chat_rate_limiter()
+
+    assert chat_module._chat_chain_fallback_enabled() is True
+    assert chat_module._chat_zone_disabled() is True
+    assert limiter._max_requests == 3
+    assert limiter._window_seconds == 4.5
+
+
+def test_chat_intent_classifier_does_not_swallow_unexpected_errors(monkeypatch):
+    from api import chat as chat_module
+
+    class BrokenIntentModule:
+        @staticmethod
+        def classify_intent(_question: str) -> str:
+            raise RuntimeError("classifier side effect")
+
+    def fake_import_module(name: str):
+        if name == "chains.intent":
+            return BrokenIntentModule
+        return __import__(name)
+
+    monkeypatch.setattr(chat_module.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(RuntimeError, match="classifier side effect"):
+        chat_module._classify_intent("What changed?")
+
+
+def test_prompt_injection_loader_does_not_swallow_unexpected_errors(monkeypatch):
+    from api import chat as chat_module
+
+    def broken_import_module(_name: str):
+        raise RuntimeError("unexpected import side effect")
+
+    monkeypatch.setattr(chat_module.importlib, "import_module", broken_import_module)
+
+    with pytest.raises(RuntimeError, match="unexpected import side effect"):
+        chat_module._load_prompt_injection_error_class()
 
 
 def test_redis_backend_does_not_swallow_unexpected_errors(monkeypatch):

--- a/tests/test_config_hygiene.py
+++ b/tests/test_config_hygiene.py
@@ -99,7 +99,7 @@ def test_runtime_config_falls_back_for_bad_cache_env_values(monkeypatch):
     monkeypatch.setenv("CACHE_TTL_SECONDS", "not-int")
     monkeypatch.setenv("CACHE_MAX_ITEMS", "-1")
     monkeypatch.setenv("CHAT_RATE_LIMIT_PER_MINUTE", "not-int")
-    monkeypatch.setenv("CHAT_RATE_LIMIT_WINDOW_SECONDS", "-1")
+    monkeypatch.setenv("CHAT_RATE_LIMIT_WINDOW_SECONDS", "inf")
 
     config = load_runtime_config()
 


### PR DESCRIPTION
## Summary
- centralize chat fallback, rate-limit, session-cookie, and LLM-zone defaults in `config.py`
- route `api/chat.py` chat helpers through the runtime config seed
- narrow chat intent and prompt-injection fallback handling so unexpected import/classifier errors are not swallowed
- add regression coverage for the #1371 verifier concerns

## Validation
- `python -m pytest tests/test_config_hygiene.py tests/test_chat_zone_disabled.py tests/test_chat_api_fleet_integration.py -q`
- `python -m ruff check config.py api/chat.py tests/test_config_hygiene.py`
- `python -m black --check ... config.py api/chat.py tests/test_config_hygiene.py`
- `git diff --check`

Follow-up for #1371 verifier concerns.

Closes #1316