### PR TITLE
Repair dependency setup validator drift

### DIFF
--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -131,7 +131,7 @@ if [ "$all_ok" = true ]; then
     echo -e "${GREEN}All required dependencies are available!${NC}"
     echo ""
     echo "You can run the full test suite with:"
-    echo "  ./scripts/run_tests.sh"
+    echo "  python -m pytest"
     exit 0
 else
     echo -e "${RED}Some required dependencies are missing!${NC}"

--- a/scripts/validate_dependency_test_setup.py
+++ b/scripts/validate_dependency_test_setup.py
@@ -11,6 +11,7 @@ Run this script to verify:
 
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 
@@ -19,44 +20,43 @@ def check_lock_file_completeness() -> tuple[bool, list[str]]:
     issues = []
 
     # Read pyproject.toml to get all optional groups
-    pyproject = Path("pyproject.toml").read_text()
-
-    # Extract optional dependency groups
-    optional_section = re.search(
-        r"\[project\.optional-dependencies\](.*?)(?=\n\[|\Z)", pyproject, re.DOTALL
-    )
-    if not optional_section:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    optional_dependencies = pyproject.get("project", {}).get("optional-dependencies", {})
+    if not optional_dependencies:
         issues.append("No [project.optional-dependencies] section found")
         return False, issues
 
-    optional_groups = re.findall(r"^(\w+)\s*=", optional_section.group(1), re.MULTILINE)
+    optional_groups = sorted(optional_dependencies)
     print(f"✓ Found optional dependency groups: {', '.join(optional_groups)}")
 
-    # Check dependabot-auto-lock.yml includes all extras
-    workflow_path = Path(".github/workflows/dependabot-auto-lock.yml")
+    # Check the current Dependabot lock workflow includes all non-empty extras.
+    workflow_path = Path(".github/workflows/maint-dependabot-auto-lock.yml")
     if workflow_path.exists():
-        workflow = workflow_path.read_text()
+        workflow = workflow_path.read_text(encoding="utf-8")
         for group in optional_groups:
+            if not optional_dependencies[group]:
+                continue
             if f"--extra {group}" not in workflow:
-                issues.append(f"dependabot-auto-lock.yml missing --extra {group}")
+                issues.append(f"{workflow_path.name} missing --extra {group}")
 
         if not issues:
-            print("✓ dependabot-auto-lock.yml includes all extras")
+            print(f"✓ {workflow_path.name} includes all non-empty extras")
     else:
-        issues.append("dependabot-auto-lock.yml not found")
+        issues.append(f"{workflow_path.name} not found")
 
     return len(issues) == 0, issues
 
 
 def check_for_hardcoded_versions() -> tuple[bool, list[str]]:
-    """Check for hardcoded version numbers in tests."""
+    """Check for hardcoded dependency version pins in tests."""
     issues = []
     test_files = list(Path("tests").rglob("*.py"))
 
-    # Patterns that indicate hardcoded versions
+    # Patterns that indicate package version pins, not ordinary numeric
+    # assertions such as score == 1.0 or threshold == 25.0.
     version_patterns = [
-        r'==\s*["\']?\d+\.\d+',  # == version
-        r'assert.*version.*==.*["\d]',  # assert version == "x.y"
+        r'["\'][A-Za-z0-9_.-]+==\d+\.\d+',
+        r'assert.*(?:package|dependency|requirement|version).*==.*["\'][A-Za-z0-9_.-]+==\d+\.\d+',
     ]
 
     problematic_files = []
@@ -79,49 +79,30 @@ def check_for_hardcoded_versions() -> tuple[bool, list[str]]:
                         problematic_files.append((test_file, i + 1, line.strip()))
 
     if problematic_files:
-        issues.append("Found potential hardcoded versions in tests:")
+        issues.append("Found potential hardcoded dependency version pins in tests:")
         for file, line_no, line in problematic_files:
             issues.append(f"  {file}:{line_no}: {line[:80]}")
     else:
-        print("✓ No hardcoded version numbers found in tests")
+        print("✓ No hardcoded dependency version pins found in tests")
 
     return len(issues) == 0, issues
 
 
-def check_metadata_serialization() -> tuple[bool, list[str]]:
-    """Check that metadata is properly serialized to dicts, not Pydantic objects."""
+def check_dependency_script_recommendations() -> tuple[bool, list[str]]:
+    """Check that dependency helper output references existing repo commands."""
     issues = []
+    helper_path = Path("scripts/check_test_dependencies.sh")
+    if not helper_path.exists():
+        return False, ["scripts/check_test_dependencies.sh not found"]
 
-    # Check validators.py returns dict
-    validators_path = Path("src/trend_analysis/io/validators.py")
-    if validators_path.exists():
-        content = validators_path.read_text()
+    content = helper_path.read_text(encoding="utf-8")
+    recommended_script_paths = sorted(set(re.findall(r"\./(scripts/[A-Za-z0-9_./-]+)", content)))
+    for script_path in recommended_script_paths:
+        if not Path(script_path).is_file():
+            issues.append(f"{helper_path}: recommended script path does not exist: {script_path}")
 
-        # Look for load_and_validate_upload function
-        if "validated.metadata.model_dump(mode=" in content:
-            print("✓ load_and_validate_upload serializes metadata to dict")
-        else:
-            issues.append("load_and_validate_upload may not be serializing metadata properly")
-
-    # Check attach_metadata serializes
-    market_data_path = Path("src/trend_analysis/io/market_data.py")
-    if market_data_path.exists():
-        content = market_data_path.read_text()
-
-        if "metadata.model_dump(mode=" in content:
-            print("✓ attach_metadata serializes metadata to dict")
-        else:
-            issues.append("attach_metadata may not be serializing metadata properly")
-
-    # Check data_schema.py serializes
-    data_schema_path = Path("streamlit_app/components/data_schema.py")
-    if data_schema_path.exists():
-        content = data_schema_path.read_text()
-
-        if "metadata.model_dump(mode=" in content:
-            print("✓ _build_meta serializes metadata to dict")
-        else:
-            issues.append("_build_meta may not be serializing metadata properly")
+    if not issues:
+        print("✓ Dependency helper recommendations reference existing script paths")
 
     return len(issues) == 0, issues
 
@@ -168,7 +149,7 @@ def main():
     checks = [
         ("Lock file completeness", check_lock_file_completeness),
         ("Hardcoded versions", check_for_hardcoded_versions),
-        ("Metadata serialization", check_metadata_serialization),
+        ("Dependency helper recommendations", check_dependency_script_recommendations),
         ("Test expectations", check_test_expectations),
     ]
 

--- a/scripts/validate_dependency_test_setup.py
+++ b/scripts/validate_dependency_test_setup.py
@@ -20,7 +20,15 @@ def check_lock_file_completeness() -> tuple[bool, list[str]]:
     issues = []
 
     # Read pyproject.toml to get all optional groups
-    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    pyproject_path = Path("pyproject.toml")
+    try:
+        pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        issues.append(f"{pyproject_path} not found")
+        return False, issues
+    except tomllib.TOMLDecodeError as exc:
+        issues.append(f"{pyproject_path} could not be parsed: {exc}")
+        return False, issues
     optional_dependencies = pyproject.get("project", {}).get("optional-dependencies", {})
     if not optional_dependencies:
         issues.append("No [project.optional-dependencies] section found")

--- a/tests/test_validate_dependency_test_setup.py
+++ b/tests/test_validate_dependency_test_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -27,10 +28,9 @@ def test_check_test_dependencies_recommends_existing_commands() -> None:
     helper = Path("scripts/check_test_dependencies.sh").read_text(encoding="utf-8")
 
     assert "./scripts/run_tests.sh" not in helper
+    assert "python -m pytest" in helper
 
-    recommended_script_paths = {
-        line.split("./", 1)[1].strip() for line in helper.splitlines() if "./scripts/" in line
-    }
+    recommended_script_paths = set(re.findall(r"\./(scripts/[A-Za-z0-9_./-]+)", helper))
 
     missing = sorted(path for path in recommended_script_paths if not Path(path).is_file())
     assert not missing

--- a/tests/test_validate_dependency_test_setup.py
+++ b/tests/test_validate_dependency_test_setup.py
@@ -1,0 +1,80 @@
+"""Regression tests for the dependency setup validator."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_validator_uses_current_dependabot_lock_workflow() -> None:
+    validator = Path("scripts/validate_dependency_test_setup.py").read_text(encoding="utf-8")
+
+    assert ".github/workflows/maint-dependabot-auto-lock.yml" in validator
+    assert ".github/workflows/dependabot-auto-lock.yml" not in validator
+
+
+def test_validator_no_longer_checks_stale_trend_or_streamlit_paths() -> None:
+    validator = Path("scripts/validate_dependency_test_setup.py").read_text(encoding="utf-8")
+
+    assert "src/trend_analysis" not in validator
+    assert "streamlit_app" not in validator
+
+
+def test_check_test_dependencies_recommends_existing_commands() -> None:
+    helper = Path("scripts/check_test_dependencies.sh").read_text(encoding="utf-8")
+
+    assert "./scripts/run_tests.sh" not in helper
+
+    recommended_script_paths = {
+        line.split("./", 1)[1].strip() for line in helper.splitlines() if "./scripts/" in line
+    }
+
+    missing = sorted(path for path in recommended_script_paths if not Path(path).is_file())
+    assert not missing
+
+
+def test_validator_passes_on_current_repository() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/validate_dependency_test_setup.py"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert "maint-dependabot-auto-lock.yml includes all non-empty extras" in result.stdout
+
+
+def test_validator_fails_when_current_dependabot_workflow_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path
+    workflow_dir = repo / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (repo / "pyproject.toml").write_text(
+        """
+[project]
+name = "fixture"
+version = "0.1.0"
+
+[project.optional-dependencies]
+dev = ["pytest"]
+""".strip(),
+        encoding="utf-8",
+    )
+    (workflow_dir / "dependabot-auto-lock.yml").write_text(
+        "run: uv pip compile pyproject.toml --extra dev\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(repo)
+    import scripts.validate_dependency_test_setup as validator
+
+    passed, issues = validator.check_lock_file_completeness()
+
+    assert not passed
+    assert "maint-dependabot-auto-lock.yml not found" in issues


### PR DESCRIPTION
Closes #1284

## Summary
- Point the dependency setup validator at the current maint-dependabot auto-lock workflow and skip empty optional dependency groups.
- Replace stale Trend/Streamlit metadata path checks with a current check that dependency-helper recommendations reference existing scripts.
- Update the test dependency helper to recommend `python -m pytest` instead of the missing `scripts/run_tests.sh`.
- Add regression tests for the workflow filename, stale path removal, helper recommendations, validator pass behavior, and missing-current-workflow failure.

## Validation
- `python -m pytest tests/test_validate_dependency_test_setup.py -q`
- `python scripts/validate_dependency_test_setup.py`
- `bash scripts/check_test_dependencies.sh`
- `python -m ruff check scripts/validate_dependency_test_setup.py tests/test_validate_dependency_test_setup.py`
- `python -m black --check scripts/validate_dependency_test_setup.py tests/test_validate_dependency_test_setup.py`
- `git diff --check`
- Deliberate break: temporarily pointed the validator back to `.github/workflows/dependabot-auto-lock.yml`; `tests/test_validate_dependency_test_setup.py::test_validator_uses_current_dependabot_lock_workflow` failed, then the break was reverted.
