### PR TITLE
Consume shared PDF extraction baseline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,13 +135,6 @@ disable_error_code = ["attr-defined"]
 
 [[tool.mypy.overrides]]
 module = [
-    "stranske_pdf_extract",
-    "stranske_pdf_extract.*",
-]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = [
     "semantic_matcher",
     "label_matcher",
     "issue_dedup",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # Prefect requires newer FastAPI; avoid conflicting pin.
     "fastapi",
     "uvicorn",
-    "pdfplumber",
+    "stranske-pdf-extract[baseline] @ git+https://github.com/stranske/Workflows.git@a0ee3aa25c08d4eeb8e96dc6c8d7791930cd2d9a#subdirectory=packages/stranske_pdf_extract",
     "langchain>=1.2,<2.0",
     "langchain-core>=1.2,<2.0",
     "langchain-openai>=0.3,<2.0",
@@ -132,6 +132,13 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = ["tests.*"]
 disable_error_code = ["attr-defined"]
+
+[[tool.mypy.overrides]]
+module = [
+    "stranske_pdf_extract",
+    "stranske_pdf_extract.*",
+]
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/requirements.lock
+++ b/requirements.lock
@@ -350,7 +350,9 @@ pathspec==1.1.1
 pdfminer-six==20260107
     # via pdfplumber
 pdfplumber==0.11.10
-    # via manager-database (pyproject.toml)
+    # via stranske-pdf-extract
+pendulum==3.2.0 ; python_full_version < '3.13'
+    # via prefect
 pillow==12.3.0
     # via
     #   captcha
@@ -421,6 +423,8 @@ pygments==2.20.0
     #   rich-rst
 pyjwt==2.13.0
     # via streamlit-authenticator
+pypdf==6.14.2
+    # via stranske-pdf-extract
 pypdfium2==5.11.0
     # via pdfplumber
 pyrate-limiter==4.4.0
@@ -450,6 +454,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   dateparser
     #   pandas
+    #   pendulum
     #   prefect
 python-discovery==1.4.3
     # via virtualenv
@@ -572,6 +577,8 @@ starlette==1.3.1
     #   fastapi
     #   prefect
     #   streamlit
+stranske-pdf-extract @ git+https://github.com/stranske/Workflows.git@a0ee3aa25c08d4eeb8e96dc6c8d7791930cd2d9a#subdirectory=packages/stranske_pdf_extract
+    # via manager-database (pyproject.toml)
 streamlit==1.58.0
     # via
     #   manager-database (pyproject.toml)
@@ -611,7 +618,9 @@ typing-extensions==4.16.0
     #   alembic
     #   altair
     #   anthropic
+    #   anyio
     #   beautifulsoup4
+    #   exceptiongroup
     #   fastapi
     #   langchain-core
     #   langchain-protocol
@@ -620,12 +629,16 @@ typing-extensions==4.16.0
     #   openai
     #   opentelemetry-api
     #   prefect
+    #   psycopg
     #   py-key-value-aio
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
     #   pydocket
+    #   pytest-asyncio
+    #   referencing
     #   sqlalchemy
+    #   starlette
     #   streamlit
     #   typing-inspection
 typing-inspection==0.4.2
@@ -633,10 +646,11 @@ typing-inspection==0.4.2
     #   fastapi
     #   pydantic
     #   pydantic-settings
-tzdata==2026.2 ; sys_platform == 'emscripten' or sys_platform == 'win32'
+tzdata==2026.2 ; python_full_version < '3.13' or sys_platform == 'emscripten' or sys_platform == 'win32'
     # via
     #   apprise
     #   pandas
+    #   pendulum
     #   psycopg
     #   pydocket
     #   tzlocal
@@ -673,7 +687,7 @@ websockets==15.0.1
     #   langsmith
     #   prefect
     #   streamlit
-whenever==0.10.1
+whenever==0.10.1 ; python_full_version >= '3.13'
     # via prefect
 xxhash==3.8.0
     # via

--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -131,11 +131,7 @@ if [ "$all_ok" = true ]; then
     echo -e "${GREEN}All required dependencies are available!${NC}"
     echo ""
     echo "You can run the full test suite with:"
-    if [ -x ./scripts/run_tests.sh ]; then
-        echo "  ./scripts/run_tests.sh"
-    else
-        echo "  python -m pytest"
-    fi
+    echo "  python -m pytest"
     exit 0
 else
     echo -e "${RED}Some required dependencies are missing!${NC}"

--- a/tests/test_extract_pdf.py
+++ b/tests/test_extract_pdf.py
@@ -25,3 +25,34 @@ def test_extract_pdf_raises_on_empty_provider_result(monkeypatch):
 
     with pytest.raises(ValueError, match="Failed to extract PDF text"):
         extract_text(FIXTURE_PDF.read_bytes(), "sample.pdf")
+
+
+def test_extract_pdf_raises_on_whitespace_provider_result(monkeypatch):
+    class WhitespaceProvider:
+        def extract_modalities(self, _document_id, _file_bytes):
+            class Block:
+                text = "   \n\t"
+
+            class WhitespaceOutput:
+                text_blocks = [Block()]
+
+            return WhitespaceOutput()
+
+    monkeypatch.setattr("utils.extract.TextBaselineProvider", WhitespaceProvider)
+
+    with pytest.raises(ValueError, match="Failed to extract PDF text"):
+        extract_text(FIXTURE_PDF.read_bytes(), "sample.pdf")
+
+
+def test_extract_pdf_wraps_malformed_provider_output(monkeypatch):
+    class MalformedProvider:
+        def extract_modalities(self, _document_id, _file_bytes):
+            class MalformedOutput:
+                pass
+
+            return MalformedOutput()
+
+    monkeypatch.setattr("utils.extract.TextBaselineProvider", MalformedProvider)
+
+    with pytest.raises(ValueError, match="Failed to extract PDF text"):
+        extract_text(FIXTURE_PDF.read_bytes(), "sample.pdf")

--- a/tests/test_extract_pdf.py
+++ b/tests/test_extract_pdf.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import pytest
+
+from utils.extract import extract_text
+
+FIXTURE_PDF = Path(__file__).resolve().parent / "fixtures" / "sample.pdf"
+
+
+def test_extract_pdf_returns_text_from_native_pdf():
+    text = extract_text(FIXTURE_PDF.read_bytes(), "sample.pdf")
+
+    assert "Sample PDF fixture text for upload tests." in text
+
+
+def test_extract_pdf_raises_on_empty_provider_result(monkeypatch):
+    class EmptyProvider:
+        def extract_modalities(self, _document_id, _file_bytes):
+            class EmptyOutput:
+                text_blocks = []
+
+            return EmptyOutput()
+
+    monkeypatch.setattr("utils.extract.TextBaselineProvider", EmptyProvider)
+
+    with pytest.raises(ValueError, match="Failed to extract PDF text"):
+        extract_text(FIXTURE_PDF.read_bytes(), "sample.pdf")

--- a/utils/extract.py
+++ b/utils/extract.py
@@ -22,9 +22,9 @@ def _extract_pdf(file_bytes: bytes) -> str:
 
     try:
         output = TextBaselineProvider().extract_modalities("upload", file_bytes)
+        text = "\n\n".join(block.text.strip() for block in output.text_blocks if block.text.strip())
     except Exception as exc:
         raise ValueError("Failed to extract PDF text") from exc
-    text = "\n\n".join(block.text for block in output.text_blocks if block.text)
     if not text or text.lstrip().startswith("%PDF-"):
         raise ValueError("Failed to extract PDF text")
     return text

--- a/utils/extract.py
+++ b/utils/extract.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import io
+from stranske_pdf_extract.providers.text_baseline import TextBaselineProvider
 
 
 def extract_text(file_bytes: bytes, filename: str) -> str:
@@ -18,16 +18,13 @@ def extract_text(file_bytes: bytes, filename: str) -> str:
 
 
 def _extract_pdf(file_bytes: bytes) -> str:
-    """Extract text from PDF using pdfplumber."""
-    import pdfplumber
+    """Extract text from PDF using the shared baseline provider."""
 
-    text_parts: list[str] = []
     try:
-        with pdfplumber.open(io.BytesIO(file_bytes)) as pdf:
-            for page in pdf.pages:
-                page_text = page.extract_text()
-                if page_text:
-                    text_parts.append(page_text)
+        output = TextBaselineProvider().extract_modalities("upload", file_bytes)
     except Exception as exc:
         raise ValueError("Failed to extract PDF text") from exc
-    return "\n\n".join(text_parts)
+    text = "\n\n".join(block.text for block in output.text_blocks if block.text)
+    if not text or text.lstrip().startswith("%PDF-"):
+        raise ValueError("Failed to extract PDF text")
+    return text


### PR DESCRIPTION
Closes stranske/Workflows#2715.

## Summary
- Replace Manager-Database's private pdfplumber loop with stranske-pdf-extract TextBaselineProvider
- Add the pinned shared baseline dependency and refresh requirements.lock
- Add direct native-PDF extraction coverage plus empty/corrupt output guards

## Validation
- UV_CACHE_DIR=/tmp/uv-cache-manager-2715 PYTHONPYCACHEPREFIX=/tmp/pycache-manager-2715 uv run --extra dev pytest tests/test_uk_adapter.py tests/test_extract_pdf.py tests/test_upload.py::test_corrupted_pdf_raises_exception tests/test_upload.py::test_extract_text_corrupted_pdf_propagates_exception -q
- UV_CACHE_DIR=/tmp/uv-cache-manager-2715 uv run --extra dev ruff check utils/extract.py tests/test_extract_pdf.py pyproject.toml
- UV_CACHE_DIR=/tmp/uv-cache-manager-2715 uv run --extra dev black --check --target-version py312 utils/extract.py tests/test_extract_pdf.py
- UV_CACHE_DIR=/tmp/uv-cache-manager-2715 PYTHONPYCACHEPREFIX=/tmp/pycache-manager-2715 uv run --extra dev mypy utils/extract.py
- rg -n "import pdfplumber" utils/extract.py || true
- git diff --check

## Deliberate break
- Temporarily returned "" after TextBaselineProvider().extract_modalities(...); test_extract_pdf_returns_text_from_native_pdf failed as expected, proving the test catches loss of provider text output. The same break also showed why the final raw-PDF/empty-output guard is required for corrupt PDFs. Reverted before final validation.
