### PR TITLE
Expose resolved holding identifiers in search

### DIFF
--- a/api/search.py
+++ b/api/search.py
@@ -270,35 +270,93 @@ def _search_postgres(query: str, conn: Any, limit: int) -> list[SearchResult]:
             )
 
     if table_exists(conn, "holdings"):
+        holdings_columns = get_table_columns(conn, "holdings")
+        resolved_identifier_columns = [
+            column
+            for column in (
+                "resolved_ticker",
+                "resolved_figi",
+                "resolved_lei",
+                "isin",
+            )
+            if column in holdings_columns
+        ]
+        resolved_identifier_select = ", ".join(
+            f"h.{column}" for column in resolved_identifier_columns
+        )
+        resolved_identifier_select = (
+            f", {resolved_identifier_select}" if resolved_identifier_select else ""
+        )
+        resolved_identifier_text = " || ' ' || ".join(
+            f"COALESCE(h.{column}, '')" for column in resolved_identifier_columns
+        )
+        holdings_search_text = "COALESCE(h.name_of_issuer, '')"
+        if resolved_identifier_text:
+            holdings_search_text = f"{holdings_search_text} || ' ' || {resolved_identifier_text}"
+        resolved_identifier_predicates = " ".join(
+            f"OR upper(COALESCE(h.{column}, '')) = upper(%s)"
+            for column in resolved_identifier_columns
+        )
+        resolved_identifier_rank = " + ".join(
+            f"CASE WHEN upper(COALESCE(h.{column}, '')) = upper(%s) THEN 1.0 ELSE 0.0 END"
+            for column in resolved_identifier_columns
+        )
+        resolved_identifier_rank = (
+            f" + {resolved_identifier_rank}" if resolved_identifier_rank else ""
+        )
         rows = conn.execute(
-            """
+            f"""
             SELECT
                 h.holding_id,
                 m.name,
                 h.name_of_issuer,
                 h.cusip,
-                f.filed_date,
+                f.filed_date{resolved_identifier_select},
                 ts_rank(
-                    to_tsvector('english', COALESCE(h.name_of_issuer, '')),
+                    to_tsvector('english', {holdings_search_text}),
                     plainto_tsquery('english', %s)
                 ) AS issuer_rank,
-                CASE WHEN upper(COALESCE(h.cusip, '')) = upper(%s) THEN 1.0 ELSE 0.0 END AS cusip_rank
+                (
+                    CASE WHEN upper(COALESCE(h.cusip, '')) = upper(%s) THEN 1.0 ELSE 0.0 END
+                    {resolved_identifier_rank}
+                ) AS identifier_rank
             FROM holdings h
             JOIN filings f ON f.filing_id = h.filing_id
             LEFT JOIN managers m ON m.manager_id = f.manager_id
-            WHERE to_tsvector('english', COALESCE(h.name_of_issuer, '')) @@ plainto_tsquery('english', %s)
+            WHERE to_tsvector('english', {holdings_search_text}) @@ plainto_tsquery('english', %s)
                OR upper(COALESCE(h.cusip, '')) = upper(%s)
+               {resolved_identifier_predicates}
             ORDER BY GREATEST(
-                ts_rank(to_tsvector('english', COALESCE(h.name_of_issuer, '')), plainto_tsquery('english', %s)),
+                ts_rank(to_tsvector('english', {holdings_search_text}), plainto_tsquery('english', %s)),
                 CASE WHEN upper(COALESCE(h.cusip, '')) = upper(%s) THEN 1.0 ELSE 0.0 END
+                {resolved_identifier_rank}
             ) DESC
             LIMIT %s
             """,
-            (query, query, query, query, query, query, limit),
+            (
+                query,
+                query,
+                *(query for _ in resolved_identifier_columns),
+                query,
+                query,
+                *(query for _ in resolved_identifier_columns),
+                query,
+                query,
+                *(query for _ in resolved_identifier_columns),
+                limit,
+            ),
         ).fetchall()
-        for holding_id, manager_name, issuer, cusip, filed_date, issuer_rank, cusip_rank in rows:
+        for row in rows:
+            holding_id, manager_name, issuer, cusip, filed_date, *tail = row
+            resolved_values = [
+                str(value).strip() for value in tail[: len(resolved_identifier_columns)] if value
+            ]
+            issuer_rank, identifier_rank = tail[len(resolved_identifier_columns) :]
             headline = f"{issuer or 'Holding'} ({cusip or 'n/a'})"
-            snippet = f"CUSIP: {cusip or 'n/a'}"
+            identifier_parts = [f"CUSIP: {cusip or 'n/a'}"]
+            if resolved_values:
+                identifier_parts.append("Resolved: " + " / ".join(resolved_values))
+            snippet = " | ".join(identifier_parts)
             results.append(
                 SearchResult(
                     entity_type="holding",
@@ -311,7 +369,7 @@ def _search_postgres(query: str, conn: Any, limit: int) -> list[SearchResult]:
                         query,
                         headline,
                         snippet,
-                        fts_rank=max(float(issuer_rank or 0.0), float(cusip_rank or 0.0)),
+                        fts_rank=max(float(issuer_rank or 0.0), float(identifier_rank or 0.0)),
                     ),
                     url=None,
                     timestamp=str(filed_date) if filed_date is not None else None,
@@ -579,6 +637,16 @@ def _search_sqlite(query: str, conn: Any, limit: int) -> list[SearchResult]:
     holdings_columns = get_table_columns(conn, "holdings")
     if holdings_columns:
         if "holding_id" in holdings_columns:
+            resolved_identifier_columns = [
+                column
+                for column in (
+                    "resolved_ticker",
+                    "resolved_figi",
+                    "resolved_lei",
+                    "isin",
+                )
+                if column in holdings_columns
+            ]
             filing_columns = get_table_columns(conn, "filings")
             filing_date_col = (
                 "filed_date"
@@ -586,18 +654,37 @@ def _search_sqlite(query: str, conn: Any, limit: int) -> list[SearchResult]:
                 else ("period_end" if "period_end" in filing_columns else None)
             )
             filing_date_expr = f"f.{filing_date_col}" if filing_date_col else "NULL"
+            resolved_identifier_select = "".join(
+                f", h.{column}" for column in resolved_identifier_columns
+            )
+            resolved_identifier_where = "".join(
+                f" OR upper(COALESCE(h.{column}, '')) = upper(?)"
+                for column in resolved_identifier_columns
+            )
             rows = conn.execute(
                 "SELECT h.holding_id, f.manager_id, h.name_of_issuer, h.cusip, "
                 + filing_date_expr
+                + resolved_identifier_select
                 + " "
                 "FROM holdings h JOIN filings f ON f.filing_id = h.filing_id "
                 "WHERE COALESCE(h.name_of_issuer, '') LIKE ? OR upper(COALESCE(h.cusip, '')) = upper(?) "
-                "LIMIT ?",
-                (like_token, query.strip(), limit),
+                + resolved_identifier_where
+                + " LIMIT ?",
+                (
+                    like_token,
+                    query.strip(),
+                    *(query.strip() for _ in resolved_identifier_columns),
+                    limit,
+                ),
             ).fetchall()
-            for entity_id, manager_id, issuer, cusip, filed_date in rows:
+            for row in rows:
+                entity_id, manager_id, issuer, cusip, filed_date, *resolved_values = row
+                resolved_values = [str(value).strip() for value in resolved_values if value]
                 headline = f"{issuer or 'Holding'} ({cusip or 'n/a'})"
-                snippet = f"CUSIP: {cusip or 'n/a'}"
+                identifier_parts = [f"CUSIP: {cusip or 'n/a'}"]
+                if resolved_values:
+                    identifier_parts.append("Resolved: " + " / ".join(resolved_values))
+                snippet = " | ".join(identifier_parts)
                 results.append(
                     SearchResult(
                         entity_type="holding",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -57,7 +57,14 @@ class _FakePostgresConn:
                     ("period_end",),
                     ("url",),
                 ],
-                "holdings": [("holding_id",), ("filing_id",), ("name_of_issuer",), ("cusip",)],
+                "holdings": [
+                    ("holding_id",),
+                    ("filing_id",),
+                    ("name_of_issuer",),
+                    ("cusip",),
+                    ("resolved_ticker",),
+                    ("resolved_figi",),
+                ],
                 "news_items": [("news_id",), ("manager_id",), ("headline",), ("body_snippet",)],
                 "documents": [("doc_id",), ("manager_id",), ("filename",), ("text",)],
             }
@@ -70,7 +77,19 @@ class _FakePostgresConn:
             )
         if "from holdings h" in lowered:
             return _FakeCursor(
-                [(3, "Elliott Management", "Elliott Corp", "123456789", "2025-04-01", 0.6, 0.0)]
+                [
+                    (
+                        3,
+                        "Elliott Management",
+                        "Elliott Corp",
+                        "123456789",
+                        "2025-04-01",
+                        "ELT",
+                        "BBG000ELT",
+                        0.6,
+                        0.0,
+                    )
+                ]
             )
         if "from news_items n" in lowered:
             return _FakeCursor(
@@ -185,6 +204,36 @@ def test_universal_search_returns_ranked_multi_entity_results():
     entity_types = {item.entity_type for item in results}
     assert {"manager", "filing", "news", "document", "holding"}.issubset(entity_types)
     assert results == sorted(results, key=lambda item: item.relevance, reverse=True)
+
+
+def test_universal_search_matches_resolved_holding_identifiers():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE managers (id INTEGER PRIMARY KEY, name TEXT, role TEXT)")
+    conn.execute(
+        "CREATE TABLE filings (filing_id INTEGER PRIMARY KEY, manager_id INTEGER, type TEXT, raw_key TEXT, period_end TEXT, url TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE holdings ("
+        "holding_id INTEGER PRIMARY KEY, filing_id INTEGER, name_of_issuer TEXT, cusip TEXT, "
+        "resolved_ticker TEXT, resolved_figi TEXT, isin TEXT)"
+    )
+    conn.execute("INSERT INTO managers(id, name, role) VALUES (1, 'Manager', 'Activist')")
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, raw_key, period_end, url) "
+        "VALUES (10, 1, '13F-HR', 'raw-10', '2025-01-01', NULL)"
+    )
+    conn.execute(
+        "INSERT INTO holdings("
+        "holding_id, filing_id, name_of_issuer, cusip, resolved_ticker, resolved_figi, isin"
+        ") VALUES (20, 10, 'Apple Inc', '037833100', 'AAPL', 'BBG000B9XRY4', 'US0378331005')"
+    )
+
+    results = universal_search("AAPL", conn, limit=20, entity_type="holding")
+
+    assert [item.entity_type for item in results] == ["holding"]
+    assert results[0].headline == "Apple Inc (037833100)"
+    assert "AAPL" in results[0].snippet
+    assert "BBG000B9XRY4" in results[0].snippet
 
 
 def test_score_result_clamps_non_finite_rank_and_distance():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import httpx
+import pytest
 from fastapi.encoders import jsonable_encoder
 
 import api.chat as chat_api_module
@@ -64,6 +65,8 @@ class _FakePostgresConn:
                     ("cusip",),
                     ("resolved_ticker",),
                     ("resolved_figi",),
+                    ("resolved_lei",),
+                    ("isin",),
                 ],
                 "news_items": [("news_id",), ("manager_id",), ("headline",), ("body_snippet",)],
                 "documents": [("doc_id",), ("manager_id",), ("filename",), ("text",)],
@@ -86,6 +89,8 @@ class _FakePostgresConn:
                         "2025-04-01",
                         "ELT",
                         "BBG000ELT",
+                        "5493001KJTIIGC8Y1R12",
+                        "US0000000001",
                         0.6,
                         0.0,
                     )
@@ -206,7 +211,16 @@ def test_universal_search_returns_ranked_multi_entity_results():
     assert results == sorted(results, key=lambda item: item.relevance, reverse=True)
 
 
-def test_universal_search_matches_resolved_holding_identifiers():
+@pytest.mark.parametrize(
+    ("column", "query_value"),
+    [
+        ("resolved_ticker", "AAPL"),
+        ("resolved_figi", "BBG000B9XRY4"),
+        ("resolved_lei", "HWUPKR0MPOU8FGXBT394"),
+        ("isin", "US0378331005"),
+    ],
+)
+def test_universal_search_matches_resolved_holding_identifiers(column: str, query_value: str):
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE managers (id INTEGER PRIMARY KEY, name TEXT, role TEXT)")
     conn.execute(
@@ -215,7 +229,7 @@ def test_universal_search_matches_resolved_holding_identifiers():
     conn.execute(
         "CREATE TABLE holdings ("
         "holding_id INTEGER PRIMARY KEY, filing_id INTEGER, name_of_issuer TEXT, cusip TEXT, "
-        "resolved_ticker TEXT, resolved_figi TEXT, isin TEXT)"
+        "resolved_ticker TEXT, resolved_figi TEXT, resolved_lei TEXT, isin TEXT)"
     )
     conn.execute("INSERT INTO managers(id, name, role) VALUES (1, 'Manager', 'Activist')")
     conn.execute(
@@ -224,16 +238,35 @@ def test_universal_search_matches_resolved_holding_identifiers():
     )
     conn.execute(
         "INSERT INTO holdings("
-        "holding_id, filing_id, name_of_issuer, cusip, resolved_ticker, resolved_figi, isin"
-        ") VALUES (20, 10, 'Apple Inc', '037833100', 'AAPL', 'BBG000B9XRY4', 'US0378331005')"
+        "holding_id, filing_id, name_of_issuer, cusip, "
+        "resolved_ticker, resolved_figi, resolved_lei, isin"
+        ") VALUES (20, 10, 'Apple Inc', '037833100', "
+        "'AAPL', 'BBG000B9XRY4', 'HWUPKR0MPOU8FGXBT394', 'US0378331005')"
     )
 
-    results = universal_search("AAPL", conn, limit=20, entity_type="holding")
+    results = universal_search(query_value, conn, limit=20, entity_type="holding")
 
     assert [item.entity_type for item in results] == ["holding"]
     assert results[0].headline == "Apple Inc (037833100)"
-    assert "AAPL" in results[0].snippet
-    assert "BBG000B9XRY4" in results[0].snippet
+    assert query_value in results[0].snippet
+    assert "US0378331005" in results[0].snippet
+
+
+def test_universal_search_postgres_matches_resolved_holding_identifiers():
+    conn = _FakePostgresConn()
+
+    results = universal_search("US0000000001", conn, limit=10, entity_type="holding")
+
+    assert [item.entity_type for item in results] == ["holding"]
+    assert results[0].headline == "Elliott Corp (123456789)"
+    assert "ELT" in results[0].snippet
+    assert "BBG000ELT" in results[0].snippet
+    assert "5493001KJTIIGC8Y1R12" in results[0].snippet
+    assert "US0000000001" in results[0].snippet
+    holdings_queries = [query for query in conn.queries if "from holdings h" in query.lower()]
+    assert holdings_queries
+    assert "h.resolved_lei" in holdings_queries[0]
+    assert "h.isin" in holdings_queries[0]
 
 
 def test_score_result_clamps_non_finite_rank_and_distance():


### PR DESCRIPTION
## Summary
- Include resolved ticker/FIGI/LEI/ISIN fields in holdings search when those columns exist.
- Match holdings by resolved identifiers in Postgres and SQLite search paths.
- Show resolved identifier values in holding search snippets.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache-manager-1321 python -m pytest tests/test_openfigi_resolution.py tests/test_search.py -q` -> 31 passed
- `PYTHONPYCACHEPREFIX=/tmp/pycache-manager-1321 python -m ruff check api/search.py tests/test_search.py` -> passed
- `PYTHONPYCACHEPREFIX=/tmp/pycache-manager-1321 python -m black --check --line-length 100 --target-version py312 --exclude '(\\.workflows-lib|node_modules)' api/search.py tests/test_search.py` -> passed\n- `git diff --check` -> passed\n\nFollow-up for #1374 verifier CONCERNS. Closes #1321.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results for holdings now match on additional resolved identifiers, making it easier to find entries using ticker, FIGI, LEI, or ISIN values.
  * Result snippets now show matched resolved identifiers in a new “Resolved” section for clearer context.

* **Bug Fixes**
  * Improved holding search relevance so results are scored using both issuer text and resolved identifier matches.
  * Holdings search now works more consistently across supported databases, including broader identifier matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->