### PR TITLE
Read chat session cookie name at runtime

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -382,9 +382,6 @@ def _chat_chain_fallback_enabled() -> bool:
     }
 
 
-_CHAT_SESSION_COOKIE_NAME = load_runtime_config().chat_session_cookie_name
-
-
 class InMemoryChatRateLimiter:
     """Simple in-memory session limiter for chat endpoints."""
 
@@ -446,12 +443,16 @@ def _verified_chat_session_cookie(raw_value: str | None) -> str | None:
     return session_id
 
 
+def _chat_session_cookie_name() -> str:
+    return load_runtime_config().chat_session_cookie_name
+
+
 def _chat_session_id(request: Request | None) -> str:
     """Derive a stable quota key without trusting client-chosen headers."""
     if request is None:
         return "unknown"
     client_host = request.client.host if request.client and request.client.host else "unknown"
-    session_id = _verified_chat_session_cookie(request.cookies.get(_CHAT_SESSION_COOKIE_NAME))
+    session_id = _verified_chat_session_cookie(request.cookies.get(_chat_session_cookie_name()))
     if session_id:
         return f"client:{client_host}:session:{session_id}"
     return f"client:{client_host}"

--- a/tests/test_rate_limit_contract.py
+++ b/tests/test_rate_limit_contract.py
@@ -176,6 +176,39 @@ def test_chat_limiter_accepts_signed_server_session_cookies(
     assert second.status_code == 503
 
 
+def test_chat_limiter_reads_runtime_cookie_name(monkeypatch: pytest.MonkeyPatch):
+    limiter = chat_api_module.InMemoryChatRateLimiter(max_requests=1, window_seconds=60)
+    ip_limiter = chat_api_module.InMemoryChatRateLimiter(max_requests=10, window_seconds=60)
+    monkeypatch.setattr(chat_api_module, "CHAT_RATE_LIMITER", limiter)
+    monkeypatch.setattr(chat_api_module, "CHAT_IP_RATE_LIMITER", ip_limiter)
+    monkeypatch.setattr(chat_api_module, "_build_chat_client_info", lambda: None)
+    monkeypatch.setenv("CHAT_SESSION_COOKIE_NAME", "research_session")
+    monkeypatch.setenv("CHAT_SESSION_COOKIE_SECRET", "test-secret")
+
+    first_cookie = _signed_session_cookie("server-session-a", "test-secret")
+    second_cookie = _signed_session_cookie("server-session-b", "test-secret")
+
+    first = asyncio.run(
+        _request(
+            "POST",
+            "/api/chat",
+            json={"question": "first"},
+            headers={"Cookie": f"research_session={first_cookie}"},
+        )
+    )
+    second = asyncio.run(
+        _request(
+            "POST",
+            "/api/chat",
+            json={"question": "second"},
+            headers={"Cookie": f"research_session={second_cookie}"},
+        )
+    )
+
+    assert first.status_code == 503
+    assert second.status_code == 503
+
+
 def test_chat_limiter_rejects_rotating_client_session_headers(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
Closes #1316

## Summary
- remove the import-time chat session cookie-name lookup
- read `CHAT_SESSION_COOKIE_NAME` through runtime config when deriving the chat session id
- add a regression proving a renamed signed session cookie is honored after module import

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache-imi-manager-1316-cookie python -m pytest tests/test_rate_limit_contract.py::test_chat_limiter_reads_runtime_cookie_name tests/test_rate_limit_contract.py::test_chat_limiter_accepts_signed_server_session_cookies tests/test_config_hygiene.py::test_chat_config_helpers_use_runtime_config -q`
- `PYTHONPYCACHEPREFIX=/tmp/pycache-imi-manager-1316-cookie python -m pytest tests/test_config_hygiene.py tests/test_chat_zone_disabled.py tests/test_chat_api_fleet_integration.py tests/test_rate_limit_contract.py -q`
- `python -m ruff check api/chat.py tests/test_rate_limit_contract.py`
- `python -m black --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' api/chat.py tests/test_rate_limit_contract.py`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat rate limiting now correctly uses the configured session cookie name at runtime.
  * Requests using a customized cookie name continue to be recognized for quota tracking and limiting.
* **Tests**
  * Added coverage to verify chat rate limiting works with runtime cookie-name configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->