### PR TITLE
Codex bootstrap for #1278

### DIFF
--- a/agents/codex-1278.md
+++ b/agents/codex-1278.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1278 -->


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1278 -->

### Source Issue #1278: [Audit] Consolidate dependency install sources for nightly and bootstrap

Base: main
Head: codex/issue-1278

Source: https://github.com/stranske/Manager-Database/issues/1278

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is a **current bootstrap/test fragility**. Runtime dependencies are declared in `pyproject.toml`, including `alembic`, `feedparser`, `jsonschema`, and `pdfplumber` (`pyproject.toml:10`, `pyproject.toml:11`, `pyproject.toml:13`, `pyproject.toml:15`, `pyproject.toml:27`). They are present in `requirements.lock` (`requirements.lock:5`, `requirements.lock:140`, `requirements.lock:225`, `requirements.lock:330`) but absent from `requirements.txt:1-26`. The nightly workflow installs from `requirements.txt` (`.github/workflows/nightly.yml:15`, `.github/workflows/nightly.yml:18`) and the bootstrap docs instruct ETL users to do the same (`README_bootstrap.md:59`, `README_bootstrap.md:61`). Missing behavior: every documented/CI install path must install the same runtime dependencies that tests and app modules import.

#### Tasks
- [ ] In `.github/workflows/nightly.yml:15-22`, replace `pip install -r requirements.txt` with the repo's supported install command, such as `python -m pip install -e ".[dev]"` or an equivalent lockfile sync command.
- [ ] In `README_bootstrap.md:59-62`, replace the stale `python -m pip install -r requirements.txt` instruction with the same supported install command used by CI.
- [ ] Either update `requirements.txt:1-26` from `pyproject.toml`/`requirements.lock` with a documented generation command or mark it as legacy and remove it from active workflows/docs.
- [ ] Add a drift guard in `tests/test_dependency_version_alignment.py` that fails when `.github/workflows/*.yml` or `README*.md` instructs users to install active test/runtime paths from an unsynchronized `requirements.txt`.
- [ ] Verify that imports for `alembic`, `feedparser`, `jsonschema`, and `pdfplumber` resolve under the documented install path.

#### Acceptance Criteria
- [ ] Named test passes: `python -m pytest tests/test_dependency_version_alignment.py -q`, including a new assertion that active workflows/docs no longer depend on stale `requirements.txt`.
- [ ] **Deliberate-break gate:** temporarily restore `.github/workflows/nightly.yml:18` to `pip install -r requirements.txt`. The new dependency-source drift test must FAIL and name `.github/workflows/nightly.yml`. Revert the break before review.
- [ ] `rg -n "pip install -r requirements.txt" .github README*.md docs` returns no active install instruction unless it is explicitly documented as legacy/non-authoritative.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is a **current bootstrap/test fragility**. Runtime dependencies are declared in `pyproject.toml`, including `alembic`, `feedparser`, `jsonschema`, and `pdfplumber` (`pyproject.toml:10`, `pyproject.toml:11`, `pyproject.toml:13`, `pyproject.toml:15`, `pyproject.toml:27`). They are present in `requirements.lock` (`requirements.lock:5`, `requirements.lock:140`, `requirements.lock:225`, `requirements.lock:330`) but absent from `requirements.txt:1-26`. The nightly workflow installs from `requirements.txt` (`.github/workflows/nightly.yml:15`, `.github/workflows/nightly.yml:18`) and the bootstrap docs instruct ETL users to do the same (`README_bootstrap.md:59`, `README_bootstrap.md:61`). Missing behavior: every documented/CI install path must install the same runtime dependencies that tests and app modules import.

## Scope

Remove or eliminate reliance on stale `requirements.txt` for CI/docs, or make it generated and validated against `pyproject.toml`. Prefer the repo's package metadata and lockfile as the source of truth.

## Non-Goals

- Do NOT hand-edit a one-off dependency list without adding a drift guard.
- Do NOT change unrelated model/provider credentials or external service setup.
- Do NOT remove `requirements.lock`; `tests/test_dependency_version_alignment.py:46-78` already guards the lockfile.
- Scaffold-only completion does NOT count: adding `pdfplumber` alone while leaving nightly/bootstrap pointed at a drifting dependency source is a failure of this issue.

## Tasks

- [ ] In `.github/workflows/nightly.yml:15-22`, replace `pip install -r requirements.txt` with the repo's supported install command, such as `python -m pip install -e ".[dev]"` or an equivalent lockfile sync command.
- [ ] In `README_bootstrap.md:59-62`, replace the stale `python -m pip install -r requirements.txt` instruction with the same supported install command used by CI.
- [ ] Either update `requirements.txt:1-26` from `pyproject.toml`/`requirements.lock` with a documented generation command or mark it as legacy and remove it from active workflows/docs.
- [ ] Add a drift guard in `tests/test_dependency_version_alignment.py` that fails when `.github/workflows/*.yml` or `README*.md` instructs users to install active test/runtime paths from an unsynchronized `requirements.txt`.
- [ ] Verify that imports for `alembic`, `feedparser`, `jsonschema`, and `pdfplumber` resolve under the documented install path.

## Acceptance Criteria

- [ ] Named test passes: `python -m pytest tests/test_dependency_version_alignment.py -q`, including a new assertion that active workflows/docs no longer depend on stale `requirements.txt`.
- [ ] **Deliberate-break gate:** temporarily restore `.github/workflows/nightly.yml:18` to `pip install -r requirements.txt`. The new dependency-source drift test must FAIL and name `.github/workflows/nightly.yml`. Revert the break before review.
- [ ] `rg -n "pip install -r requirements.txt" .github README*.md docs` returns no active install instruction unless it is explicitly documented as legacy/non-authoritative.

## Implementation Notes

Audit baseline: `main` at `e7e8f06a9658dbb7106da1fc3c128ecfd836c573` on 2026-06-28.

Confirmed current reproduction: in the audit environment, full `python -m pytest -q` failed `tests/test_upload.py` because `pdfplumber` was not installed in the active environment.



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new introductory note at the top of an existing markdown file to support issue-related guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->