### PR TITLE
Gemini bootstrap for #1324

### DIFF
--- a/agents/gemini-1324.md
+++ b/agents/gemini-1324.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for gemini on issue #1324 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1324 -->

### Source Issue #1324: [Audit][R4] Add 13F amendment (/A) reconciliation as an explicit tested stage

Base: main
Head: gemini/issue-1324

Source: https://github.com/stranske/Manager-Database/issues/1324

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
13F filings are amended (`13F-HR/A`), and the field standard is to **reconcile** them — keep the most recent filing per manager-quarter and supersede `13F-HR` with its `13F-HR/A` — so diffs and large-delta alerts don't double-count. MDB **ingests** amendments (`adapters/edgar.py: THIRTEEN_F_FORMS = {"13F-HR", "13F-HR/A", "13-F"}`) but there is **no reconciliation logic** (verified: no latest-per-quarter/supersede handling at `e5764a5`). So raw filings — including amendments — flow into the diff, which both noises the alerts and **compounds the duplicate-holdings idempotency bug #1298**.

#### Tasks
- [ ] Add a reconciliation step (in the ingest/diff path) that, per (manager_id, period), selects the latest filing and treats `13F-HR/A` as superseding the matching `13F-HR`; mark superseded filings so downstream diff/alerts use only the authoritative set.
- [ ] Ensure the daily diff and large-delta alerts read the reconciled set, not raw filings.

#### Acceptance Criteria
- [ ] **Test:** ingest a `13F-HR` then a `13F-HR/A` for the same manager-quarter with changed holdings; assert the diff/alerts reflect the amended holdings once (not both filings double-counted). Current code double-counts.
- [ ] Superseded filings remain queryable (provenance preserved) but are excluded from diffs/alerts.
- [ ] **Deliberate-break demonstration:** disabling the supersede step reproduces the double-count in the test; restoring it passes.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

13F filings are amended (`13F-HR/A`), and the field standard is to **reconcile** them — keep the most recent filing per manager-quarter and supersede `13F-HR` with its `13F-HR/A` — so diffs and large-delta alerts don't double-count. MDB **ingests** amendments (`adapters/edgar.py: THIRTEEN_F_FORMS = {"13F-HR", "13F-HR/A", "13-F"}`) but there is **no reconciliation logic** (verified: no latest-per-quarter/supersede handling at `e5764a5`). So raw filings — including amendments — flow into the diff, which both noises the alerts and **compounds the duplicate-holdings idempotency bug #1298**.

## Scope

Add an explicit, tested amendment-reconciliation stage that resolves to one authoritative holdings set per (manager, quarter) before diffing/alerting.

## Non-Goals

- Do NOT discard amendments — they supersede, not delete; keep provenance.
- Do NOT change the alert thresholds themselves (separate concern).
- Coordinate with #1298 (idempotent holdings) — reconciliation assumes stable filing identity.

## Tasks

- [ ] Add a reconciliation step (in the ingest/diff path) that, per (manager_id, period), selects the latest filing and treats `13F-HR/A` as superseding the matching `13F-HR`; mark superseded filings so downstream diff/alerts use only the authoritative set.
- [ ] Ensure the daily diff and large-delta alerts read the reconciled set, not raw filings.

## Acceptance Criteria

- [ ] **Test:** ingest a `13F-HR` then a `13F-HR/A` for the same manager-quarter with changed holdings; assert the diff/alerts reflect the amended holdings once (not both filings double-counted). Current code double-counts.
- [ ] Superseded filings remain queryable (provenance preserved) but are excluded from diffs/alerts.
- [ ] **Deliberate-break demonstration:** disabling the supersede step reproduces the double-count in the test; restoring it passes.

## Implementation Notes

Audit baseline `e5764a5`. Verified: `adapters/edgar.py:22` form set includes `13F-HR/A` but no reconciliation exists. Refs: WhaleWisdom amendment/split handling. Part of the expansion roadmap (R4); best done after R3 (edgartools) and alongside #1298. dim-5/6 "amendment reconciliation" gap.


_Part of epic #1320._



</details>

—
PR created automatically to engage Gemini.