### PR TITLE
Reconcile amended 13F filings before diffing

### DIFF
--- a/diff_holdings.py
+++ b/diff_holdings.py
@@ -40,6 +40,11 @@ def _select_authoritative_filings(manager_id: int, conn: Any) -> list[tuple[Any,
         SELECT f.filing_id, f.{period_column}, f.filed_date, f.type
         FROM filings f
         WHERE f.manager_id = {ph}
+          AND EXISTS (
+            SELECT 1
+            FROM holdings h
+            WHERE h.filing_id = f.filing_id
+          )
         """,
         (manager_id,),
     )
@@ -55,13 +60,13 @@ def _select_authoritative_filings(manager_id: int, conn: Any) -> list[tuple[Any,
             by_period[period] = candidate
             continue
         existing_rank = (
-            _is_amendment(existing[2]),
             _sort_key(existing[1]),
+            _is_amendment(existing[2]),
             existing[0],
         )
         candidate_rank = (
-            _is_amendment(candidate[2]),
             _sort_key(candidate[1]),
+            _is_amendment(candidate[2]),
             candidate[0],
         )
         if candidate_rank > existing_rank:

--- a/diff_holdings.py
+++ b/diff_holdings.py
@@ -7,7 +7,7 @@ import sys
 import time
 from typing import Any
 
-from adapters.base import connect_db, resolve_manager_id_column
+from adapters.base import connect_db, get_table_columns, resolve_manager_id_column
 from tools.registry import run_contract_fields
 from tools.run_contract import RunResult
 
@@ -17,46 +17,105 @@ def _placeholder(conn: Any) -> str:
     return "?" if isinstance(conn, sqlite3.Connection) else "%s"
 
 
-def _fetch_latest_sets(
-    manager_id: int, conn: Any
-) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
-    """Fetch holdings keyed by CUSIP for the two most-recent filing dates.
+def _is_amendment(filing_type: Any) -> bool:
+    return str(filing_type or "").strip().upper().endswith("/A")
 
-    Returns ``(current, prior)`` where each is
-    ``{cusip: {"shares": int|None, "value_usd": float|None, "name_of_issuer": str|None}}``.
+
+def _sort_key(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+def _select_authoritative_filings(manager_id: int, conn: Any) -> list[tuple[Any, int]]:
+    """Return authoritative filing IDs for the latest two reporting periods.
+
+    Raw EDGAR rows remain queryable in ``filings``/``holdings``. This selector is
+    the reconciliation boundary for downstream diffs: per manager-period, use the
+    latest amendment when present, otherwise the latest original filing.
     """
     ph = _placeholder(conn)
+    filing_columns = get_table_columns(conn, "filings")
+    period_column = "period_end" if "period_end" in filing_columns else "filed_date"
     cursor = conn.execute(
         f"""
-        SELECT f.filed_date, h.cusip, h.shares, h.value_usd, h.name_of_issuer
-        FROM holdings h
-        JOIN filings f ON f.filing_id = h.filing_id
+        SELECT f.filing_id, f.{period_column}, f.filed_date, f.type
+        FROM filings f
         WHERE f.manager_id = {ph}
-        ORDER BY f.filed_date DESC
         """,
         (manager_id,),
     )
 
-    grouped: dict[object, dict[str, dict[str, Any]]] = {}
-    ordered_dates: list[object] = []
+    by_period: dict[Any, tuple[int, Any, Any]] = {}
+    for filing_id, period_key, filed_date, filing_type in cursor:
+        period = period_key or filed_date
+        if period is None:
+            continue
+        candidate = (int(filing_id), filed_date, filing_type)
+        existing = by_period.get(period)
+        if existing is None:
+            by_period[period] = candidate
+            continue
+        existing_rank = (
+            _is_amendment(existing[2]),
+            _sort_key(existing[1]),
+            existing[0],
+        )
+        candidate_rank = (
+            _is_amendment(candidate[2]),
+            _sort_key(candidate[1]),
+            candidate[0],
+        )
+        if candidate_rank > existing_rank:
+            by_period[period] = candidate
 
-    for filed_date, cusip, shares, value_usd, name_of_issuer in cursor:
-        if filed_date not in grouped:
-            if len(ordered_dates) == 2:
-                break
-            ordered_dates.append(filed_date)
-            grouped[filed_date] = {}
-        grouped[filed_date][cusip] = {
+    return [
+        (period, filing[0])
+        for period, filing in sorted(
+            by_period.items(),
+            key=lambda item: (_sort_key(item[0]), _sort_key(item[1][1]), item[1][0]),
+            reverse=True,
+        )[:2]
+    ]
+
+
+def _fetch_holdings_for_filing(conn: Any, filing_id: int) -> dict[str, dict[str, Any]]:
+    ph = _placeholder(conn)
+    cursor = conn.execute(
+        f"""
+        SELECT h.cusip, h.shares, h.value_usd, h.name_of_issuer
+        FROM holdings h
+        WHERE h.filing_id = {ph}
+        ORDER BY h.cusip
+        """,
+        (filing_id,),
+    )
+    return {
+        cusip: {
             "shares": shares,
             "value_usd": value_usd,
             "name_of_issuer": name_of_issuer,
         }
+        for cusip, shares, value_usd, name_of_issuer in cursor
+    }
 
-    if not ordered_dates:
+
+def _fetch_latest_sets(
+    manager_id: int, conn: Any
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Fetch holdings keyed by CUSIP for the latest two authoritative periods.
+
+    Returns ``(current, prior)`` where each is
+    ``{cusip: {"shares": int|None, "value_usd": float|None, "name_of_issuer": str|None}}``.
+    """
+    authoritative = _select_authoritative_filings(manager_id, conn)
+    if not authoritative:
         raise SystemExit("Manager not found or has no filings")
-    if len(ordered_dates) < 2:
+    if len(authoritative) < 2:
         raise SystemExit("Need at least two filings to compute a diff")
-    return grouped[ordered_dates[0]], grouped[ordered_dates[1]]
+    current_filing_id = authoritative[0][1]
+    prior_filing_id = authoritative[1][1]
+    return _fetch_holdings_for_filing(conn, current_filing_id), _fetch_holdings_for_filing(
+        conn, prior_filing_id
+    )
 
 
 def _resolve_manager_id(identifier: int | str, conn: Any) -> int:

--- a/diff_holdings.py
+++ b/diff_holdings.py
@@ -46,9 +46,9 @@ def _select_authoritative_filings(manager_id: int, conn: Any) -> list[tuple[Any,
 
     by_period: dict[Any, tuple[int, Any, Any]] = {}
     for filing_id, period_key, filed_date, filing_type in cursor:
-        period = period_key or filed_date
-        if period is None:
+        if period_key is None:
             continue
+        period = period_key
         candidate = (int(filing_id), filed_date, filing_type)
         existing = by_period.get(period)
         if existing is None:

--- a/tests/test_diff_holdings.py
+++ b/tests/test_diff_holdings.py
@@ -230,29 +230,159 @@ def test_fetch_latest_sets_only_returns_top_two_dates():
     assert "AAA" in latest and "AAA" in prior
 
 
+def test_fetch_latest_sets_reconciles_13f_amendments_before_diffing(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT, cik TEXT UNIQUE)"
+    )
+    conn.execute(
+        "CREATE TABLE filings ("
+        "filing_id INTEGER PRIMARY KEY, manager_id INTEGER, type TEXT, "
+        "period_end TEXT, filed_date TEXT, source TEXT, raw_key TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE holdings ("
+        "holding_id INTEGER PRIMARY KEY AUTOINCREMENT, filing_id INTEGER, "
+        "cusip TEXT, name_of_issuer TEXT, shares INTEGER, value_usd REAL)"
+    )
+    conn.execute("INSERT INTO managers(manager_id, name, cik) VALUES (1, 'TestFund', '0000000000')")
+    conn.executemany(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (101, 1, "13F-HR", "2024-03-31", "2024-04-15", "edgar"),
+            (102, 1, "13F-HR/A", "2024-03-31", "2024-04-20", "edgar"),
+            (201, 1, "13F-HR", "2023-12-31", "2024-01-15", "edgar"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            (101, "AAA", "CorpA", 100, 1000),
+            (101, "BBB", "CorpB", 50, 500),
+            (102, "AAA", "CorpA", 130, 1300),
+            (102, "CCC", "CorpC", 10, 100),
+            (201, "AAA", "CorpA", 90, 900),
+            (201, "DDD", "CorpD", 5, 50),
+        ],
+    )
+
+    rows = diff_holdings(1, conn).deltas
+
+    assert rows == [
+        {
+            "cusip": "AAA",
+            "name_of_issuer": "CorpA",
+            "delta_type": "INCREASE",
+            "shares_prev": 90,
+            "shares_curr": 130,
+            "value_prev": 900,
+            "value_curr": 1300,
+        },
+        {
+            "cusip": "CCC",
+            "name_of_issuer": "CorpC",
+            "delta_type": "ADD",
+            "shares_prev": None,
+            "shares_curr": 10,
+            "value_prev": None,
+            "value_curr": 100,
+        },
+        {
+            "cusip": "DDD",
+            "name_of_issuer": "CorpD",
+            "delta_type": "EXIT",
+            "shares_prev": 5,
+            "shares_curr": None,
+            "value_prev": 50,
+            "value_curr": None,
+        },
+    ]
+
+    def disable_supersede(_manager_id, _conn):
+        return [("2024-03-31 amended", 102), ("2024-03-31 original", 101)]
+
+    monkeypatch.setattr(diff_holdings_module, "_select_authoritative_filings", disable_supersede)
+    broken_rows = diff_holdings(1, conn).deltas
+    conn.close()
+
+    assert broken_rows == [
+        {
+            "cusip": "AAA",
+            "name_of_issuer": "CorpA",
+            "delta_type": "INCREASE",
+            "shares_prev": 100,
+            "shares_curr": 130,
+            "value_prev": 1000,
+            "value_curr": 1300,
+        },
+        {
+            "cusip": "BBB",
+            "name_of_issuer": "CorpB",
+            "delta_type": "EXIT",
+            "shares_prev": 50,
+            "shares_curr": None,
+            "value_prev": 500,
+            "value_curr": None,
+        },
+        {
+            "cusip": "CCC",
+            "name_of_issuer": "CorpC",
+            "delta_type": "ADD",
+            "shares_prev": None,
+            "shares_curr": 10,
+            "value_prev": None,
+            "value_curr": 100,
+        },
+    ]
+
+
 def test_fetch_latest_sets_uses_postgres_placeholders():
     """Non-sqlite3 connections should produce %s placeholders."""
+
+    class FakeCursor:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def __iter__(self):
+            return iter(self.rows)
+
+        def fetchall(self):
+            return self.rows
 
     class FakePostgresConn:
         def __init__(self):
             self.sql = ""
             self.params: tuple[int, ...] | None = None
+            self.calls: list[tuple[str, tuple[int, ...]]] = []
 
         def execute(self, sql, params):
             self.sql = sql
             self.params = params
-            return iter(
+            self.calls.append((sql, params))
+            if "information_schema.columns" in sql:
+                return FakeCursor(
+                    [(column,) for column in {"filing_id", "manager_id", "type", "filed_date"}]
+                )
+            if "FROM filings" in sql:
+                return FakeCursor(
+                    [
+                        (101, "2024-04-01", "2024-04-01", "13F-HR"),
+                        (102, "2024-01-01", "2024-01-01", "13F-HR"),
+                    ]
+                )
+            return FakeCursor(
                 [
-                    ("2024-04-01", "AAA", 110, 1100, "CorpA"),
-                    ("2024-01-01", "AAA", 100, 1000, "CorpA"),
+                    ("AAA", 110, 1100, "CorpA"),
+                    ("AAA", 100, 1000, "CorpA"),
                 ]
             )
 
     conn = FakePostgresConn()
     _fetch_latest_sets(7, conn)
-    assert "%s" in conn.sql
-    assert "?" not in conn.sql
-    assert conn.params == (7,)
+    assert all("?" not in sql for sql, _params in conn.calls)
+    assert any("%s" in sql and params == (7,) for sql, params in conn.calls)
 
 
 def test_diff_holdings_uses_default_connect_db_when_conn_missing(monkeypatch):

--- a/tests/test_diff_holdings.py
+++ b/tests/test_diff_holdings.py
@@ -389,6 +389,63 @@ def test_fetch_latest_sets_ignores_missing_period_end_when_period_column_exists(
     ]
 
 
+def test_fetch_latest_sets_ignores_filings_without_holdings():
+    conn = _setup_canonical_db()
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, filed_date, source) "
+        "VALUES (103, 1, '13F-HR', '2024-07-01', 'edgar')"
+    )
+
+    latest, prior = _fetch_latest_sets(1, conn)
+    conn.close()
+
+    assert "AAA" in latest and "AAA" in prior
+    assert latest["AAA"]["shares"] == 120
+    assert prior["AAA"]["shares"] == 100
+
+
+def test_fetch_latest_sets_prefers_latest_filed_date_before_amendment_tie_breaker():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT, cik TEXT UNIQUE)"
+    )
+    conn.execute(
+        "CREATE TABLE filings ("
+        "filing_id INTEGER PRIMARY KEY, manager_id INTEGER, type TEXT, "
+        "period_end TEXT, filed_date TEXT, source TEXT, raw_key TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE holdings ("
+        "holding_id INTEGER PRIMARY KEY AUTOINCREMENT, filing_id INTEGER, "
+        "cusip TEXT, name_of_issuer TEXT, shares INTEGER, value_usd REAL)"
+    )
+    conn.execute("INSERT INTO managers(manager_id, name, cik) VALUES (1, 'TestFund', '0000000000')")
+    conn.executemany(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (101, 1, "13F-HR/A", "2024-03-31", "2024-04-15", "edgar"),
+            (102, 1, "13F-HR", "2024-03-31", "2024-04-20", "edgar"),
+            (103, 1, "13F-HR", "2023-12-31", "2024-01-15", "edgar"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            (101, "AAA", "CorpA", 130, 1300),
+            (102, "AAA", "CorpA", 140, 1400),
+            (103, "AAA", "CorpA", 90, 900),
+        ],
+    )
+
+    latest, prior = _fetch_latest_sets(1, conn)
+    conn.close()
+
+    assert latest["AAA"]["shares"] == 140
+    assert prior["AAA"]["shares"] == 90
+
+
 def test_fetch_latest_sets_uses_postgres_placeholders():
     """Non-sqlite3 connections should produce %s placeholders."""
 

--- a/tests/test_diff_holdings.py
+++ b/tests/test_diff_holdings.py
@@ -338,6 +338,57 @@ def test_fetch_latest_sets_reconciles_13f_amendments_before_diffing(monkeypatch)
     ]
 
 
+def test_fetch_latest_sets_ignores_missing_period_end_when_period_column_exists():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT, cik TEXT UNIQUE)"
+    )
+    conn.execute(
+        "CREATE TABLE filings ("
+        "filing_id INTEGER PRIMARY KEY, manager_id INTEGER, type TEXT, "
+        "period_end TEXT, filed_date TEXT, source TEXT, raw_key TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE holdings ("
+        "holding_id INTEGER PRIMARY KEY AUTOINCREMENT, filing_id INTEGER, "
+        "cusip TEXT, name_of_issuer TEXT, shares INTEGER, value_usd REAL)"
+    )
+    conn.execute("INSERT INTO managers(manager_id, name, cik) VALUES (1, 'TestFund', '0000000000')")
+    conn.executemany(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (101, 1, "13F-HR", None, "2024-04-15", "legacy"),
+            (102, 1, "13F-HR/A", "2024-03-31", "2024-04-20", "edgar"),
+            (201, 1, "13F-HR", "2023-12-31", "2024-01-15", "edgar"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            (101, "BBB", "CorpB", 50, 500),
+            (102, "AAA", "CorpA", 130, 1300),
+            (201, "AAA", "CorpA", 90, 900),
+        ],
+    )
+
+    rows = diff_holdings(1, conn).deltas
+    conn.close()
+
+    assert rows == [
+        {
+            "cusip": "AAA",
+            "name_of_issuer": "CorpA",
+            "delta_type": "INCREASE",
+            "shares_prev": 90,
+            "shares_curr": 130,
+            "value_prev": 900,
+            "value_curr": 1300,
+        }
+    ]
+
+
 def test_fetch_latest_sets_uses_postgres_placeholders():
     """Non-sqlite3 connections should produce %s placeholders."""
 


### PR DESCRIPTION
Closes #1324

## Summary
- select one authoritative filing per manager reporting period before holdings diffs
- prefer amended 13F filings while preserving raw original/amended filings for provenance
- add regression coverage, including a deliberate-break selector that reproduces the old double-count behavior

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache-manager-1324 python -m pytest tests/test_diff_holdings.py -q
- python -m ruff check diff_holdings.py tests/test_diff_holdings.py
- python -m black --target-version py312 --check diff_holdings.py tests/test_diff_holdings.py
- PYTHONPYCACHEPREFIX=/tmp/pycache-manager-1324-mypy python -m mypy diff_holdings.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved holdings comparison to use the latest authoritative filing for each period, including amended filings, before calculating changes.
  * Updated period selection to handle either reported period end dates or filing dates when needed.
  * Fixed comparison behavior so the latest and prior holdings are chosen more accurately for each manager.

* **Tests**
  * Added regression coverage for amendment-aware holdings diffs.
  * Strengthened database/query test coverage for more realistic SQL execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->