### PR TITLE
Consolidate dependency install sources

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -238,7 +238,7 @@ jobs:
         if: steps.check_enabled.outputs.enabled == 'true'
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          python -m pip install -e ".[dev]"
           pip install -r tools/requirements-llm.txt
 
       - name: Initialize auto-pilot metrics logs

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -147,7 +147,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          python -m pip install -e ".[dev]"
           # Install langchain dependencies
           pip install langchain langchain-core langchain-openai \
             langchain-anthropic langchain-community

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python -m pip install -e ".[dev]"
       - name: Start services
         run: docker compose up -d
       - name: Run nightly tests

--- a/README_bootstrap.md
+++ b/README_bootstrap.md
@@ -61,7 +61,7 @@ Feel free to open issues or pull requests as you iterate.
 
 1. Ensure Python 3.12 is available via `pyenv` and install dependencies:
    ```bash
-   python -m pip install -r requirements.txt
+   python -m pip install -e ".[dev]"
    ```
 2. Trigger the sample EDGAR flow:
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# Legacy compatibility list only.
+# Active CI and bootstrap installs use pyproject.toml via:
+#   python -m pip install -e ".[dev]"
+# Keep requirements.lock as the generated dependency snapshot guarded by tests.
 pytest
 edgartools>=4.6,<5.0
 httpx

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 
@@ -11,7 +12,29 @@ _ACTIVE_INSTALL_SOURCE_GLOBS = (
     "README*.md",
     "docs/**/*.md",
 )
-_STALE_REQUIREMENTS_INSTALL = "pip install -r requirements.txt"
+_STALE_REQUIREMENTS_INSTALL = re.compile(r"\bpip\s+install\s+-r\s+(?:\./)?requirements\.txt\b")
+
+
+def _logical_lines(text: str) -> list[tuple[int, str]]:
+    lines: list[tuple[int, str]] = []
+    start_line = 1
+    current: list[str] = []
+
+    for line_number, raw_line in enumerate(text.splitlines(), 1):
+        stripped = raw_line.rstrip()
+        if not current:
+            start_line = line_number
+        if stripped.endswith("\\"):
+            current.append(stripped[:-1])
+            continue
+        current.append(stripped)
+        lines.append((start_line, re.sub(r"\s+", " ", " ".join(current)).strip()))
+        current = []
+
+    if current:
+        lines.append((start_line, re.sub(r"\s+", " ", " ".join(current)).strip()))
+
+    return lines
 
 
 def _split_spec(raw: str) -> str:
@@ -91,11 +114,27 @@ def test_active_install_instructions_do_not_use_legacy_requirements_txt() -> Non
         for path in Path(".").glob(pattern):
             if not path.is_file():
                 continue
-            for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-                if _STALE_REQUIREMENTS_INSTALL in line:
+            for line_number, line in _logical_lines(path.read_text(encoding="utf-8")):
+                if _STALE_REQUIREMENTS_INSTALL.search(line):
                     offenders.append(f"{path}:{line_number}")
 
     assert not offenders, (
         "Active workflows/docs must install from pyproject.toml, not legacy "
         f"requirements.txt: {', '.join(offenders)}"
     )
+
+
+def test_legacy_requirements_install_scan_handles_shell_variants() -> None:
+    logical_lines = _logical_lines("""
+python -m pip install \\
+  -r ./requirements.txt
+python -m pip install -r tools/requirements-llm.txt
+""".strip())
+
+    matches = [
+        line_number
+        for line_number, line in logical_lines
+        if _STALE_REQUIREMENTS_INSTALL.search(line)
+    ]
+
+    assert matches == [1]

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -6,6 +6,12 @@ import tomllib
 from pathlib import Path
 
 _OPERATORS = ("==", ">=", "<=", "~=", "!=", ">", "<", "===")
+_ACTIVE_INSTALL_SOURCE_GLOBS = (
+    ".github/workflows/*.yml",
+    "README*.md",
+    "docs/**/*.md",
+)
+_STALE_REQUIREMENTS_INSTALL = "pip install -r requirements.txt"
 
 
 def _split_spec(raw: str) -> str:
@@ -76,3 +82,20 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
             missing.append(dependency)
 
     assert not missing, "requirements.lock is missing pinned versions for: " + ", ".join(missing)
+
+
+def test_active_install_instructions_do_not_use_legacy_requirements_txt() -> None:
+    offenders: list[str] = []
+
+    for pattern in _ACTIVE_INSTALL_SOURCE_GLOBS:
+        for path in Path(".").glob(pattern):
+            if not path.is_file():
+                continue
+            for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if _STALE_REQUIREMENTS_INSTALL in line:
+                    offenders.append(f"{path}:{line_number}")
+
+    assert not offenders, (
+        "Active workflows/docs must install from pyproject.toml, not legacy "
+        f"requirements.txt: {', '.join(offenders)}"
+    )


### PR DESCRIPTION
Closes #1278

## Summary
- switch active CI/bootstrap installs from requirements.txt to the package metadata dev install
- mark requirements.txt as legacy compatibility documentation
- add a dependency-source drift test that fails if active workflows/docs reinstall from requirements.txt

## Validation
- python -m pytest tests/test_dependency_version_alignment.py -q
- deliberate break: temporarily restored .github/workflows/nightly.yml to pip install -r requirements.txt and confirmed the new test failed naming .github/workflows/nightly.yml:18, then reverted
- rg -n "pip install -r requirements\.txt" .github README*.md docs
- /tmp/pd-opener-manager-1278.FtU0rs/venv/bin/python -m pip install -e ".[dev]"
- /tmp/pd-opener-manager-1278.FtU0rs/venv/bin/python - <<'PY'
import alembic
import feedparser
import jsonschema
import pdfplumber
print('imports-ok')
PY
- python -m ruff check tests/test_dependency_version_alignment.py
- python -m black --check tests/test_dependency_version_alignment.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated setup instructions and automation to install the project in editable mode with development extras.

* **Tests**
  * Added a check to prevent active documentation and workflow files from using the older dependency installation command.

* **Documentation**
  * Refreshed setup guidance to match the current installation approach.

* **Chores**
  * Clarified compatibility notes in dependency-related guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->