### PR TITLE
Codex bootstrap for #1398

### DIFF
--- a/agents/codex-1398.md
+++ b/agents/codex-1398.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1398 -->

--- a/etl/activism_detection.py
+++ b/etl/activism_detection.py
@@ -334,38 +334,6 @@ def detect_events(conn: Any, filing: Mapping[str, Any]) -> list[ActivismEvent]:
     return events
 
 
-def detect_events_batch(conn: Any, since: str) -> list[ActivismEvent]:
-    """Detect events for all activism filings since a given date."""
-    ensure_activism_events_table(conn)
-    ph = get_placeholder(conn)
-    rows = conn.execute(
-        "SELECT filing_id, manager_id, filing_type, subject_company, subject_cusip, "
-        "ownership_pct, group_members, filed_date "
-        f"FROM activism_filings WHERE filed_date >= {ph} "
-        "ORDER BY filed_date ASC, filing_id ASC",
-        (since,),
-    ).fetchall()
-
-    events: list[ActivismEvent] = []
-    for row in rows:
-        events.extend(
-            detect_events(
-                conn,
-                {
-                    "filing_id": int(row[0]),
-                    "manager_id": int(row[1]),
-                    "filing_type": str(row[2] or ""),
-                    "subject_company": str(row[3] or ""),
-                    "subject_cusip": str(row[4] or "") or None,
-                    "ownership_pct": _to_float(row[5]),
-                    "group_members": row[6],
-                    "filed_date": str(row[7] or ""),
-                },
-            )
-        )
-    return events
-
-
 def insert_activism_events(conn: Any, events: Iterable[ActivismEvent]) -> list[ActivismEvent]:
     """Persist detected activism events, skipping duplicates on reruns."""
     ensure_activism_events_table(conn)

--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -131,11 +131,7 @@ if [ "$all_ok" = true ]; then
     echo -e "${GREEN}All required dependencies are available!${NC}"
     echo ""
     echo "You can run the full test suite with:"
-    if [ -x ./scripts/run_tests.sh ]; then
-        echo "  ./scripts/run_tests.sh"
-    else
-        echo "  python -m pytest"
-    fi
+    echo "  python -m pytest"
     exit 0
 else
     echo -e "${RED}Some required dependencies are missing!${NC}"

--- a/tests/test_activism_detection.py
+++ b/tests/test_activism_detection.py
@@ -7,7 +7,6 @@ from etl.activism_detection import (
     ALERT_EVENT_TYPE,
     AlertEvent,
     detect_events,
-    detect_events_batch,
     ensure_activism_events_table,
     ensure_alert_tables,
     event_payload,
@@ -337,26 +336,5 @@ def test_fire_alerts_for_matching_activism_event(tmp_path):
         assert history[1] == ALERT_EVENT_TYPE
         assert '"threshold_crossing"' in str(history[2])
         assert history[3] == '["streamlit"]'
-    finally:
-        conn.close()
-
-
-def test_detect_events_batch_returns_recent_events(tmp_path):
-    conn = _setup_db(tmp_path / "activism.db")
-    try:
-        _insert_filing(conn, filing_type="SC 13D", filed_date="2024-05-01", ownership_pct=4.0)
-        _insert_filing(conn, filing_type="SC 13D", filed_date="2024-05-03", ownership_pct=11.0)
-        _insert_filing(
-            conn,
-            filing_type="SC 13D/A",
-            filed_date="2024-05-05",
-            ownership_pct=10.0,
-            group_members="Elliott|Blue Pool",
-        )
-
-        events = detect_events_batch(conn, "2024-05-03")
-
-        assert any(event.event_type == "threshold_crossing" for event in events)
-        assert any(event.event_type == "amendment" for event in events)
     finally:
         conn.close()

--- a/tests/test_config_hygiene.py
+++ b/tests/test_config_hygiene.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import sys
 from pathlib import Path
 
 import pytest
@@ -21,25 +20,6 @@ ROOT = Path(__file__).resolve().parents[1]
 def _defined_functions(path: str) -> set[str]:
     tree = ast.parse((ROOT / path).read_text(encoding="utf-8"))
     return {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
-
-
-def _has_external_callers(name: str, definition_path: str) -> bool:
-    definition_file = (ROOT / definition_path).resolve()
-    for path in ROOT.rglob("*.py"):
-        if path.resolve() == definition_file:
-            continue
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (OSError, SyntaxError, UnicodeDecodeError):
-            continue
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call):
-                func = node.func
-                if (isinstance(func, ast.Name) and func.id == name) or (
-                    isinstance(func, ast.Attribute) and func.attr == name
-                ):
-                    return True
-    return False
 
 
 def test_runtime_config_centralizes_db_and_cache_defaults(monkeypatch):
@@ -199,24 +179,7 @@ def test_store_document_does_not_swallow_unexpected_import_errors(monkeypatch):
 
 def test_removed_dead_code_does_not_reappear():
     assert "_deserialize_json_object" not in _defined_functions("etl/activism_detection.py")
+    assert "detect_events_batch" not in _defined_functions("etl/activism_detection.py")
     assert "evaluate_filing_summary_completeness" not in _defined_functions("llm/evaluation.py")
     assert "search_notes" not in _defined_functions("ui/search.py")
-
-
-def test_kept_issue_listed_helpers_still_have_callers():
-    assert "search_news" in _defined_functions("ui/search.py")
-    assert "detect_events_batch" in _defined_functions("etl/activism_detection.py")
-    assert _has_external_callers("search_news", "ui/search.py")
-    assert _has_external_callers("detect_events_batch", "etl/activism_detection.py")
-
-
-def test_external_caller_scan_skips_bad_files_and_finds_attribute_calls(tmp_path, monkeypatch):
-    (tmp_path / "helpers.py").write_text("def search_news():\n    pass\n", encoding="utf-8")
-    (tmp_path / "caller.py").write_text(
-        "import helpers\nhelpers.search_news()\n",
-        encoding="utf-8",
-    )
-    (tmp_path / "bad_syntax.py").write_text("def broken(:\n", encoding="utf-8")
-    monkeypatch.setattr(sys.modules[__name__], "ROOT", tmp_path)
-
-    assert _has_external_callers("search_news", "helpers.py")
+    assert "search_news" not in _defined_functions("ui/search.py")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -20,7 +20,6 @@ from ui.search import (
     _entity_badge_html,
     _format_result_meta_html,
     _group_results_by_entity_type,
-    search_news,
 )
 
 
@@ -115,66 +114,6 @@ class _FakePostgresConn:
                 [(5, "Elliott Management", "memo.txt", "Elliott strategy memo", "2025-04-03", 0.5)]
             )
         return _FakeCursor([])
-
-
-def setup_db(tmp_path: Path) -> str:
-    db_path = tmp_path / "dev.db"
-    conn = sqlite3.connect(db_path)
-    conn.execute("CREATE TABLE managers (manager_id TEXT, name TEXT)")
-    conn.execute(
-        "CREATE TABLE news_items (headline TEXT, url TEXT, published_at TEXT, source TEXT, topics TEXT, body_snippet TEXT, manager_id TEXT)"
-    )
-    conn.executemany(
-        "INSERT INTO managers VALUES (?,?)",
-        [("m1", "Manager One"), ("m2", "Manager Two")],
-    )
-    data = [
-        (
-            "Alpha Beta",
-            "https://example.com/alpha",
-            "2024-01-01T09:00:00",
-            "src",
-            "macro",
-            "Markets opened flat",
-            "m1",
-        ),
-        (
-            "Gamma Delta",
-            "https://example.com/gamma",
-            "2024-01-02T10:00:00",
-            "src",
-            "earnings",
-            "Strong guidance posted",
-            "m2",
-        ),
-    ]
-    conn.executemany("INSERT INTO news_items VALUES (?,?,?,?,?,?,?)", data)
-    conn.commit()
-    conn.close()
-    return str(db_path)
-
-
-def test_search_fts(tmp_path: Path, monkeypatch):
-    db_path = setup_db(tmp_path)
-    monkeypatch.setenv("DB_PATH", db_path)
-    df = search_news("Gamma")
-    assert list(df["headline"]) == ["Gamma Delta"]
-    assert df.iloc[0]["manager_name"] == "Manager Two"
-    assert list(df.columns) == [
-        "headline",
-        "url",
-        "published_at",
-        "source",
-        "topics",
-        "manager_name",
-    ]
-
-
-def test_search_uses_body_snippet_sqlite(tmp_path: Path, monkeypatch):
-    db_path = setup_db(tmp_path)
-    monkeypatch.setenv("DB_PATH", db_path)
-    df = search_news("guidance")
-    assert list(df["headline"]) == ["Gamma Delta"]
 
 
 def test_universal_search_returns_ranked_multi_entity_results():

--- a/tests/test_wasm_demo_build.py
+++ b/tests/test_wasm_demo_build.py
@@ -47,7 +47,8 @@ def test_deterministic_pages_render_offline(monkeypatch, tmp_path):
     assert not dashboard.load_latest_holdings_snapshot(manager_id).empty
     assert not dashboard.load_top_deltas(manager_id).empty
     assert not daily_report.load_diffs("2026-03-15").empty
-    assert not search.search_news("readiness").empty
+    with sqlite3.connect(db_path) as conn:
+        assert search.universal_search("readiness", conn, 20)
     assert upload._load_managers()
 
 

--- a/ui/search.py
+++ b/ui/search.py
@@ -2,46 +2,15 @@
 
 from __future__ import annotations
 
-import sqlite3
 from collections import Counter
 from html import escape
 
-import pandas as pd
 import streamlit as st
 
 from adapters.base import connect_db
 from api.search import SearchResult, universal_search
 
 from . import require_login
-
-
-def search_news(term: str) -> pd.DataFrame:
-    conn = connect_db()
-    if isinstance(conn, sqlite3.Connection):
-        query = (
-            "SELECT n.headline, n.url, n.published_at, n.source, n.topics, "
-            "m.name AS manager_name "
-            "FROM news_items n "
-            "LEFT JOIN managers m ON m.manager_id = n.manager_id "
-            "WHERE n.headline LIKE ? OR COALESCE(n.body_snippet, '') LIKE ? "
-            "ORDER BY n.published_at DESC LIMIT 20"
-        )
-        like_term = f"%{term}%"
-        df = pd.read_sql_query(query, conn, params=(like_term, like_term))
-    else:
-        query = (
-            "SELECT n.headline, n.url, n.published_at, n.source, n.topics, "
-            "m.name AS manager_name "
-            "FROM news_items n "
-            "LEFT JOIN managers m ON m.manager_id = n.manager_id "
-            "WHERE to_tsvector('english', n.headline || ' ' || COALESCE(n.body_snippet, '')) "
-            "@@ plainto_tsquery('english', %s) "
-            "ORDER BY n.published_at DESC LIMIT 20"
-        )
-        df = pd.read_sql_query(query, conn, params=(term,))
-    conn.close()
-    return df
-
 
 _ENTITY_LABELS: dict[str, str] = {
     "manager": "Managers",


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1398 -->

### Source Issue #1398: [Audit] Complete #1316 dead-code removal: detect_events_batch + search_news (drop the self-justifying guard)

Base: main
Head: codex/issue-1398

Source: https://github.com/stranske/Manager-Database/issues/1398

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Follow-up to the hygiene work in #1316. That issue asked to remove 5 dead functions "or justify keeping each." Three were removed (`_deserialize_json_object`, `search_notes`, `evaluate_filing_summary_completeness`), but two were **kept** with a justification that doesn't hold up on inspection:

- `etl/activism_detection.py:337` `detect_events_batch` — **no production caller**. The wired activism path uses `detect_events` (singular): `etl/activism_flow.py:26,313`. `detect_events_batch` is only referenced by `tests/test_activism_detection.py:344,357`.
- `ui/search.py:18` `search_news` — **no production caller**. `ui/search.py:main()` (line 121) does not call it; no `ui/` page or `web/` demo references it. Only `tests/test_search.py:160,176` and `tests/test_wasm_demo_build.py:50` call it.

The kept-justification is encoded as `tests/test_config_hygiene.py::test_kept_issue_listed_helpers_still_have_callers`, which uses `_has_external_callers()` — a scan that **counts test files as callers** and **excludes the defining file**. So "still has callers" here means "a test calls it," which is exactly the dead-code definition the other three removals used. Net effect: two production-unreferenced functions remain, and a guard test now actively **prevents** their removal.

Verified at `main` @ `eba93e3`: neither function has a non-test caller (same-file, cross-file, or dynamic/attribute).

#### Tasks
- [ ] Remove `detect_events_batch` (`etl/activism_detection.py:337`) and its test `test_detect_events_batch_returns_recent_events` (`tests/test_activism_detection.py:344`) + the import at line 10.
- [ ] Remove `search_news` (`ui/search.py:18`) and update its test references (`tests/test_search.py:160,176` and `tests/test_wasm_demo_build.py:50`) — drop them, or repoint the wasm build-test to the search path the demo actually uses.
- [ ] Remove `test_kept_issue_listed_helpers_still_have_callers` and the now-unused `_has_external_callers` helper from `tests/test_config_hygiene.py`.
- [ ] Extend `test_removed_dead_code_does_not_reappear` to also assert `detect_events_batch` and `search_news` stay absent (guard against reintroduction).

#### Acceptance Criteria
- [ ] `test_removed_dead_code_does_not_reappear` asserts all five functions (the original 3 + these 2) are absent; the suite is green.
- [ ] `git grep` shows no definition or reference to `detect_events_batch` / `search_news` anywhere (app or tests).
- [ ] **Deliberate-break demonstration:** re-adding either function (unused) makes the extended `does_not_reappear` test fail; removing it passes.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

Follow-up to the hygiene work in #1316. That issue asked to remove 5 dead functions "or justify keeping each." Three were removed (`_deserialize_json_object`, `search_notes`, `evaluate_filing_summary_completeness`), but two were **kept** with a justification that doesn't hold up on inspection:

- `etl/activism_detection.py:337` `detect_events_batch` — **no production caller**. The wired activism path uses `detect_events` (singular): `etl/activism_flow.py:26,313`. `detect_events_batch` is only referenced by `tests/test_activism_detection.py:344,357`.
- `ui/search.py:18` `search_news` — **no production caller**. `ui/search.py:main()` (line 121) does not call it; no `ui/` page or `web/` demo references it. Only `tests/test_search.py:160,176` and `tests/test_wasm_demo_build.py:50` call it.

The kept-justification is encoded as `tests/test_config_hygiene.py::test_kept_issue_listed_helpers_still_have_callers`, which uses `_has_external_callers()` — a scan that **counts test files as callers** and **excludes the defining file**. So "still has callers" here means "a test calls it," which is exactly the dead-code definition the other three removals used. Net effect: two production-unreferenced functions remain, and a guard test now actively **prevents** their removal.

Verified at `main` @ `eba93e3`: neither function has a non-test caller (same-file, cross-file, or dynamic/attribute).

## Scope

Complete the #1316 dead-code removal for the two functions the prior PR retained, and remove the self-justifying guard so cleanup isn't locked out. Prove-before-delete is already satisfied (zero production callers, confirmed above).

## Non-Goals

- Do NOT remove `detect_events` (singular) — it is the wired production entry point (`activism_flow.py:313`).
- Do NOT reintroduce `search_notes` / `_deserialize_json_object` / `evaluate_filing_summary_completeness` (already correctly removed).
- If (and only if) there is a *documented, intended* production use for either — e.g. a planned operator batch entry (`detect_events_batch`) or an offline-demo search page wiring (`search_news`) — then WIRE it to a real caller instead of removing, and keep a test that exercises that real path. Absent such intent, remove.

## Tasks

- [ ] Remove `detect_events_batch` (`etl/activism_detection.py:337`) and its test `test_detect_events_batch_returns_recent_events` (`tests/test_activism_detection.py:344`) + the import at line 10.
- [ ] Remove `search_news` (`ui/search.py:18`) and update its test references (`tests/test_search.py:160,176` and `tests/test_wasm_demo_build.py:50`) — drop them, or repoint the wasm build-test to the search path the demo actually uses.
- [ ] Remove `test_kept_issue_listed_helpers_still_have_callers` and the now-unused `_has_external_callers` helper from `tests/test_config_hygiene.py`.
- [ ] Extend `test_removed_dead_code_does_not_reappear` to also assert `detect_events_batch` and `search_news` stay absent (guard against reintroduction).

## Acceptance Criteria

- [ ] `test_removed_dead_code_does_not_reappear` asserts all five functions (the original 3 + these 2) are absent; the suite is green.
- [ ] `git grep` shows no definition or reference to `detect_events_batch` / `search_news` anywhere (app or tests).
- [ ] **Deliberate-break demonstration:** re-adding either function (unused) makes the extended `does_not_reappear` test fail; removing it passes.

## Implementation Notes

Audit baseline `main` @ `eba93e3`. Confirmed zero production callers for both functions (prod activism path = `detect_events`; `ui/search.py:main()` does not call `search_news`; no page/demo reference). Surfaced by the implementation-verification spot-check of #1316 (`Code/Audits/Manager-Database/`). Low severity (dead-code hygiene, no behavior at risk) — but closes the loop the prior PR left open.



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new header note with bootstrap guidance for Codex related to issue 1398.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->