### PR TITLE
Fix bitemporal verifier README wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ and serve `web/index.html` locally; details are in `README_bootstrap.md`.
 - [API Rate Limiting](docs/api_rate_limiting.md) - Rate limits, headers, and error handling
 - [API Design Guidelines](docs/api_design_guidelines.md) - API design standards and conventions
 - [API Changes](docs/api_changes.md) - Historical API modifications
-- [Point-In-Time Holdings Design](docs/bitemporal_holdings_design.md) - bitemporal holdings migration and as-of query contract
+- [Point-In-Time Holdings Design](docs/bitemporal_holdings_design.md) -
+  bitemporal holdings migration and as-of query contract
 - [Memory Profiler](docs/memory_profiler.md) - Background memory leak diagnostics
 
 ## API examples


### PR DESCRIPTION
Follow-up for #1400 after post-merge verifier feedback on PR #1406.

## Summary
- wraps the new bitemporal holdings README link so the added line satisfies the issue line-length acceptance criterion
- leaves the design document unchanged; current main already has `manager_id: int`, so the verifier typo concern is stale

## Validation
- `git diff --check`
- `awk 'length($0)>100 {print FNR ":" length($0) ":" $0}' README.md` (only pre-existing line 38 remains over 100 chars)

Closes stranske/Manager-Database#1400
