### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,8 +3,8 @@
 # Tuned for the stranske autonomous-agent fleet:
 #   - assertive review of substantial agent-authored PRs
 #   - advisory / non-gating, matching the fleet rule that review never blocks a merge
-#   - maintenance-bot PRs and generated sync/draft PRs do not spend review budget
-#   - a workflow-injection guard, since workflow YAML is synced across consumer repos
+#   - maintenance-bot, generated sync/release, and draft PRs do not spend review budget
+#   - path guidance concentrates review depth on core source, migrations, and workflow YAML
 language: en-US
 reviews:
   profile: assertive
@@ -15,15 +15,16 @@ reviews:
     enabled: true
     drafts: false                      # opener creates drafts; review when marked ready
     # Skip automatic-review budget on maintenance-bot PRs (dependency bumps, CI/version
-    # syncs). agents-workflows-bot is intentionally NOT listed — it authors substantial
-    # agent code PRs (e.g. "Agent belt for #N") that should still be reviewed.
+    # syncs) and generated sync/release PRs. agents-workflows-bot is intentionally NOT listed
+    # — it authors substantial agent code PRs (e.g. "Agent belt for #N") that should still be
+    # reviewed; its release-please PRs are caught by the "chore(main): release" title filter.
     ignore_usernames:
       - "renovate[bot]"
       - "dependabot[bot]"
       - "github-actions[bot]"
       - "stranske-keepalive[bot]"
-    # Also skip generated maintenance / sync PRs by title and by negative label.
     ignore_title_keywords:
+      - "chore(main): release"
       - "chore: sync workflow templates"
       - "sync workflow templates"
     labels:
@@ -44,5 +45,22 @@ reviews:
         Flag template-injection, unpinned third-party actions, and spoofable bot-actor
         checks — this workflow YAML is synced across consumer repos, so one bug
         replicates fleet-wide.
+    - path: "**/*.py"
+      instructions: >-
+        Prioritize correctness, error handling, and test coverage. Flag new or changed
+        behavior with no accompanying test, silently swallowed exceptions, and unguarded
+        NaN/None propagation in numeric or scoring code.
+    - path: "**/alembic/**"
+      instructions: >-
+        Verify migrations are reversible and portable across SQLite (CI) and PostgreSQL
+        (prod): keep constraint/index identifiers within Postgres' 63-char limit, use
+        op.f() for auto-named constraints, and guard dialect-specific SQL. Flag a
+        downgrade() that does not invert upgrade().
+    - path: "**/migrations/**"
+      instructions: >-
+        Verify migrations are reversible and portable across SQLite (CI) and PostgreSQL
+        (prod): keep constraint/index identifiers within Postgres' 63-char limit, use
+        op.f() for auto-named constraints, and guard dialect-specific SQL. Flag a
+        downgrade() that does not invert upgrade().
 chat:
   auto_reply: true

--- a/.github/actions/agent-run-base/action.yml
+++ b/.github/actions/agent-run-base/action.yml
@@ -1,0 +1,154 @@
+name: Agent Run Base
+description: >-
+  Shared, agent-agnostic setup for the reusable agent runner workflows: check
+  out the target repository, set up Node.js, prepare the API client, and check
+  out the stranske/Workflows scripts into .workflows-lib. Extracted from
+  reusable-claude-run.yml and reusable-codex-run.yml so the steps are
+  maintained in one place (issue #2341). Agent-specific steps (Workflows
+  script-dep install, tooling validation, and the agent invocation) stay in
+  each runner.
+
+inputs:
+  checkout_ref:
+    description: Git ref to check out for the target repository.
+    required: false
+    default: ''
+  workflows_app_id:
+    description: GitHub App ID used to mint the preferred write token.
+    required: false
+    default: ''
+  workflows_app_private_key:
+    description: GitHub App private key used to mint the preferred write token.
+    required: false
+    default: ''
+  workflows_ref:
+    description: Ref of stranske/Workflows to check out into .workflows-lib.
+    required: true
+  secrets:
+    description: JSON-encoded secrets (toJSON(secrets)) forwarded to setup-api-client.
+    required: false
+    default: '{}'
+  github_token:
+    description: GITHUB_TOKEN forwarded to setup-api-client.
+    required: true
+  runner_mode:
+    description: Current runner mode; exported to the agent-specific mode env name.
+    required: false
+    default: ''
+  runner_pr_number:
+    description: Current PR number; exported to the agent-specific PR env name.
+    required: false
+    default: ''
+  mode_env_name:
+    description: Environment variable name that receives runner_mode.
+    required: true
+  pr_number_env_name:
+    description: Environment variable name that receives runner_pr_number.
+    required: true
+
+outputs:
+  checkout_token:
+    description: Token selected for checkouts.
+    value: ${{ steps.auth_token.outputs.checkout_token }}
+  push_token:
+    description: App token selected for pushes, or empty when unavailable.
+    value: ${{ steps.auth_token.outputs.push_token }}
+  source:
+    description: Selected auth source, app-token or github-token.
+    value: ${{ steps.auth_token.outputs.source }}
+  push_allowed:
+    description: true when push_token is available.
+    value: ${{ steps.auth_token.outputs.push_allowed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Mint GitHub App token
+      id: app_token
+      continue-on-error: true
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      with:
+        app-id: ${{ inputs.workflows_app_id || '0' }}
+        private-key: ${{ inputs.workflows_app_private_key || 'dummy' }}
+
+    - name: Select auth token
+      id: auth_token
+      shell: bash
+      env:
+        APP_TOKEN: ${{ steps.app_token.outputs.token || '' }}
+        GITHUB_TOKEN_VALUE: ${{ inputs.github_token }}
+        RUNNER_MODE: ${{ inputs.runner_mode }}
+        RUNNER_PR_NUMBER: ${{ inputs.runner_pr_number }}
+        MODE_ENV_NAME: ${{ inputs.mode_env_name }}
+        PR_NUMBER_ENV_NAME: ${{ inputs.pr_number_env_name }}
+      run: |
+        set -euo pipefail
+        checkout_token="${APP_TOKEN:-${GITHUB_TOKEN_VALUE}}"
+        push_token="${APP_TOKEN:-}"
+        source="app-token"
+        push_allowed="true"
+
+        if [ -z "$push_token" ]; then
+          source="github-token"
+          push_allowed="false"
+        fi
+
+        env_name_pattern='^[A-Za-z_][A-Za-z0-9_]*$'
+        if [[ ! "$MODE_ENV_NAME" =~ $env_name_pattern ]]; then
+          echo "Invalid mode_env_name: expected a shell environment variable name" >&2
+          exit 1
+        fi
+        if [[ ! "$PR_NUMBER_ENV_NAME" =~ $env_name_pattern ]]; then
+          echo "Invalid pr_number_env_name: expected a shell environment variable name" >&2
+          exit 1
+        fi
+
+        {
+          echo "checkout_token=${checkout_token}"
+          echo "push_token=${push_token}"
+          echo "source=${source}"
+          echo "push_allowed=${push_allowed}"
+        } >> "$GITHUB_OUTPUT"
+
+        {
+          echo "WORKFLOWS_TOKEN=${checkout_token}"
+          echo "${MODE_ENV_NAME}=${RUNNER_MODE}"
+          echo "${PR_NUMBER_ENV_NAME}=${RUNNER_PR_NUMBER}"
+        } >> "$GITHUB_ENV"
+
+        printf 'Checkout auth: %s; push permitted with app token: %s.\n' "$source" "$push_allowed"
+
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.checkout_ref || github.ref }}
+        token: ${{ steps.auth_token.outputs.checkout_token }}
+        # Preserve the pre-checked-out .workflows-actions local action.  The
+        # runner reloads local action metadata during post-job cleanup.
+        clean: false
+
+    - name: Set up Node.js
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        node-version: 24
+
+    # Aligns infrastructure prep across both agent runners so they share the
+    # same token load balancer, scripts checkout, and tooling deps.
+    - name: Setup API client
+      uses: ./.github/actions/setup-api-client
+      with:
+        secrets: ${{ inputs.secrets }}
+        github_token: ${{ inputs.github_token }}
+
+    - name: Checkout Workflows scripts
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: stranske/Workflows
+        ref: ${{ inputs.workflows_ref }}
+        path: .workflows-lib
+        sparse-checkout: |
+          .github
+          tools
+          scripts
+        token: ${{ steps.auth_token.outputs.checkout_token }}

--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -5,6 +5,76 @@ default_agent: codex
 # Shared keepalive marker prefix (agent-agnostic)
 keepalive_marker_prefix: agent-keepalive
 
+# Dedicated instrumentation-only contract for the Sol/Terra/Luna plumbing
+# canary. The reusable workflow ref is replaced with the exact commit containing
+# this runner before merge. Trial profiles are rejected by ordinary agent and
+# Keepalive execution. The lane cannot fall back, mutate source, invoke an
+# evaluator, or claim provider-resolved identity.
+model_profile_trial_contract:
+  mode: read-only
+  artifact_schema: workflows.model-profile-trial-result/v2
+  identity_authority: workflows-read-only-trial-artifact/v2
+  collector_identity_authority: github-actions-api/workflows-read-only-trial-artifact/v2
+  runner_ref: stranske/Workflows/.github/workflows/reusable-model-profile-trial.yml@822e323eefba3edb640e0bd9c922caec6fffee65
+  cli_version: 0.144.1
+  runtime_fallback_allowed: false
+  auxiliary_evaluator_allowed: false
+  provider_resolved_identity: unavailable
+  capacity_pool_mapping:
+    orchestrator: codex-subscription
+    workflows: codex-standard
+
+execution_profiles:
+  codex-default:
+    agent: codex
+    model: gpt-5.5
+    fallback_model: gpt-5.4
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: active
+  codex-fast:
+    agent: codex
+    model: gpt-5.4
+    fallback_model: gpt-5.5
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: active
+  codex-5.6-sol-high:
+    agent: codex
+    model: gpt-5.6-sol
+    fallback_model: gpt-5.5
+    runner: reusable-model-profile-trial
+    runner_ref: stranske/Workflows/.github/workflows/reusable-model-profile-trial.yml@822e323eefba3edb640e0bd9c922caec6fffee65
+    capacity_pool: codex-standard
+    safety: read-only
+    lifecycle: trial
+    reasoning_effort: high
+    permission_mode: read-only
+  codex-5.6-terra-high:
+    agent: codex
+    model: gpt-5.6-terra
+    fallback_model: gpt-5.5
+    runner: reusable-model-profile-trial
+    runner_ref: stranske/Workflows/.github/workflows/reusable-model-profile-trial.yml@822e323eefba3edb640e0bd9c922caec6fffee65
+    capacity_pool: codex-standard
+    safety: read-only
+    lifecycle: trial
+    reasoning_effort: high
+    permission_mode: read-only
+  codex-5.6-luna-high:
+    agent: codex
+    model: gpt-5.6-luna
+    fallback_model: gpt-5.5
+    runner: reusable-model-profile-trial
+    runner_ref: stranske/Workflows/.github/workflows/reusable-model-profile-trial.yml@822e323eefba3edb640e0bd9c922caec6fffee65
+    capacity_pool: codex-standard
+    safety: read-only
+    lifecycle: trial
+    reasoning_effort: high
+    permission_mode: read-only
+
 agents:
   codex:
     runner_workflow: .github/workflows/reusable-codex-run.yml

--- a/.github/scripts/agent_registry.js
+++ b/.github/scripts/agent_registry.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 
 const ALLOWED_CAPACITY_WINDOWS = new Set(['5h', 'weekly', 'daily']);
 
@@ -146,8 +147,8 @@ function normalizeRegistryOptions(options = {}) {
 
 function loadAgentRegistry(options = {}) {
   const { registryPath } = normalizeRegistryOptions(options);
-  const path = registryPath || '.github/agents/registry.yml';
-  const raw = fs.readFileSync(path, 'utf8');
+  const registryFilePath = registryPath || '.github/agents/registry.yml';
+  const raw = fs.readFileSync(registryFilePath, 'utf8');
   const registry = parseRegistryYaml(raw);
   if (!registry || typeof registry !== 'object') {
     throw new Error('Agent registry did not parse into an object');
@@ -158,8 +159,36 @@ function loadAgentRegistry(options = {}) {
   if (!registry.default_agent || typeof registry.default_agent !== 'string') {
     throw new Error('Agent registry missing required "default_agent" string');
   }
-  validateAgentRegistry(registry);
+  validateAgentRegistry(registry, { registryPath: registryFilePath });
   return registry;
+}
+
+function resolveModelRegistryPath(options = {}) {
+  if (options.modelRegistryPath) {
+    return options.modelRegistryPath;
+  }
+  const registryPath = options.registryPath || '.github/agents/registry.yml';
+  if (path.isAbsolute(registryPath)) {
+    return path.resolve(path.dirname(registryPath), '..', '..', 'config', 'model_registry.json');
+  }
+  return path.resolve(process.cwd(), 'config', 'model_registry.json');
+}
+
+function loadModelRegistryIds(options = {}) {
+  const modelRegistryPath = resolveModelRegistryPath(options);
+  if (!fs.existsSync(modelRegistryPath)) {
+    return null;
+  }
+  const raw = fs.readFileSync(modelRegistryPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed.models)) {
+    throw new Error(`Model registry ${modelRegistryPath} missing required models array`);
+  }
+  return new Set(
+    parsed.models
+      .map((model) => String(model?.model_id || '').trim())
+      .filter(Boolean),
+  );
 }
 
 function validateAgentCapacity(agentKey, agentConfig) {
@@ -184,10 +213,65 @@ function validateAgentCapacity(agentKey, agentConfig) {
   }
 }
 
-function validateAgentRegistry(registry) {
+function validateAgentRegistry(registry, options = {}) {
+  const knownModelIds = loadModelRegistryIds(options);
+
   for (const [agentKey, agentConfig] of Object.entries(registry.agents || {})) {
     validateAgentCapacity(agentKey, agentConfig);
   }
+
+  for (const [profileId, profile] of Object.entries(registry.execution_profiles || {})) {
+    validateExecutionProfile(profileId, profile, registry, { knownModelIds });
+  }
+}
+
+function validateExecutionProfile(profileId, profile, registry, options = {}) {
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    throw new Error(`Execution profile ${profileId} must be an object`);
+  }
+  const agent = String(profile.agent || '').trim();
+  if (!agent || !registry.agents?.[agent]) {
+    throw new Error(`Execution profile ${profileId} references unknown agent: ${agent || '(empty)'}`);
+  }
+  for (const field of ['model', 'runner', 'capacity_pool', 'safety', 'lifecycle']) {
+    if (!String(profile[field] || '').trim()) {
+      throw new Error(`Execution profile ${profileId} missing required field: ${field}`);
+    }
+  }
+  if (options.knownModelIds) {
+    for (const field of ['model', 'fallback_model']) {
+      const modelId = String(profile[field] || '').trim();
+      if (modelId && !options.knownModelIds.has(modelId)) {
+        throw new Error(
+          `Execution profile ${profileId} references unknown ${field}: ${modelId}`,
+        );
+      }
+    }
+  }
+}
+
+function resolveExecutionProfile(profileId, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
+  const registry = loadAgentRegistry({ registryPath });
+  const id = String(profileId || '').trim() || 'codex-default';
+  const profile = registry.execution_profiles?.[id];
+  if (!profile) {
+    const known = Object.keys(registry.execution_profiles || {}).sort();
+    throw new Error(
+      `Unknown execution profile: ${id}. Known profiles: ${known.join(', ') || '(none)'}`,
+    );
+  }
+  validateExecutionProfile(id, profile, registry);
+  if (String(profile.lifecycle || '').trim() !== 'active') {
+    throw new Error(
+      `Execution profile ${id} has lifecycle ${profile.lifecycle || '(empty)'}; ` +
+        'ordinary agent execution accepts active profiles only',
+    );
+  }
+  return {
+    id,
+    ...profile,
+  };
 }
 
 function normalizeLabel(label) {
@@ -373,6 +457,7 @@ module.exports = {
   getRunnerWorkflow,
   loadAgentRegistry,
   parseRegistryYaml,
+  resolveExecutionProfile,
   resolveAgentFromLabels,
   resolveAgentRoutingFromLabels,
   validateAgentRegistry,

--- a/.github/scripts/capability_bundle.js
+++ b/.github/scripts/capability_bundle.js
@@ -1,0 +1,269 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+
+const SCHEMA_VERSION = 'capability-bundle/v1';
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  'schema_version',
+  'capability_id',
+  'version',
+  'content_hash',
+  'selector',
+  'owner',
+  'fragments',
+  'gates',
+  'playbooks',
+  'expires_at',
+  'rollback',
+]);
+const CAPABILITY_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]*$/;
+const VERSION_PATTERN = /^v?[0-9]+(\.[0-9]+){0,2}$/;
+const FORBIDDEN_KEY_PATTERN = /(?:raw[_-]?prompt|credential|secret|api[_-]?key|local[_-]?weight|posterior[_-]?weight|command|control|exec)/i;
+
+function normalise(value) {
+  return String(value ?? '').trim();
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256Hex(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function bundleHashPayload(bundle) {
+  const {
+    content_hash: _contentHash,
+    ...payload
+  } = bundle || {};
+  return payload;
+}
+
+function computeCapabilityBundleHash(bundle) {
+  return `sha256:${sha256Hex(stableStringify(bundleHashPayload(bundle)))}`;
+}
+
+function walkForbiddenKeys(value, path = []) {
+  const hits = [];
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      hits.push(...walkForbiddenKeys(item, [...path, String(index)]));
+    });
+    return hits;
+  }
+  if (!value || typeof value !== 'object') {
+    return hits;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = [...path, key];
+    if (FORBIDDEN_KEY_PATTERN.test(key)) {
+      hits.push(childPath.join('.'));
+    }
+    hits.push(...walkForbiddenKeys(child, childPath));
+  }
+  return hits;
+}
+
+function asArray(value) {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function requireNonEmpty(value, fieldName) {
+  if (!normalise(value)) {
+    throw new Error(`capability bundle missing ${fieldName}`);
+  }
+}
+
+function validateCapabilityBundle(bundle, options = {}) {
+  const knownCapabilities = new Set(asArray(options.knownCapabilities));
+  const now = options.now instanceof Date ? options.now : new Date();
+
+  if (!bundle || typeof bundle !== 'object' || Array.isArray(bundle)) {
+    throw new Error('capability bundle must be an object');
+  }
+  if (normalise(bundle.schema_version) !== SCHEMA_VERSION) {
+    throw new Error(`capability bundle schema_version must be ${SCHEMA_VERSION}`);
+  }
+  const unknownKeys = Object.keys(bundle).filter((key) => !ALLOWED_TOP_LEVEL_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    throw new Error(`capability bundle has unknown top-level fields: ${unknownKeys.join(', ')}`);
+  }
+  const capabilityId = normalise(bundle.capability_id);
+  if (!capabilityId) {
+    throw new Error('capability bundle missing capability_id');
+  }
+  if (!CAPABILITY_ID_PATTERN.test(capabilityId)) {
+    throw new Error(`capability bundle has invalid capability_id: ${capabilityId}`);
+  }
+  if (knownCapabilities.size > 0 && !knownCapabilities.has(capabilityId)) {
+    throw new Error(`unknown capability id: ${capabilityId}`);
+  }
+  const version = normalise(bundle.version);
+  if (!version) {
+    throw new Error('capability bundle missing version');
+  }
+  if (!VERSION_PATTERN.test(version)) {
+    throw new Error(`capability bundle has invalid version: ${version}`);
+  }
+  requireNonEmpty(bundle.owner, 'owner');
+  requireNonEmpty(bundle.rollback, 'rollback');
+  if (!bundle.selector || typeof bundle.selector !== 'object' || Array.isArray(bundle.selector)) {
+    throw new Error('capability bundle missing selector object');
+  }
+  if (!bundle.fragments || typeof bundle.fragments !== 'object' || Array.isArray(bundle.fragments)) {
+    throw new Error('capability bundle missing fragments object');
+  }
+  if (!normalise(bundle.fragments.task) && !normalise(bundle.fragments.acceptance)) {
+    throw new Error('capability bundle must include a task or acceptance fragment');
+  }
+  if (!Array.isArray(bundle.gates) || bundle.gates.length === 0 || bundle.gates.some((gate) => !normalise(gate))) {
+    throw new Error('capability bundle must include at least one gate ref');
+  }
+  const forbidden = walkForbiddenKeys(bundle);
+  if (forbidden.length > 0) {
+    throw new Error(`capability bundle contains unsafe inline fields: ${forbidden.join(', ')}`);
+  }
+  const expiresAt = normalise(bundle.expires_at);
+  if (expiresAt) {
+    const expiry = new Date(expiresAt);
+    if (Number.isNaN(expiry.getTime())) {
+      throw new Error(`capability bundle has invalid expires_at: ${expiresAt}`);
+    }
+    if (expiry.getTime() <= now.getTime()) {
+      throw new Error(`capability bundle expired at ${expiresAt}`);
+    }
+  }
+  const expectedHash = normalise(bundle.content_hash);
+  if (!expectedHash) {
+    throw new Error('capability bundle missing content_hash');
+  }
+  const actualHash = computeCapabilityBundleHash(bundle);
+  if (expectedHash !== actualHash) {
+    throw new Error(`capability bundle hash mismatch: expected ${expectedHash}, computed ${actualHash}`);
+  }
+  return true;
+}
+
+function loadCapabilityBundles(bundlePath, options = {}) {
+  const raw = fs.readFileSync(bundlePath, 'utf8');
+  const parsed = JSON.parse(raw);
+  const bundles = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.bundles)
+      ? parsed.bundles
+      : [parsed];
+  bundles.forEach((bundle) => validateCapabilityBundle(bundle, options));
+  return bundles;
+}
+
+function predicateMatches(expected, actual) {
+  if (expected === undefined || expected === null) {
+    return true;
+  }
+  if (Array.isArray(expected)) {
+    return expected.map(normalise).filter(Boolean).includes(normalise(actual));
+  }
+  return normalise(expected) === normalise(actual);
+}
+
+function selectorMatches(selector = {}, context = {}) {
+  const labels = new Set(asArray(context.labels).map((label) => normalise(label).toLowerCase()));
+  if (!predicateMatches(selector.repo, context.repo)) {
+    return [false, 'repo'];
+  }
+  if (!predicateMatches(selector.agent, context.agent)) {
+    return [false, 'agent'];
+  }
+  if (!predicateMatches(selector.mode, context.mode)) {
+    return [false, 'mode'];
+  }
+  for (const requiredLabel of asArray(selector.labels)) {
+    if (!labels.has(normalise(requiredLabel).toLowerCase())) {
+      return [false, `label:${requiredLabel}`];
+    }
+  }
+  return [true, 'matched'];
+}
+
+function selectCapabilityBundles(bundles, context = {}, options = {}) {
+  const applied = [];
+  const rejected = [];
+  for (const bundle of asArray(bundles)) {
+    try {
+      validateCapabilityBundle(bundle, options);
+      const [matched, reason] = selectorMatches(bundle.selector, context);
+      if (!matched) {
+        rejected.push({
+          capability_id: normalise(bundle.capability_id),
+          content_hash: normalise(bundle.content_hash),
+          reason,
+        });
+        continue;
+      }
+      applied.push({
+        capability_id: normalise(bundle.capability_id),
+        version: normalise(bundle.version),
+        content_hash: normalise(bundle.content_hash),
+        gate_versions: asArray(bundle.gates).map((gate) => normalise(gate)).filter(Boolean),
+        playbooks: asArray(bundle.playbooks).map((playbook) => normalise(playbook)).filter(Boolean),
+        fragments: {
+          task: normalise(bundle.fragments?.task),
+          acceptance: normalise(bundle.fragments?.acceptance),
+        },
+      });
+    } catch (error) {
+      rejected.push({
+        capability_id: normalise(bundle?.capability_id) || 'unknown',
+        content_hash: normalise(bundle?.content_hash),
+        reason: error.message,
+      });
+    }
+  }
+  return { applied, rejected };
+}
+
+function renderCapabilityFragments(applied = []) {
+  const blocks = asArray(applied)
+    .map((bundle) => {
+      const lines = [
+        `Capability: ${bundle.capability_id}@${bundle.version}`,
+        `Hash: ${bundle.content_hash}`,
+      ];
+      if (bundle.fragments?.task) {
+        lines.push(`Task fragment: ${bundle.fragments.task}`);
+      }
+      if (bundle.fragments?.acceptance) {
+        lines.push(`Acceptance fragment: ${bundle.fragments.acceptance}`);
+      }
+      if (bundle.gate_versions?.length) {
+        lines.push(`Gates: ${bundle.gate_versions.join(', ')}`);
+      }
+      return lines.join('\n');
+    })
+    .filter(Boolean);
+  return blocks.join('\n\n');
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  computeCapabilityBundleHash,
+  loadCapabilityBundles,
+  renderCapabilityFragments,
+  selectCapabilityBundles,
+  stableStringify,
+  validateCapabilityBundle,
+};

--- a/.github/scripts/gate_summary.py
+++ b/.github/scripts/gate_summary.py
@@ -361,9 +361,9 @@ def summarize(context: SummaryContext) -> SummaryResult:
     # files changed.
     elif not context.python_required and python_result == "skipped":
         lines.append("- Python CI skipped: no Python-code changes detected.")
-    elif python_result == "cancelled":
+    elif python_result in {"cancelled", "abandoned"}:
         state = "pending"
-        description = "Python CI cancelled; waiting for rerun."
+        description = f"Python CI {python_result}; waiting for rerun."
     elif python_result not in ("success", "skipped") or (
         python_result == "skipped" and context.run_core
     ):

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -796,7 +796,17 @@ function buildMetricsRecord({
   durationMs,
   tasksTotal,
   tasksComplete,
+  capabilityBundles,
 }) {
+  const capabilityResult = capabilityBundles && typeof capabilityBundles === 'object'
+    ? capabilityBundles
+    : { applied: [], rejected: [] };
+  const applied = Array.isArray(capabilityResult.applied)
+    ? capabilityResult.applied.filter((bundle) => bundle && typeof bundle === 'object' && !Array.isArray(bundle))
+    : [];
+  const rejected = Array.isArray(capabilityResult.rejected)
+    ? capabilityResult.rejected.filter((bundle) => bundle && typeof bundle === 'object' && !Array.isArray(bundle))
+    : [];
   return {
     pr_number: toNumber(prNumber, 0),
     iteration: Math.max(1, toNumber(iteration, 0)),
@@ -806,7 +816,38 @@ function buildMetricsRecord({
     duration_ms: Math.max(0, toNumber(durationMs, 0)),
     tasks_total: Math.max(0, toNumber(tasksTotal, 0)),
     tasks_complete: Math.max(0, toNumber(tasksComplete, 0)),
+    capability_bundle_ids: applied.map((bundle) => normalise(bundle.capability_id)).filter(Boolean),
+    capability_bundle_hashes: applied.map((bundle) => normalise(bundle.content_hash)).filter(Boolean),
+    capability_gate_versions: applied
+      .flatMap((bundle) => [
+        ...(Array.isArray(bundle.gate_versions) ? bundle.gate_versions : []),
+        ...(Array.isArray(bundle.playbooks) ? bundle.playbooks : []),
+      ])
+      .map(normalise)
+      .filter(Boolean),
+    capability_rejection_reasons: rejected
+      .map((bundle) => normalise(bundle.reason))
+      .filter(Boolean),
   };
+}
+
+function parseCapabilityBundlesInput(value) {
+  const raw = normalise(value);
+  if (!raw) {
+    return { applied: [], rejected: [] };
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { applied: [], rejected: [{ reason: 'invalid-capability-bundles-json' }] };
+    }
+    return {
+      applied: Array.isArray(parsed.applied) ? parsed.applied : [],
+      rejected: Array.isArray(parsed.rejected) ? parsed.rejected : [],
+    };
+  } catch {
+    return { applied: [], rejected: [{ reason: 'invalid-capability-bundles-json' }] };
+  }
 }
 
 function emitMetricsRecord({ core, record }) {
@@ -1604,6 +1645,9 @@ function normaliseConfig(config = {}) {
   const promptMode = normalise(cfg.prompt_mode ?? cfg.promptMode);
   const promptFile = normalise(cfg.prompt_file ?? cfg.promptFile);
   const promptScenario = normalise(cfg.prompt_scenario ?? cfg.promptScenario);
+  const executionProfile = normalise(
+    cfg.execution_profile ?? cfg.executionProfile ?? cfg.worker_profile ?? cfg.workerProfile,
+  );
   return {
     keepalive_enabled: toBool(
       cfg.keepalive_enabled ?? cfg.enable_keepalive ?? cfg.keepalive,
@@ -1617,6 +1661,7 @@ function normaliseConfig(config = {}) {
     prompt_mode: promptMode,
     prompt_file: promptFile,
     prompt_scenario: promptScenario,
+    execution_profile: executionProfile,
     verifier_agent: normalise(cfg.verifier_agent),
     progress_review_threshold: cfg.progress_review_threshold != null ? toNumber(cfg.progress_review_threshold, 4) : undefined,
     complete_gate_failure_rounds: cfg.complete_gate_failure_rounds != null ? toNumber(cfg.complete_gate_failure_rounds, 3) : undefined,
@@ -2833,7 +2878,6 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     });
     const promptMode = promptModeOverride || promptRoute.mode;
     const promptFile = promptFileOverride || promptRoute.file;
-
     // For verification steps, prefer a different agent than the one that did
     // the implementation work.  This avoids the structural problem where the
     // same model that produced the work also verifies it — a conflict of
@@ -2847,6 +2891,34 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
         core.info(`Verification step: switching agent from ${agentType} to ${verifierAgentType} for independent verification`);
       }
     }
+    const resolvedAgentType = isVerificationReason ? verifierAgentType : agentType;
+
+    const requestedExecutionProfile = normalise(config.execution_profile)
+      || normalise(process.env.INPUT_EXECUTION_PROFILE)
+      || 'codex-default';
+    let executionProfile = null;
+    if (AGENT_EXECUTION_ACTIONS.has(action) && resolvedAgentType === 'codex') {
+      try {
+        const { resolveExecutionProfile } = require('./agent_registry.js');
+        executionProfile = resolveExecutionProfile(requestedExecutionProfile);
+        if (executionProfile.agent !== 'codex') {
+          throw new Error(
+            `Execution profile ${executionProfile.id} routes to ${executionProfile.agent}; keepalive codex runner requires codex`,
+          );
+        }
+        core?.info?.(
+          `Resolved execution profile ${executionProfile.id}: model=${executionProfile.model}, ` +
+            `fallback=${executionProfile.fallback_model || ''}`,
+        );
+      } catch (profileError) {
+        throw new Error(`Invalid keepalive execution profile: ${profileError.message}`);
+      }
+    } else if (core && requestedExecutionProfile !== 'codex-default') {
+      core.info(
+        `Skipping execution profile validation for non-Codex/non-execution action ` +
+          `${resolvedAgentType || '(none)'}/${action || '(none)'}`,
+      );
+    }
 
     return {
       prNumber,
@@ -2857,6 +2929,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       reason,
       promptMode,
       promptFile,
+      executionProfile,
       gateConclusion,
       config,
       iteration,
@@ -2865,7 +2938,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       checkboxCounts,
       hasAgentLabel,
       hasHighPrivilege,
-      agentType: isVerificationReason ? verifierAgentType : agentType,
+      agentType: resolvedAgentType,
       agentRoutingMode,
       delegationReason,
       delegationShouldSwitch,
@@ -3357,6 +3430,9 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       durationMs: toOptionalNumber(inputs.duration_ms ?? inputs.durationMs),
       startTs: toOptionalNumber(inputs.start_ts ?? inputs.startTs),
     });
+    const capabilityBundles = parseCapabilityBundlesInput(
+      inputs.capability_bundles_json ?? inputs.capabilityBundlesJson,
+    );
     const metricsRecord = buildMetricsRecord({
       prNumber,
       iteration: metricsIteration,
@@ -3365,6 +3441,7 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       durationMs,
       tasksTotal,
       tasksComplete,
+      capabilityBundles,
     });
     emitMetricsRecord({ core, record: metricsRecord });
     await appendMetricsRecord({
@@ -4786,4 +4863,6 @@ module.exports = {
   extractScopePatterns,
   fileMatchesScopePattern,
   validateScopeCompliance,
+  buildMetricsRecord,
+  parseCapabilityBundlesInput,
 };

--- a/.github/scripts/keepalive_prompt_composer.js
+++ b/.github/scripts/keepalive_prompt_composer.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const DEFAULT_SEPARATOR = '\n\n';
+const {
+  renderCapabilityFragments,
+  selectCapabilityBundles,
+} = require('./capability_bundle');
 
 function normalise(value) {
   return String(value ?? '').trim();
@@ -15,7 +19,7 @@ function normaliseSegmentId(value, fallback) {
 }
 
 function coerceSegments(value) {
-  if (!value) {
+  if (value === undefined || value === null || value === '' || value === false) {
     return [];
   }
   if (Array.isArray(value)) {
@@ -27,6 +31,8 @@ function coerceSegments(value) {
 function createPromptComposer(options = {}) {
   const segments = coerceSegments(options.segments);
   const separator = normalise(options.separator) || DEFAULT_SEPARATOR;
+  const capabilityBundles = coerceSegments(options.capabilityBundles);
+  const knownCapabilities = coerceSegments(options.knownCapabilities).map(normalise).filter(Boolean);
 
   const compose = (params = {}) => {
     const state = params.state && typeof params.state === 'object' ? params.state : {};
@@ -34,6 +40,18 @@ function createPromptComposer(options = {}) {
     const mode = normalise(params.mode);
     const rendered = [];
     const usedSegments = [];
+    const capabilityResult = selectCapabilityBundles(
+      Object.prototype.hasOwnProperty.call(params, 'capabilityBundles')
+        ? coerceSegments(params.capabilityBundles)
+        : capabilityBundles,
+      { ...context, mode },
+      { knownCapabilities },
+    );
+    const capabilityText = renderCapabilityFragments(capabilityResult.applied);
+    if (capabilityText) {
+      rendered.push(capabilityText);
+      usedSegments.push('capability-bundle');
+    }
 
     segments.forEach((segment, index) => {
       if (!segment || typeof segment !== 'object') {
@@ -67,6 +85,7 @@ function createPromptComposer(options = {}) {
       text: rendered.join(separator).trim(),
       segments: usedSegments,
       separator,
+      capability_bundles: capabilityResult,
     };
   };
 

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -337,6 +337,14 @@ jobs:
               ? fs.readFileSync(summaryPath, 'utf8')
               : 'No metrics available.';
             const title = 'Agent metrics weekly summary';
+            const repoLabels = await paginateWithRetry(
+              github,
+              github.rest.issues.listLabelsForRepo,
+              { owner, repo, per_page: 100 },
+            );
+            const hasDurableTrackerLabel = repoLabels.some(
+              (label) => label.name === 'tracker:durable',
+            );
 
             const issues = await paginateWithRetry(github, github.rest.issues.listForRepo, {
               owner,
@@ -352,6 +360,9 @@ jobs:
                 repo,
                 title,
                 body: 'Tracking issue for weekly agent workflow metrics.\n\n' + body,
+                labels: hasDurableTrackerLabel
+                  ? ['tracker:durable', 'automated']
+                  : ['automated'],
               }));
               target = created.data;
             } else {
@@ -361,6 +372,17 @@ jobs:
                 issue_number: target.number,
                 body,
               }));
+              const hasLabel = (target.labels || []).some(
+                l => (typeof l === 'string' ? l : l?.name) === 'tracker:durable'
+              );
+              if (hasDurableTrackerLabel && !hasLabel) {
+                await withRetry(() => github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: target.number,
+                  labels: ['tracker:durable'],
+                }));
+              }
             }
 
             core.setOutput('issue_number', target.number);

--- a/.github/workflows/backplane-conformance.yml
+++ b/.github/workflows/backplane-conformance.yml
@@ -17,6 +17,9 @@ on:
       # Tune per repo: source that affects the run envelope + emitter.
       - 'src/**'
       - 'artifacts/**'
+      - 'scripts/**'
+      - 'docs/contracts/**'
+      - 'config/backplane_participants.json'
 
 jobs:
   emit-reference-run:

--- a/config/model_registry.json
+++ b/config/model_registry.json
@@ -1,216 +1,284 @@
 {
-  "version": "1.0.0",
-  "last_updated": "2026-06-29",
-  "review_interval_days": 60,
-  "review_by": "2026-08-28",
+  "schema_version": "2.0.0",
+  "as_of": "2026-07-10",
+  "review_by": "2026-07-24",
+  "purpose": "Auditable model facts and auxiliary judge/evaluator selections. Coding-worker execution profiles remain in .github/agents/registry.yml::execution_profiles.",
+  "selection_policy": "config/model_selection_policy.json",
+  "catalog_baselines": {
+    "openai": {
+      "checked_at": "2026-07-10T00:00:00Z",
+      "model_ids": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
+    },
+    "anthropic": {
+      "checked_at": "2026-07-10T00:00:00Z",
+      "model_ids": [
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+        "claude-haiku-4-5-20251001"
+      ]
+    },
+    "github-models": {
+      "checked_at": "2026-07-10T00:00:00Z",
+      "model_ids": [
+        "openai/gpt-4.1",
+        "openai/gpt-4.1-mini",
+        "openai/gpt-4.1-nano",
+        "openai/gpt-4o",
+        "openai/gpt-4o-mini",
+        "openai/gpt-5",
+        "openai/gpt-5-chat",
+        "openai/gpt-5-mini",
+        "openai/gpt-5-nano",
+        "openai/o1",
+        "openai/o1-mini",
+        "openai/o1-preview",
+        "openai/o3",
+        "openai/o3-mini",
+        "openai/o4-mini"
+      ]
+    }
+  },
+  "sources": [
+    {
+      "source_id": "openai-current-models-2026-07-10",
+      "provider": "openai",
+      "checked_at": "2026-07-10",
+      "url": "https://developers.openai.com/api/docs/guides/latest-model"
+    },
+    {
+      "source_id": "openai-pricing-2026-07-10",
+      "provider": "openai",
+      "checked_at": "2026-07-10",
+      "url": "https://developers.openai.com/api/docs/pricing"
+    },
+    {
+      "source_id": "anthropic-current-models-2026-07-10",
+      "provider": "anthropic",
+      "checked_at": "2026-07-10",
+      "url": "https://platform.claude.com/docs/en/about-claude/models/overview"
+    },
+    {
+      "source_id": "github-models-catalog-2026-07-10",
+      "provider": "github-models",
+      "checked_at": "2026-07-10",
+      "url": "https://models.github.ai/catalog/models"
+    }
+  ],
   "models": [
+    {
+      "model_id": "gpt-5.6-sol",
+      "provider": "openai",
+      "api": "chat",
+      "lifecycle": "current",
+      "positioning": "frontier",
+      "source_ids": [
+        "openai-current-models-2026-07-10",
+        "openai-pricing-2026-07-10"
+      ],
+      "pricing": {
+        "currency": "USD",
+        "input_per_million_tokens": 5.0,
+        "output_per_million_tokens": 30.0,
+        "as_of": "2026-07-10"
+      }
+    },
+    {
+      "model_id": "gpt-5.6-terra",
+      "provider": "openai",
+      "api": "chat",
+      "lifecycle": "current",
+      "positioning": "balanced",
+      "source_ids": [
+        "openai-current-models-2026-07-10",
+        "openai-pricing-2026-07-10"
+      ],
+      "pricing": {
+        "currency": "USD",
+        "input_per_million_tokens": 2.5,
+        "output_per_million_tokens": 15.0,
+        "as_of": "2026-07-10"
+      }
+    },
+    {
+      "model_id": "gpt-5.6-luna",
+      "provider": "openai",
+      "api": "chat",
+      "lifecycle": "current",
+      "positioning": "efficient",
+      "source_ids": [
+        "openai-current-models-2026-07-10",
+        "openai-pricing-2026-07-10"
+      ],
+      "pricing": {
+        "currency": "USD",
+        "input_per_million_tokens": 1.0,
+        "output_per_million_tokens": 6.0,
+        "as_of": "2026-07-10"
+      }
+    },
+    {
+      "model_id": "claude-fable-5",
+      "provider": "anthropic",
+      "api": "chat",
+      "lifecycle": "current",
+      "positioning": "frontier",
+      "source_ids": ["anthropic-current-models-2026-07-10"],
+      "pricing": {
+        "currency": "USD",
+        "input_per_million_tokens": 10.0,
+        "output_per_million_tokens": 50.0,
+        "as_of": "2026-07-10"
+      }
+    },
+    {
+      "model_id": "claude-opus-4-8",
+      "provider": "anthropic",
+      "api": "chat",
+      "lifecycle": "current",
+      "positioning": "high-capability",
+      "source_ids": ["anthropic-current-models-2026-07-10"],
+      "pricing": {
+        "currency": "USD",
+        "input_per_million_tokens": 5.0,
+        "output_per_million_tokens": 25.0,
+        "as_of": "2026-07-10"
+      }
+    },
+    {
+      "model_id": "claude-sonnet-5",
+      "provider": "anthropic",
+      "api": "chat",
+      "lifecycle": "current",
+      "positioning": "balanced",
+      "source_ids": ["anthropic-current-models-2026-07-10"],
+      "pricing": {
+        "currency": "USD",
+        "input_per_million_tokens": 3.0,
+        "output_per_million_tokens": 15.0,
+        "as_of": "2026-07-10",
+        "notes": "Standard price; temporary introductory pricing is not used for durable decisions."
+      }
+    },
+    {
+      "model_id": "claude-haiku-4-5-20251001",
+      "provider": "anthropic",
+      "api": "chat",
+      "lifecycle": "current",
+      "positioning": "efficient",
+      "source_ids": ["anthropic-current-models-2026-07-10"],
+      "pricing": {
+        "currency": "USD",
+        "input_per_million_tokens": 1.0,
+        "output_per_million_tokens": 5.0,
+        "as_of": "2026-07-10"
+      }
+    },
+    {
+      "model_id": "openai/gpt-5",
+      "provider": "github-models",
+      "api": "chat",
+      "lifecycle": "current",
+      "positioning": "catalog-fallback",
+      "source_ids": ["github-models-catalog-2026-07-10"],
+      "pricing": {
+        "basis": "GitHub Models quota and rate limits",
+        "as_of": "2026-07-10"
+      }
+    },
+    {
+      "model_id": "gpt-5.5",
+      "provider": "openai",
+      "api": "chat",
+      "lifecycle": "compatibility",
+      "positioning": "coding-worker-profile",
+      "notes": "Retained only because .github/agents/registry.yml still references this coding-worker model. It is not eligible for auxiliary evaluator selection."
+    },
     {
       "model_id": "gpt-5.4",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.97 },
-      "cost_score": 0.25,
-      "speed_score": 0.64,
-      "notes": "Current flagship verifier default. Highest-quality general evaluator."
-    },
-    {
-      "model_id": "gpt-5.1",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.90, "T2": 0.90, "T3": 0.92, "T4": 0.92, "T5": 0.93 },
-      "cost_score": 0.40,
-      "speed_score": 0.72,
-      "notes": "Nov 2025 flagship. Reasoning defaults to none — set effort explicitly."
-    },
-    {
-      "model_id": "gpt-5.1-codex",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.88, "T2": 0.92, "T3": 0.95, "T4": 0.93, "T5": 0.94 },
-      "cost_score": 0.38,
-      "speed_score": 0.70,
-      "notes": "Code-optimized GPT-5.1. Strong candidate for Codex session analysis."
-    },
-    {
-      "model_id": "gpt-5.1-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.82, "T2": 0.80, "T3": 0.75, "T4": 0.72, "T5": 0.68 },
-      "cost_score": 0.82,
-      "speed_score": 0.92,
-      "notes": "Lightweight 5.1. Risk of leniency on analysis tasks."
-    },
-    {
-      "model_id": "gpt-5",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.90, "T4": 0.90, "T5": 0.90 },
-      "cost_score": 0.45,
-      "speed_score": 0.75,
-      "notes": "Aug 2025 flagship. Proven, superseded by 5.1+."
-    },
-    {
-      "model_id": "gpt-5-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.78, "T2": 0.75, "T3": 0.70, "T4": 0.68, "T5": 0.62 },
-      "cost_score": 0.85,
-      "speed_score": 0.93,
-      "notes": "Budget GPT-5. Good speed/cost, but not chosen for verifier-critical tasks."
-    },
-    {
-      "model_id": "gpt-5.4-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.84, "T2": 0.82, "T3": 0.78, "T4": 0.76, "T5": 0.72 },
-      "cost_score": 0.88,
-      "speed_score": 0.94,
-      "notes": "High-quality mini. Default for progress review where speed still matters."
-    },
-    {
-      "model_id": "gpt-5-nano",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.70, "T2": 0.65, "T3": 0.55, "T4": 0.50, "T5": 0.40 },
-      "cost_score": 0.95,
-      "speed_score": 0.98,
-      "notes": "Smallest GPT-5. Only suitable for T1 tasks."
-    },
-    {
-      "model_id": "gpt-4.1",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.88, "T4": 0.87, "T5": 0.88 },
-      "cost_score": 0.55,
-      "speed_score": 0.80,
-      "notes": "Battle-tested (Apr 2025). Excellent stability and structured output."
-    },
-    {
-      "model_id": "gpt-4.1-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.65 },
-      "cost_score": 0.90,
-      "speed_score": 0.95,
-      "notes": "Lightweight 4.1. Good for T1/T2, risky for T3+."
-    },
-    {
-      "model_id": "gpt-4.1-nano",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.68, "T2": 0.63, "T3": 0.52, "T4": 0.48, "T5": 0.38 },
-      "cost_score": 1.00,
-      "speed_score": 1.00,
-      "notes": "Cheapest and fastest. Only for trivial classification."
-    },
-    {
-      "model_id": "codex-mini-latest",
-      "provider": "github-models",
-      "api": "chat",
-      "quality": { "T1": 0.75, "T2": 0.80, "T3": 0.78, "T4": 0.72, "T5": 0.65 },
-      "cost_score": 0.80,
-      "speed_score": 0.88,
-      "notes": "Rolling Codex alias. Good for code-centric extraction."
-    },
-    {
-      "model_id": "o4-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.85, "T2": 0.88, "T3": 0.92, "T4": 0.88, "T5": 0.93 },
-      "cost_score": 0.30,
-      "speed_score": 0.35,
-      "notes": "Reasoning model. High quality but 5-15s latency. Use for high-stakes only."
-    },
-    {
-      "model_id": "o3",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.90, "T2": 0.92, "T3": 0.95, "T4": 0.92, "T5": 0.96 },
-      "cost_score": 0.15,
-      "speed_score": 0.15,
-      "notes": "Deep reasoning. 10-30s response. Generally too slow for CI/CD."
-    },
-    {
-      "model_id": "o3-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.83, "T2": 0.85, "T3": 0.88, "T4": 0.85, "T5": 0.90 },
-      "cost_score": 0.35,
-      "speed_score": 0.30,
-      "notes": "Legacy reasoning mini. Superseded by o4-mini."
-    },
-    {
-      "model_id": "gpt-4o",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.85, "T4": 0.84, "T5": 0.84 },
-      "cost_score": 0.55,
-      "speed_score": 0.80,
-      "notes": "Legacy — currently used as DEFAULT_MODEL. Two generations behind."
-    },
-    {
-      "model_id": "gpt-4o-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": { "T1": 0.60, "T2": 0.55, "T3": 0.45, "T4": 0.40, "T5": 0.30 },
-      "cost_score": 0.78,
-      "speed_score": 0.88,
-      "blocked": true,
-      "notes": "BLOCKED: Documented as too lenient, passes obvious deficiencies."
+      "lifecycle": "current",
+      "positioning": "incumbent-verifier",
+      "source_ids": ["openai-current-models-2026-07-10"],
+      "pricing": {
+        "basis": "Observed billed cost is captured by the paired pilot",
+        "as_of": "2026-07-12"
+      },
+      "notes": "Incumbent OpenAI verifier baseline. Remains selected until paired benchmark evidence approves a replacement."
     },
     {
       "model_id": "claude-opus-4-6",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.93, "T2": 0.94, "T3": 0.96, "T4": 0.96, "T5": 0.98 },
-      "cost_score": 0.08,
-      "speed_score": 0.38,
-      "notes": "Just released Feb 5, 2026. Highest quality, very expensive."
+      "lifecycle": "current",
+      "positioning": "incumbent-verifier",
+      "source_ids": ["anthropic-current-models-2026-07-10"],
+      "pricing": {
+        "basis": "Observed billed cost is captured by the paired pilot",
+        "as_of": "2026-07-12"
+      },
+      "notes": "Incumbent Anthropic verifier baseline. Remains selected until paired benchmark evidence approves a replacement."
     },
     {
-      "model_id": "claude-opus-4-5",
-      "provider": "anthropic",
+      "model_id": "codex-mini-latest",
+      "provider": "github-models",
       "api": "chat",
-      "quality": { "T1": 0.92, "T2": 0.93, "T3": 0.95, "T4": 0.95, "T5": 0.97 },
-      "cost_score": 0.10,
-      "speed_score": 0.40,
-      "notes": "Opus tier. Overkill for most tasks, great for T5."
+      "lifecycle": "current",
+      "positioning": "incumbent-verifier",
+      "source_ids": ["github-models-catalog-2026-07-10"],
+      "pricing": {
+        "basis": "GitHub Models quota and rate limits",
+        "as_of": "2026-07-12"
+      },
+      "notes": "Incumbent GitHub Models verifier fallback. Remains selected until paired benchmark evidence approves a replacement."
+    }
+  ],
+  "selections": [
+    {
+      "profile": "verifier-balanced",
+      "provider": "openai",
+      "model_id": "gpt-5.4",
+      "status": "provisional",
+      "decided_at": "2026-07-10",
+      "review_by": "2026-07-24",
+      "evidence_ids": ["catalog-review-2026-07-10"],
+      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate."
     },
     {
-      "model_id": "claude-sonnet-4-6",
+      "profile": "verifier-balanced",
       "provider": "anthropic",
-      "api": "chat",
-      "quality": { "T1": 0.91, "T2": 0.91, "T3": 0.93, "T4": 0.93, "T5": 0.95 },
-      "cost_score": 0.35,
-      "speed_score": 0.63,
-      "notes": "Current Anthropic compare-mode default. Strong cross-provider verifier."
+      "model_id": "claude-opus-4-6",
+      "status": "provisional",
+      "decided_at": "2026-07-10",
+      "review_by": "2026-07-24",
+      "evidence_ids": ["catalog-review-2026-07-10"],
+      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate."
     },
     {
-      "model_id": "claude-sonnet-4-0",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.88, "T4": 0.88, "T5": 0.90 },
-      "cost_score": 0.40,
-      "speed_score": 0.65,
-      "notes": "Previous Sonnet. Proven but superseded by 4-5."
-    },
+      "profile": "verifier-balanced",
+      "provider": "github-models",
+      "model_id": "codex-mini-latest",
+      "status": "provisional",
+      "decided_at": "2026-07-10",
+      "review_by": "2026-07-24",
+      "evidence_ids": ["catalog-review-2026-07-10"],
+      "rationale": "Incumbent fallback retained until catalog availability and paired repository evidence approve a replacement."
+    }
+  ],
+  "evidence": [
     {
-      "model_id": "claude-haiku-4-5",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.62 },
-      "cost_score": 0.75,
-      "speed_score": 0.90,
-      "notes": "Fast and cheap Claude. Good for T1/T2, untested for T3+."
-    },
-    {
-      "model_id": "claude-3-7-sonnet-latest",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": { "T1": 0.82, "T2": 0.82, "T3": 0.85, "T4": 0.85, "T5": 0.87 },
-      "cost_score": 0.42,
-      "speed_score": 0.65,
-      "notes": "Legacy Claude 3.7. Superseded by Claude 4 Sonnet."
+      "evidence_id": "catalog-review-2026-07-10",
+      "kind": "provider-catalog-review",
+      "measured_at": "2026-07-10",
+      "status": "catalog-only",
+      "source_ids": [
+        "openai-current-models-2026-07-10",
+        "openai-pricing-2026-07-10",
+        "anthropic-current-models-2026-07-10",
+        "github-models-catalog-2026-07-10"
+      ],
+      "notes": "Confirms availability and list pricing only. It is not repository workload quality evidence and cannot approve a selection."
     }
   ]
 }

--- a/config/model_selection_policy.json
+++ b/config/model_selection_policy.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "1.0.0",
+  "policy_id": "auxiliary-verifier-model-selection-v1",
+  "as_of": "2026-07-10",
+  "profiles": {
+    "verifier-balanced": {
+      "workload": "Issue-completion and provider-comparison judgments where false PASS is the highest-cost error.",
+      "candidate_stage": {
+        "minimum_adjudicated_cases": 30,
+        "required_case_categories": [
+          "clean-pass",
+          "missing-acceptance-criterion",
+          "stale-verifier-claim",
+          "review-thread-debt",
+          "follow-up-required"
+        ]
+      },
+      "approval_stage": {
+        "minimum_adjudicated_cases": 75,
+        "minimum_cases_per_category": 10,
+        "confidence_level": 0.95,
+        "quality_gates": {
+          "task_success_rate_wilson_lower_bound": 0.85,
+          "false_pass_rate_wilson_upper_bound": 0.05,
+          "false_fail_rate_wilson_upper_bound": 0.1,
+          "schema_error_rate_wilson_upper_bound": 0.05,
+          "paired_success_noninferiority_margin": 0.02
+        }
+      },
+      "optimization_order": [
+        "pass_all_quality_gates",
+        "minimize_observed_cost_per_accepted_review",
+        "minimize_observed_p95_latency_ms"
+      ],
+      "required_measurements": [
+        "adjudicated_outcome",
+        "false_pass",
+        "false_fail",
+        "schema_error",
+        "input_tokens",
+        "output_tokens",
+        "total_cost_usd",
+        "latency_ms"
+      ],
+      "promotion_rules": {
+        "paired_corpus_required": true,
+        "provider_marketing_claims_are_quality_evidence": false,
+        "new_catalog_models_auto_promote": false,
+        "human_approval_required": true
+      },
+      "review_triggers": {
+        "maximum_days_between_reviews": 30,
+        "catalog_change": true,
+        "pricing_change": true,
+        "material_prompt_or_workload_change": true,
+        "quality_gate_breach": true
+      }
+    }
+  }
+}

--- a/docs/MODEL_SELECTION_POLICY.md
+++ b/docs/MODEL_SELECTION_POLICY.md
@@ -1,0 +1,103 @@
+# Auxiliary Model Selection Policy
+
+> **Status:** Authoritative for `config/model_registry.json` and
+> `config/llm_slots.json`
+> **Policy version:** `auxiliary-verifier-model-selection-v1`
+> **Reviewed:** 2026-07-10
+> **Next decision review:** 2026-07-24
+
+## Decision Principle
+
+Provider positioning and list price are model facts, not workload-quality
+evidence. A model is eligible for approval only after it runs the same frozen,
+adjudicated verifier corpus as the current baseline.
+
+Selection is constrained optimization, not a weighted score:
+
+1. Pass every quality and safety gate.
+2. Among passing models, minimize observed cost per accepted review.
+3. Use observed p95 latency as the final tie-breaker.
+
+This avoids arbitrary normalized quality, cost, and speed numbers. It also
+prevents an inexpensive model from offsetting an unacceptable false-PASS rate.
+
+## Data Boundaries
+
+`config/model_registry.json` keeps three kinds of data separate:
+
+- **Facts:** provider ID, lifecycle, observed catalog date, source URL, and list
+  pricing as of a date.
+- **Evidence:** a catalog review or a versioned repository workload benchmark.
+- **Decision:** one provider/profile model, status, rationale, evidence IDs,
+  decision date, and review deadline.
+
+`config/llm_slots.json` keeps consumer-specific provider preferences but carries
+only a workload profile. Model versions resolve from the registry decision.
+
+## Benchmark Protocol
+
+The `verifier-balanced` policy is defined in
+`config/model_selection_policy.json`.
+
+Evaluate a case-level paired run with:
+
+```bash
+python tools/evaluate_model_benchmark.py benchmark.json --output benchmark-evidence.json
+```
+
+The evaluator computes the confidence bounds and recommendation from case-level
+records. Do not hand-enter aggregate rates or recommendation rankings.
+
+- Use a frozen, versioned corpus with owner-adjudicated expected outcomes.
+- Run every candidate and baseline on the same cases and prompt version.
+- Use at least 30 cases to retain a candidate and at least 75 cases, with 10 per
+  required failure category, to approve it.
+- Report Wilson 95% confidence intervals for task success, false PASS, false
+  FAIL, and schema errors.
+- Require the configured bounds and a paired success result no more than two
+  percentage points below the baseline.
+- Record input/output tokens, actual billed cost, and latency per case. Compare
+  cost per accepted review, not provider list price alone.
+- Treat prompt, schema, reasoning-effort, and retry-policy changes as new
+  benchmark versions. Do not combine unlike runs.
+
+An approved evidence record uses `kind: workload-benchmark` and
+`status: passed`. The freshness gate rejects an approved decision without it.
+
+## Incumbents and Candidates
+
+The existing OpenAI, Anthropic, and GitHub Models verifier choices are recorded
+as provisional incumbents. They remain the runtime baseline while the pilot is
+assembled and run; catalog discovery can add candidates but cannot change a
+selection. A replacement requires paired workload evidence that passes every
+quality gate and an explicit approval update.
+
+## Catalog Discovery
+
+Run:
+
+```bash
+python tools/discover_model_catalog.py --output model-catalog-discovery.json
+```
+
+GitHub Models discovery is public. OpenAI and Anthropic discovery is enabled
+when their API keys are available. The weekly maint-77 workflow attaches the
+diff to its tracking issue.
+
+A newly observed model becomes a candidate. It never changes a selection until
+the benchmark and human-approval rules are satisfied. This is the mechanism
+that keeps the system current without converting a provider release into an
+unreviewed production change.
+
+## Review Triggers
+
+Review at least every 30 days and immediately after any of:
+
+- provider catalog or durable pricing change;
+- material prompt, output schema, workload, or retry-policy change;
+- observed quality-gate breach;
+- selected model lifecycle or availability change.
+
+Update the facts and catalog baseline first, run the paired benchmark, attach
+evidence, then update the explicit selection. Maint-68 propagates the registry;
+consumer slot provider preferences remain intact.

--- a/docs/SETUP_CHECKLIST.md
+++ b/docs/SETUP_CHECKLIST.md
@@ -591,21 +591,20 @@ curl -o .github/workflows/agents-70-orchestrator.yml \
 
 ### 4.2 Autofix Versions Configuration
 
-> **Important**: Each repository maintains its own `autofix-versions.env` file
-> with dependency versions matching its lock files. This file is NOT synced.
+> **Important**: `autofix-versions.env` is not part of the general template sync.
+> Registered first-party consumers receive the canonical shared tool pins through
+> `maint-52-sync-dev-versions.yml`, together with matching dependency-file updates.
 
 Create `.github/workflows/autofix-versions.env`:
 
 ```bash
-# Tool versions for autofix - match your project's lock files
-RUFF_VERSION=0.8.1
-MYPY_VERSION=1.14.0
-BLACK_VERSION=24.10.0
-ISORT_VERSION=5.13.2
+curl -fsSL \
+  https://raw.githubusercontent.com/stranske/Workflows/main/.github/workflows/autofix-versions.env \
+  -o .github/workflows/autofix-versions.env
 ```
 
 - [ ] `autofix-versions.env` file created
-- [ ] Versions match project's dependency versions
+- [ ] Shared tool versions match the canonical Workflows pins and project lock files
 
 To find your current versions:
 ```bash

--- a/docs/contracts/agent-runner-output.md
+++ b/docs/contracts/agent-runner-output.md
@@ -1,8 +1,8 @@
 # Agent Runner Output Contract
 
-**Version:** 1.0
+**Version:** 1.1
 **Status:** Canonical specification
-**Last Updated:** February 17, 2026
+**Last Updated:** July 10, 2026
 
 ## Purpose
 
@@ -103,6 +103,26 @@ All runners MUST support LLM-based task completion analysis:
 | `llm-completed-tasks` | string | JSON array of completed task descriptions | `'["Add tests", "Fix bug"]'` |
 | `llm-has-completions` | string | Whether any task completions were detected (`"true"` \| `"false"`) | `"true"` |
 
+### Optional Capability Effect Evidence
+
+These provider-neutral outputs are empty by default. A caller MAY supply a
+complete evidence record when the run is exercising an existing bounded
+capability. Runners MUST validate the record through the shared runner library;
+they MUST NOT infer capability identity or effects from free-form agent prose.
+
+| Output | Type | Description | Example |
+|--------|------|-------------|---------|
+| `capability-id` | string | Existing lowercase kebab capability identifier | `capability:consumer-sync` |
+| `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:0000000000000000000000000000000000000000000000000000000000000000` |
+| `evidence-artifact-ref` | string | Secret-safe durable logical evidence reference | `github-actions:owner/repo:123:consumer-sync-plan` |
+| `supervision-mode` | string | `shadow` \| `human-reviewed` \| `human-on-exception` \| `unattended` | `shadow` |
+| `capability-evidence-status` | string | `accepted` \| `rejected` \| `not-evaluated` | `accepted` |
+| `terminal-disposition` | string | `success` \| `failure` \| `no-change` \| `blocked` \| `cancelled` | `no-change` |
+
+Evidence is all-or-none: if any field is non-empty, every field is required.
+Invalid or partial evidence fails before agent execution. Empty evidence retains
+the v1.0 behavior and is not interpreted as a rejected capability outcome.
+
 ---
 
 ## Output Semantics
@@ -200,6 +220,10 @@ New optional outputs MAY be added without breaking compatibility:
 - Add output with default empty string value
 - Update this document
 - Update all existing runners to provide the output
+
+Capability evidence added in v1.1 follows this rule: all existing runners
+provide the outputs, and all values remain empty unless a caller supplies one
+complete validated record.
 
 ### Deprecating Outputs
 

--- a/docs/contracts/capability-bundle-v1.md
+++ b/docs/contracts/capability-bundle-v1.md
@@ -1,0 +1,12 @@
+# Capability Bundle v1
+
+`capability-bundle/v1` is the neutral Workflows contract for portable, deterministic keepalive capability fragments. A bundle may carry task and acceptance fragments plus gate/playbook references, but it must not carry local posterior weights, credentials, raw prompts, or autonomous local-control commands.
+
+Required fields:
+
+- `capability_id`, `version`, and `content_hash`
+- deterministic `selector` predicates such as repo, agent, mode, and labels
+- `owner`, `fragments`, `gates`, and `rollback`
+- optional `expires_at` and `playbooks`
+
+The content hash is `sha256:` over the canonical JSON payload excluding `content_hash`. Keepalive prompt composition reports applied bundle IDs/hashes and rejected reasons; keepalive metrics record the same evidence so downstream dashboards can distinguish "no bundle matched" from "bundle applied."

--- a/docs/contracts/identity-map-conventions.md
+++ b/docs/contracts/identity-map-conventions.md
@@ -1,0 +1,149 @@
+# Research Backplane Identity-Map Conventions
+
+This document defines the **canonical entity ID** format and alias-handling
+conventions that backplane participants emit in `run-contract/v1`
+`identity_refs` and `evidence-object/v1` `entity_ref`. It is the convention that
+lets the orchestrator **join entities across tools**.
+
+> **Status: P0 landing (under human review).** Part of the `run-contract/v1`
+> contract set. See [`run-contract-v1.md`](./run-contract-v1.md) for the
+> envelope spec and [`research-backplane-contract.md`](./research-backplane-contract.md)
+> for ownership. These are *conventions*, not central code: resolution stays in
+> the authoritative repos.
+
+## Why this is a convention, not central code
+
+Identity is **bimodal** across the fleet (`FEASIBILITY-blueprint.md` §4.4):
+three repos have production-grade resolution, three have weak/none.
+
+- Manager-Database (3/3): canonical `manager_id` + `aliases text[]` + `cik` +
+  `lei` + `registry_ids jsonb`, with live EDGAR alias resolution
+  (`resolve_aliases.py:139-191`).
+- Pension-Data (3/3): `build_canonical_stable_id` →
+  `<entity_type>:<normalized_name>[:<keys>]` (`entities/service.py:54-67`),
+  exact/normalized/fuzzy matching, explicit `merge_canonical_entities`.
+- Counter_Risk (3/3): strictly-validated `canonical_key` name registry
+  (`name_registry.py:69-115`), but its `canonical_key` "is not surfaced as a
+  shared global ID in run outputs."
+- Trend_Model (0/3): funds identified by raw CSV column labels.
+- Inv-Man-Intake (1/3): `aliases_json` hard-coded `None`
+  (`integration.py:252`); slug-only.
+- PAEM (1/3, N/A): a Monte Carlo engine over typed config has no entities to
+  resolve.
+
+The backplane join works **only because two repos already have production
+resolution** — so this contract does **not** build a new central resolver.
+Instead, per the feasibility memo's risk-3 mitigation ("declare
+Manager-Database/Pension-Data the identity source-of-truth on day one",
+§7): Workflows owns *only* the **emission format** (the canonical-ID string
+shape below) and the rule for *which repos are authoritative*. Resolution stays
+in the strong repos.
+
+## Canonical ID format
+
+A canonical entity ID is a lowercase, colon-prefixed, deterministic string:
+
+```
+<entity_type>:<normalized_identity>
+```
+
+- `entity_type` ∈ a closed vocabulary (below), lowercase snake_case.
+- `normalized_identity` is a deterministic normalization of the entity's
+  identifying key(s): a registry id when one exists (preferred), else a
+  normalized name. Lowercase, `[a-z0-9]`, internal separators collapsed to `_`,
+  with optional dotted/colon/`-` qualifiers.
+
+Regex (enforced by the validator and the schemas'
+`identity_refs`/`entity_ref` patterns):
+
+```
+^[a-z0-9_]+:[a-z0-9][a-z0-9_.:-]*$
+```
+
+Examples:
+
+```
+manager:cik_0001067983          # registry-id-anchored (preferred)
+manager:berkshire_hathaway      # name-anchored fallback
+fund:lei_5493001kjtiigc8y1r12
+pension:calpers
+provider:bloomberg
+person:warren_buffett
+strategy:trend_following
+```
+
+This generalizes the two strong in-repo formats: Pension-Data's
+`<entity_type>:<normalized_name>[:<keys>]` and Manager-Database's
+`manager_id` + registry-id columns, lifted into one fleet-wide string.
+
+## Entity-type vocabulary (closed)
+
+| `entity_type` | Covers | Authoritative source-of-truth repo(s) |
+| --- | --- | --- |
+| `manager` | Investment managers / firms / advisers | **Manager-Database** (best-in-fleet 3/3), Pension-Data |
+| `fund` | Funds / vehicles / share classes | Pension-Data, Inv-Man-Intake (once aliasing is real) |
+| `pension` | Pension plans / asset owners | Pension-Data |
+| `provider` | Data/clearing/service providers, counterparties, clearing houses | Counter_Risk (counterparties/clearing houses), Manager-Database |
+| `person` | Named individuals (PMs, signatories) | Pension-Data, Manager-Database |
+| `strategy` | Strategies / asset classes / scenarios | Inv-Man-Intake (asset-class registry, fully solved), Trend_Model (target) |
+
+Adding a new `entity_type` is an additive v1 change (new vocabulary member) with
+a changelog note in this doc; removing one is breaking (→ a `v2` of the
+conventions).
+
+## Source-of-truth rule (the discipline decision)
+
+When two tools emit a canonical ID for the same real-world entity, the
+**authoritative repo's** ID wins for the join. The authority order is declared
+centrally (this doc + the registry), with the day-one decision being:
+
+1. **`manager` / `provider` / `person`** → Manager-Database is authoritative
+   (live EDGAR alias resolution, `cik`/`lei`/`registry_ids`).
+2. **`pension` / `fund`** → Pension-Data is authoritative (`build_canonical_stable_id`
+   + explicit merge path).
+3. **`strategy`** → Inv-Man-Intake's asset-class canonical key set is
+   authoritative for asset classes; Trend_Model resolves its column labels *to*
+   these IDs rather than inventing new ones.
+
+A non-authoritative tool that cannot resolve to the authoritative ID emits its
+best-effort name-anchored ID **and** a `confidence < 1.0` on the related evidence
+object, so the orchestrator can flag the unresolved join rather than silently
+fragmenting (the exact failure mode Inv-Man-Intake has today: "Summit Arc
+Advisors" vs "…LLC" fragment).
+
+## Alias handling
+
+- **Registry-id-anchored IDs are preferred and stable** across alias variants:
+  `manager:cik_0001067983` is the same entity regardless of the display name
+  used in a given document.
+- **Name-anchored IDs are a deterministic fallback** only. A tool that later
+  resolves a name to a registry id SHOULD prefer the registry-anchored ID and
+  record the prior name-anchored ID as an alias.
+- **Aliases are never inlined as identity.** A run that sees "Summit Arc
+  Advisors LLC" emits the canonical ID for the resolved entity (or the
+  name-anchored fallback) and may carry the surface string under a
+  `data_quality`/evidence note — it does not mint a second entity.
+- **Merges are explicit.** When two canonical IDs are later determined to be the
+  same entity, the authoritative repo records the merge (Pension-Data's
+  `merge_canonical_entities`, Manager-Database's alias append) and the merged-away
+  ID resolves forward. Backplane consumers treat a forwarded ID as equal to its
+  target.
+
+## What participants emit
+
+- In `run-contract/v1` `identity_refs`: the canonical IDs of entities the run
+  consumed and/or emitted (so the orchestrator can thread joins between steps).
+- In `evidence-object/v1` `entity_ref` (optional): the canonical ID the
+  attributed fact is about.
+- Computational tools with no entities (PAEM) omit `identity_refs` entirely and
+  do not list `identity` in their registry `required_sections` — they are never
+  failed for it.
+
+## What is NOT standardized
+
+- The **resolution algorithm** stays in each authoritative repo (fuzzy/exact/EDGAR).
+  Workflows does not host a resolver.
+- A **global entity service / shared database** is explicitly out of scope for
+  the prototype (`FEASIBILITY-blueprint.md` §2 "Depends on data & discipline":
+  the join is a discipline decision, not a new service). The convention + the
+  source-of-truth rule are sufficient for the 3-tool prototype.

--- a/docs/contracts/run-contract-v1.md
+++ b/docs/contracts/run-contract-v1.md
@@ -1,0 +1,263 @@
+# Research Backplane Run Contract
+
+`run-contract/v1` is the shared Workflows-owned contract for repo-emitted
+**run envelopes** on the investment research backplane. Participating tools own
+their domain compute and instrumentation; Workflows owns the common run-record
+shape, the participant registry, validation, and the cross-repo reference-run
+rollup.
+
+> **Status: P0 landing (under human review).** This is the wire-format spec.
+> Schema: [`run-contract-v1.schema.json`](./schemas/run-contract-v1.schema.json).
+> Program/ownership doc: [`research-backplane-contract.md`](./research-backplane-contract.md).
+> Sibling observability contract: [`langsmith-fleet-v1.md`](./langsmith-fleet-v1.md).
+> The contract is **opt-in**: a repo participates only via an entry in
+> `config/backplane_participants.json`. No participant emits an envelope yet
+> (that is P1+); nothing here is wired into any repo's CI.
+
+## Design Decision
+
+The run contract is contract-first, not package-first, and opt-in, not
+fleet-wide (same stance as `langsmith-fleet/v1`):
+
+- Workflows owns the canonical `run-contract/v1` envelope, its JSON Schema, the
+  `artifact-manifest/v1` and `evidence-object/v1` satellite schemas, the
+  identity-map conventions, the registry (`config/backplane_participants.json`),
+  the validator (`scripts/validate_run_contract.py`), fixtures, and the
+  reusable conformance workflow.
+- Participating repos own their local emitters and adapters. They project their
+  existing run state (`RunResult`, ledgers, `manifest.json`) into a conformant
+  `run.json`. A consumer-local helper is fine as long as the emitted envelope
+  conforms to this contract and the registry's participant requirements.
+- A consumer-local subset validator is not a design violation by itself. It is
+  only incomplete if it allows envelopes that fail the Workflows canonical
+  schema, references artifacts not present in the manifest, drops a
+  registry-required section, emits non-canonical identity refs, or carries
+  unsafe raw input/output payloads.
+- Workflows does not currently publish a Python package for participants to
+  import. That would only be worth the version-management overhead if the
+  backplane starts seeing repeated schema drift, duplicated validator defects,
+  or cross-repo release-coordination failures.
+
+Orchestrator/verifier agents should consult this section before pausing for a
+human decision about local emitters. If the current repo artifacts conform to
+the canonical schema and registry, advance the recipe instead of halting on
+implementation shape alone.
+
+## Why this contract exists (the keystone gap)
+
+Across the six investment repos, `run_contract` scores **uniformly 2/3 (one
+outlier at 1/3)**, and the gap is identical everywhere: **there is no single JSON
+object representing a whole run** with who/why + validated inputs + outputs +
+named artifacts + warnings + cost/latency + provenance, replayable as one record
+(`FEASIBILITY-blueprint.md` §4.1). The pieces exist but are split across
+in-memory dataclasses, a fleet-telemetry NDJSON, and separate manifests:
+
+- Trend_Model: data split across in-memory `RunResult` (holds DataFrames, not
+  JSON-serializable), `run_meta.json`, and `manifest.json`; no cost/latency on
+  the run path; warnings only via `logging` (`api.py:604`); no actor/intent.
+- PAEM: provenance split across `manifest.json`, `run_end.json`, `bundle.json`;
+  **warnings never serialized** (only stderr); **no cost** (`contracts.py:136`
+  `ManifestPayload` has neither).
+- Pension-Data: orchestration has a ledger, but the NL/SQL surface persists
+  nothing beyond an in-memory audit row; **cost captured nowhere** (grep for
+  `cost_usd|tokens` is empty).
+- Counter_Risk: schema'd manifest exists but has **no top-level
+  `schema_version`, no actor/why, no cost**; the full `manifest_schema()` is
+  never enforced against a written manifest.
+- Manager-Database (1/3): core tools return bare `list`/`None`; `cost_usd`
+  hard-coded `0.0` (`adapters/base.py:173`).
+- Inv-Man-Intake: full run is a `V1SmokeArtifacts` dataclass of `object` fields,
+  never serialized to one envelope.
+
+`run-contract/v1` is that single object. It is **additive**: a participant keeps
+its existing `RunResult`/manifests and adds the envelope as an export-time
+projection.
+
+## Artifact
+
+Each participating repo emits one JSON object per run at the artifact name
+registered in `config/backplane_participants.json` (default `run.json`), written
+under a per-run directory using the convention
+`artifacts/<tool>/<run_id>/run.json` (the layout Manager-Database's blueprint
+already proposes; `FEASIBILITY-blueprint.md` §5 Phase 1).
+
+The envelope must be safe to publish in GitHub Actions artifacts and dashboards:
+**raw prompts, personal data, documents, SQL result rows, generated report text,
+and full model outputs must be represented by hashes, excerpts of bounded
+length, or artifact references** — never inlined. Output *data* lives in named
+artifacts referenced by the manifest, not in the envelope body.
+
+## Shared Fields
+
+Required fields:
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Must be `run-contract/v1`. |
+| `repo` | Full repository name, for example `stranske/Pension-Data`. |
+| `tool` | Stable tool identifier within the repo, for example `nl-to-sql` or `run-simulation`. Matches a registry `entry_point` tool. |
+| `run_id` | Stable run identifier. SHOULD be content-addressed (e.g. `sha256(inputs|config|seed)`) so replays and "already-done" detection work; MUST be stable across a deterministic re-run. |
+| `status` | One of `success`, `error`, `partial`, `fallback`, `skipped`. |
+| `actor` | Who/why object: who initiated the run and why (see below). |
+| `inputs` | Validated input echo / references (see below). Never raw payloads. |
+| `outputs` | Output summary + the manifest reference (see below). |
+| `provenance` | Tool + code + environment provenance (see below). |
+| `github_issue` | Owning implementation issue, for example `stranske/Workflows#<n>`. |
+
+### `actor` (who/why)
+
+| Subfield | Req | Meaning |
+| --- | --- | --- |
+| `actor.kind` | required | `human`, `agent`, `schedule`, `recipe`, or `ci`. |
+| `actor.id` | required | Caller key, agent key, recipe id, or schedule id. Not PII; use a key/handle, not a name+email. |
+| `actor.intent` | optional | Short free-text or coded reason ("weekly counterparty refresh", recipe step id). The "why". |
+| `actor.correlation_id` | optional | Ties this run to an orchestrator/recipe run or an upstream request. |
+
+This closes the fleet-wide "no who/why" gap (every repo lacks an actor/intent
+field; `FEASIBILITY-blueprint.md` §4.1).
+
+### `inputs` (validated, never raw)
+
+| Subfield | Req | Meaning |
+| --- | --- | --- |
+| `inputs.validated` | required | `true` once the tool has validated inputs against its own schema/Pydantic model before running. |
+| `inputs.refs` | optional | List of `input_hash`-style references (`sha256:`/`artifact:`/`ref:`) to input files (e.g. `config_sha256`, `input_sha256`). |
+| `inputs.summary` | optional | A bounded, safe summary object (e.g. `{ "as_of_date": "...", "scenario": "..." }`) — domain keys, no raw rows/PII. |
+
+### `outputs`
+
+| Subfield | Req | Meaning |
+| --- | --- | --- |
+| `outputs.manifest_ref` | required | Reference to the run's `artifact-manifest/v1` manifest (`artifact:manifest.json` or a relative path). The named artifacts live there, not inline. |
+| `outputs.summary` | optional | Bounded safe summary of results (e.g. `{ "final_score": 0.7809 }`, `{ "limit_breach_count": 0 }`). No raw rows / full text. |
+| `outputs.artifact_ids` | optional | The stable `artifact_id`s (from the manifest) this run produced, for quick orchestrator threading. |
+
+### `provenance`
+
+| Subfield | Req | Meaning |
+| --- | --- | --- |
+| `provenance.tool_version` | required | The producing package version (`importlib.metadata.version` / `VERSION`). |
+| `provenance.git_sha` | optional | Best-effort git SHA; `null` when unavailable. |
+| `provenance.python_version` | optional | Interpreter version. |
+| `provenance.platform` | optional | OS/platform string. |
+| `provenance.code_version` | optional | Any additional code-identity hash the tool already computes (PAEM has one). |
+
+This closes the Counter_Risk/Trend_Model provenance gap (tool+git+python version
+needed for replay/audit; `Counter_Risk` blueprint issue, `manifest.py:97-120`).
+
+## Optional Shared Fields
+
+| Field | Meaning |
+| --- | --- |
+| `cost` | Object: `{ "usd": number\|null, "input_tokens": int, "output_tokens": int }`. `usd` is null-able for non-LLM/local-numpy runs; **the point is the field exists** so cost stops being un-capturable (the universal gap: cost is captured nowhere in ≥3 repos, hard-coded `0.0` in Manager-Database `adapters/base.py:173`). |
+| `latency` | Object: `{ "wall_ms": number }` (+ optional `peak_mem_mb`). Most repos already have a timing value; this normalizes it into the envelope. |
+| `warnings` | Array of `{ "code", "severity", "message", "context"? }`. Closes the universal "warnings survive only to logs/stderr" gap (PAEM, Trend_Model, Counter_Risk). Severity ∈ `info`/`warning`/`error`. When a tool's registry entry lists `warnings` as required, the *key* must be present; an **empty array is valid** and means "ran, no warnings" (a clean run is not a contract violation). |
+| `data_quality` | Object surfacing run-level missingness/conflict/low-confidence state (counts of dropped/coerced rows, a `conflict` indicator when two sources disagree). Closes the "rich at the domain layer, collapsed at the run layer" gap (`FEASIBILITY-blueprint.md` §4.5). Optional and only meaningful for tools whose registry entry lists `data_quality` in `required_sections`. |
+| `evidence_refs` | Array of references to `evidence-object/v1` objects (by `evidence_id`), present when the tool's run produced attributable facts. See `schemas/evidence-object-v1.schema.json`. Required-when-applicable per the registry's `required_sections`. |
+| `identity_refs` | Array of canonical entity IDs (per `identity-map-conventions.md`) this run consumed/emitted, so the orchestrator can join across tools. |
+| `langsmith` | Object: `{ "trace_id", "trace_url" }` linking this run to its `langsmith-fleet/v1` trace. Cross-references the sibling observability contract without duplicating payloads. |
+| `recorded_at` | ISO timestamp used for stale-artifact / reference-run freshness. |
+| `parent_run_id` | When this run is a step inside a recipe, the orchestrator's composite `run_id`. |
+
+## Registry
+
+`config/backplane_participants.json` maps each opted-in repo to:
+
+- repo and parent implementation issue,
+- adopted `contract_version` (`run-contract/v1`),
+- a `role` — `producer` | `consumer` | `bridge` (see below),
+- declared headless `entry_point` (the tool's invocation contract),
+- `artifact_name` (default `run.json`) and `manifest_name` (default
+  `manifest.json`),
+- `required_sections` — which optional sections are mandatory *for this tool*
+  (e.g. an extraction tool requires `evidence` + `identity`; a Monte Carlo
+  engine requires neither),
+- `status` (`planned` → `emitting` → `conformant`; or `candidate` for a
+  pre-approval role-architecture placeholder that the gate treats as a no-op).
+
+### Participant `role` (producer / consumer / bridge)
+
+Participation is **not binary in/out**. Each participant declares a `role` so the
+conformance gate validates the right thing for it:
+
+- **`producer`** — a research tool that *emits* a full `run-contract/v1` envelope
+  (+ `artifact-manifest/v1` manifest) from its run. The recommended first
+  producers are the Tier-1/Tier-2 investment tools. A producer's gate validates
+  full run-contract emission (all required shared fields + its
+  `required_sections`).
+- **`consumer`** — a downstream system that *ingests* backplane artifacts
+  (e.g. evidence objects and identity refs) but does not itself run a research
+  tool that emits a run envelope. A consumer's gate validates **only the schemas
+  it ingests** (the satellite `evidence-object/v1` / `artifact-manifest/v1`
+  shapes named in its `ingests`), **not** full producer run-contract emission. A
+  consumer is never failed for not emitting a `run.json`.
+- **`bridge`** — a participant that both ingests upstream artifacts and emits its
+  own envelope (an orchestrator/recipe step is the canonical bridge: it reads
+  each step's `run.json` and emits a composite one). A bridge's gate applies both
+  the producer emission checks and the consumer ingest checks.
+
+This role model is what lets cross-over use cases be expressed *architecturally*
+without forcing them live: e.g. investment-tool evidence/identity flowing into a
+learning system is a `consumer` relationship, recorded as a `candidate` entry so
+the architecture is captured while the consumer stays inactive (the gate skips
+`candidate`/`none`). See `research-backplane-contract.md` for the
+producer/consumer/bridge ownership boundaries.
+
+Reference-run / dashboard status is computed per participant entry, mirroring the
+fleet `missing`/`invalid`/`stale`/`valid` rollup:
+
+- `missing`: no `run.json` was emitted for that participant's reference run.
+- `invalid`: a `run.json` exists but fails the shared schema or a
+  registry-required section.
+- `stale`: latest valid envelope is older than the registry freshness window.
+- `valid`: at least one current valid envelope exists.
+
+## Validation
+
+Run validation locally without any cloud key (deterministic, offline — the same
+guarantee as `langsmith_fleet.py`):
+
+```bash
+python scripts/validate_run_contract.py tests/fixtures/backplane/valid_run.json
+```
+
+Validate against a specific participant's registry requirements and its manifest:
+
+```bash
+python scripts/validate_run_contract.py \
+  artifacts/pension-data/<run_id>/run.json \
+  --manifest artifacts/pension-data/<run_id>/manifest.json \
+  --repo stranske/Pension-Data
+```
+
+The validator must fail: malformed JSON, missing required shared fields, an
+unknown/absent participant repo, missing registry-required sections (e.g.
+`evidence_refs` absent when the entry requires `evidence`), any artifact named in
+`outputs.artifact_ids` that is not present in the manifest with a `sha256`,
+non-canonical identity refs, unsafe raw input/output payload fields, negative
+`cost`/`latency` numbers, and invalid `status` values. The canonical schema is
+versioned at `docs/contracts/schemas/run-contract-v1.schema.json` and is enforced
+by `scripts/validate_run_contract.py`.
+
+## Repo Responsibilities
+
+Participant implementation issues add an emitter and emit a conformant envelope.
+They must **not** move domain compute or extraction logic into Workflows.
+Workflows only validates the emitted envelope/manifest and rolls up reference-run
+status.
+
+Each participant implementation issue should:
+
+1. Keep tool/compute/extraction logic in the participant repo, not in Workflows.
+2. Emit a `run.json` (+ `manifest.json`) that validates as `run-contract/v1`
+   (+ `artifact-manifest/v1`).
+3. Populate shared fields (`repo`, `tool`, `run_id`, `status`, `actor`,
+   `inputs`, `outputs`, `provenance`, `github_issue`) exactly as the registry
+   entry defines.
+4. Populate the optional sections its registry entry lists in
+   `required_sections` (e.g. `cost`, `warnings`, `evidence_refs`,
+   `identity_refs`).
+5. Avoid raw prompts/output/PII; publish references, hashes, and bounded
+   excerpts instead.
+6. Link back to the parent Workflows backplane issue so rollout status is
+   tracked centrally, and (where present) cross-link the `langsmith` trace.

--- a/docs/contracts/schemas/artifact-manifest-v1.schema.json
+++ b/docs/contracts/schemas/artifact-manifest-v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stranske/Workflows/docs/contracts/schemas/artifact-manifest-v1.schema.json",
+  "title": "Research Backplane Artifact Manifest v1",
+  "description": "Per-run manifest of named artifacts with stable IDs and content hashes. Mirrors the shapes already shipped by the 3/3 artifact_discipline repos (Trend_Model run_meta.json outputs map, PAEM bundle.json hashes.outputs, Counter_Risk manifest output_paths). The run envelope (run-contract/v1) references this via outputs.manifest_ref.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "run_id",
+    "tool",
+    "artifacts"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "artifact-manifest/v1"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tool": {
+      "type": "string",
+      "minLength": 1
+    },
+    "git_sha": {
+      "type": ["string", "null"]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "artifact_id",
+          "name",
+          "path",
+          "sha256"
+        ],
+        "properties": {
+          "artifact_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "data",
+              "report",
+              "chart",
+              "workbook",
+              "log",
+              "evidence",
+              "envelope",
+              "other"
+            ]
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Run-dir-relative POSIX path. Absolute paths and '..' traversal are rejected by the validator.",
+            "pattern": "^(?!/)(?!.*(^|/)\\.\\.(/|$)).+"
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "bytes": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "media_type": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/contracts/schemas/capability-bundle-v1.schema.json
+++ b/docs/contracts/schemas/capability-bundle-v1.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stranske/Workflows/docs/contracts/schemas/capability-bundle-v1.schema.json",
+  "title": "capability-bundle/v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "capability_id",
+    "version",
+    "content_hash",
+    "selector",
+    "owner",
+    "fragments",
+    "gates",
+    "rollback"
+  ],
+  "properties": {
+    "schema_version": { "const": "capability-bundle/v1" },
+    "capability_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._/-]*$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^v?[0-9]+(\\.[0-9]+){0,2}$"
+    },
+    "content_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "selector": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+          ]
+        },
+        "agent": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+          ]
+        },
+        "mode": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        }
+      }
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "fragments": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "task": { "type": "string" },
+        "acceptance": { "type": "string" }
+      },
+      "anyOf": [
+        { "required": ["task"] },
+        { "required": ["acceptance"] }
+      ]
+    },
+    "gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "playbooks": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "rollback": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "not": {
+    "anyOf": [
+      { "required": ["raw_prompt"] },
+      { "required": ["credentials"] },
+      { "required": ["local_weights"] },
+      { "required": ["posterior_weights"] }
+    ]
+  }
+}

--- a/docs/contracts/schemas/evidence-object-v1.schema.json
+++ b/docs/contracts/schemas/evidence-object-v1.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stranske/Workflows/docs/contracts/schemas/evidence-object-v1.schema.json",
+  "title": "Research Backplane Evidence Object v1",
+  "description": "An attributable evidence object linking an extracted/asserted fact back to its source. Closes the fleet's most common evidence gap: even the best repos (Pension-Data 2/3, Inv-Man-Intake 2/3) omit EXCERPT text and extraction METHOD from their evidence object. Both are required here. Out of role for pure computational engines (PAEM/Trend_Model emit no facts) -- such tools list 'evidence' outside their registry required_sections and emit no evidence objects.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "evidence_id",
+    "fact_ref",
+    "source_id",
+    "method",
+    "excerpt"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "evidence-object/v1"
+    },
+    "evidence_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable, deterministic id for this evidence object (e.g. a content hash), referenced from run-contract/v1 evidence_refs."
+    },
+    "fact_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the fact/metric/field this evidence supports (e.g. 'strategy.asset_class', a metric key, a holdings delta id)."
+    },
+    "source_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable source document / dataset id the fact was drawn from."
+    },
+    "method": {
+      "type": "string",
+      "enum": [
+        "rule",
+        "parser",
+        "table",
+        "text",
+        "ocr",
+        "llm",
+        "computed",
+        "fallback",
+        "manual"
+      ],
+      "description": "How the fact was extracted/produced. This is the field the fleet's best repos are missing (Pension-Data: no method on the evidence link; Inv-Man-Intake: provider_name lives on the document result, not the field)."
+    },
+    "excerpt": {
+      "type": ["string", "null"],
+      "maxLength": 2000,
+      "description": "The quoted source text supporting the fact (bounded). Required to be PRESENT (string or explicit null) so consumers can see WHAT text supports a fact. The fleet stores positional anchors like 'text:3' instead of quoted excerpts; this field carries the quote. Bounded length keeps it artifact-safe; long source bodies stay in named artifacts."
+    },
+    "locator": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Structured location within the source. The richer locators (bbox/table/row) already exist on types like Inv-Man-Intake SourceLocation but are not propagated to the evidence object today.",
+      "properties": {
+        "page": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "section": {
+          "type": "string",
+          "minLength": 1
+        },
+        "table_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "row": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "column": {
+          "type": ["string", "integer"]
+        },
+        "bbox": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 4,
+          "maxItems": 4
+        }
+      }
+    },
+    "confidence": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Per-evidence-link confidence (so two evidence sources for one fact can carry differing confidences -- a gap noted for Pension-Data, where confidence sits on the fact not the link)."
+    },
+    "entity_ref": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+:[a-z0-9][a-z0-9_.:-]*$",
+      "description": "Optional canonical entity id (per identity-map-conventions.md) the fact is about."
+    }
+  }
+}

--- a/docs/contracts/schemas/run-contract-v1.schema.json
+++ b/docs/contracts/schemas/run-contract-v1.schema.json
@@ -1,0 +1,288 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stranske/Workflows/docs/contracts/schemas/run-contract-v1.schema.json",
+  "title": "Research Backplane Run Envelope v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "repo",
+    "tool",
+    "run_id",
+    "status",
+    "actor",
+    "inputs",
+    "outputs",
+    "provenance",
+    "github_issue"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "run-contract/v1"
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tool": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "success",
+        "error",
+        "partial",
+        "fallback",
+        "skipped"
+      ]
+    },
+    "github_issue": {
+      "type": "string",
+      "minLength": 1
+    },
+    "actor": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "id"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "human",
+            "agent",
+            "schedule",
+            "recipe",
+            "ci"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intent": {
+          "type": "string",
+          "minLength": 1
+        },
+        "correlation_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "validated"
+      ],
+      "properties": {
+        "validated": {
+          "type": "boolean"
+        },
+        "refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^(sha256:|hash:|artifact:|ref:).+"
+          }
+        },
+        "summary": {
+          "type": "object"
+        }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "manifest_ref"
+      ],
+      "properties": {
+        "manifest_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "object"
+        },
+        "artifact_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "tool_version"
+      ],
+      "properties": {
+        "tool_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "git_sha": {
+          "type": ["string", "null"]
+        },
+        "python_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "platform": {
+          "type": "string",
+          "minLength": 1
+        },
+        "code_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "usd": {
+          "type": ["number", "null"],
+          "minimum": 0
+        },
+        "input_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "output_tokens": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "latency": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "wall_ms": {
+          "type": "number",
+          "minimum": 0
+        },
+        "peak_mem_mb": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "code",
+          "severity",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "info",
+              "warning",
+              "error"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          },
+          "context": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "data_quality": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "overall_status": {
+          "type": "string",
+          "enum": [
+            "ok",
+            "info",
+            "warn",
+            "fail"
+          ]
+        },
+        "dropped_rows": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "coerced_rows": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "conflict": {
+          "type": "boolean"
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "identity_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9_]+:[a-z0-9][a-z0-9_.:-]*$"
+      }
+    },
+    "langsmith": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trace_url": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "recorded_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "parent_run_id": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -78,6 +78,7 @@ def _request_response(
     token: str,
     payload: dict[str, Any] | None,
     *,
+    accept: str = "application/vnd.github+json",
     max_attempts: int = DEFAULT_RETRY_ATTEMPTS,
     backoff: float = DEFAULT_RETRY_BACKOFF,
 ) -> _Response:
@@ -87,7 +88,7 @@ def _request_response(
             request_kwargs: dict[str, Any] = {
                 "headers": {
                     "Authorization": f"Bearer {token}",
-                    "Accept": "application/vnd.github+json",
+                    "Accept": accept,
                 },
                 "timeout": DEFAULT_TIMEOUT,
             }
@@ -159,6 +160,49 @@ def fetch_issue(
     if parser is not None:
         return parser(data)
     return data
+
+
+def fetch_pull_request(
+    repo: str,
+    pull_number: int,
+    token: str,
+    *,
+    retry_attempts: int | None = None,
+    retry_backoff: float | None = None,
+) -> dict[str, Any]:
+    """Fetch pull-request metadata through the shared retrying API client."""
+    url = f"{GITHUB_API}/repos/{repo}/pulls/{pull_number}"
+    data = _request_json(
+        "GET",
+        url,
+        token,
+        payload=None,
+        **_retry_kwargs(retry_attempts, retry_backoff),
+    )
+    if not isinstance(data, dict):
+        raise RuntimeError("GitHub API did not return a JSON object for the pull request.")
+    return data
+
+
+def fetch_pull_request_diff(
+    repo: str,
+    pull_number: int,
+    token: str,
+    *,
+    retry_attempts: int | None = None,
+    retry_backoff: float | None = None,
+) -> str:
+    """Fetch a pull-request diff through the shared retrying API client."""
+    url = f"{GITHUB_API}/repos/{repo}/pulls/{pull_number}"
+    response = _request_response(
+        "GET",
+        url,
+        token,
+        payload=None,
+        accept="application/vnd.github.v3.diff",
+        **_retry_kwargs(retry_attempts, retry_backoff),
+    )
+    return response.text
 
 
 def fetch_issues(

--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -131,7 +131,11 @@ if [ "$all_ok" = true ]; then
     echo -e "${GREEN}All required dependencies are available!${NC}"
     echo ""
     echo "You can run the full test suite with:"
-    echo "  python -m pytest"
+    if [ -x ./scripts/run_tests.sh ]; then
+        echo "  ./scripts/run_tests.sh"
+    else
+        echo "  python -m pytest"
+    fi
     exit 0
 else
     echo -e "${RED}Some required dependencies are missing!${NC}"

--- a/scripts/runner_lib/__init__.py
+++ b/scripts/runner_lib/__init__.py
@@ -1,20 +1,24 @@
 """Shared helpers for dual-provider agent runner workflows."""
 
 from .core import (
+    CapabilityEffectEvidence,
     DebounceDecision,
     RunnerPrompt,
     RunnerResult,
     assemble_prompt,
+    normalize_capability_effect_evidence,
     parse_runner_output,
     record_completion,
     should_dispatch,
 )
 
 __all__ = [
+    "CapabilityEffectEvidence",
     "DebounceDecision",
     "RunnerPrompt",
     "RunnerResult",
     "assemble_prompt",
+    "normalize_capability_effect_evidence",
     "parse_runner_output",
     "record_completion",
     "should_dispatch",

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -38,6 +38,28 @@ TRUSTED_MARKER_AUTHORS = {
     "stranske-automation-bot",
 }
 TRUSTED_MARKER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+CAPABILITY_ID_RE = re.compile(r"^capability:(?=[a-z0-9-]{3,128}$)[a-z0-9]+(?:-[a-z0-9]+)*$")
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,255}$")
+SECRET_LIKE_EVIDENCE_PREFIXES = ("ghp_", "github_pat_", "sk-")
+SECRET_LIKE_EVIDENCE_SEGMENT_RE = re.compile(
+    r"(?:^|[:/#@])(?:" + "|".join(SECRET_LIKE_EVIDENCE_PREFIXES) + r")",
+    re.IGNORECASE,
+)
+SUPERVISION_MODES = {
+    "shadow",
+    "human-reviewed",
+    "human-on-exception",
+    "unattended",
+}
+CAPABILITY_EVIDENCE_STATUSES = {"accepted", "rejected", "not-evaluated"}
+TERMINAL_DISPOSITIONS = {
+    "success",
+    "failure",
+    "no-change",
+    "blocked",
+    "cancelled",
+}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -65,6 +87,103 @@ class DebounceDecision:
     key: str
     prior_status: str | None = None
     prior_head_sha: str | None = None
+
+
+def _validate_capability_effect_evidence_values(values: dict[str, str]) -> None:
+    non_strings = [name for name, value in values.items() if not isinstance(value, str)]
+    if non_strings:
+        raise ValueError(
+            "capability evidence fields must be strings; invalid " + ", ".join(non_strings)
+        )
+    if not any(values.values()):
+        return
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        raise ValueError(
+            "partial capability evidence is not allowed; missing " + ", ".join(missing)
+        )
+    if not CAPABILITY_ID_RE.fullmatch(values["capability_id"]):
+        raise ValueError("capability_id must match capability:<lowercase-kebab-id>")
+    if not SHA256_RE.fullmatch(values["effect_fingerprint"]):
+        raise ValueError("effect_fingerprint must be a lowercase sha256 digest")
+    artifact_ref = values["evidence_artifact_ref"]
+    if not EVIDENCE_REF_RE.fullmatch(artifact_ref):
+        raise ValueError("evidence_artifact_ref must be a bounded durable logical reference")
+    lowered_ref = artifact_ref.lower()
+    if SECRET_LIKE_EVIDENCE_SEGMENT_RE.search(artifact_ref):
+        raise ValueError("evidence_artifact_ref has a credential-like prefix")
+    if any(
+        marker in lowered_ref for marker in ("token", "secret", "password", "api-key", "apikey")
+    ):
+        raise ValueError("evidence_artifact_ref contains a secret-like marker")
+    if values["supervision_mode"] not in SUPERVISION_MODES:
+        raise ValueError("unsupported supervision_mode")
+    if values["capability_evidence_status"] not in CAPABILITY_EVIDENCE_STATUSES:
+        raise ValueError("unsupported capability_evidence_status")
+    if values["terminal_disposition"] not in TERMINAL_DISPOSITIONS:
+        raise ValueError("unsupported terminal_disposition")
+
+
+@dataclasses.dataclass(frozen=True)
+class CapabilityEffectEvidence:
+    """Bounded, provider-neutral evidence carried by a runner result.
+
+    Empty evidence is valid for backwards compatibility. Once any capability
+    field is present, the identity, effect fingerprint, durable artifact
+    reference, supervision mode, evidence status, and terminal disposition
+    must all be present and valid.
+    """
+
+    capability_id: str = ""
+    effect_fingerprint: str = ""
+    evidence_artifact_ref: str = ""
+    supervision_mode: str = ""
+    capability_evidence_status: str = ""
+    terminal_disposition: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_capability_effect_evidence_values(
+            {
+                "capability_id": self.capability_id,
+                "effect_fingerprint": self.effect_fingerprint,
+                "evidence_artifact_ref": self.evidence_artifact_ref,
+                "supervision_mode": self.supervision_mode,
+                "capability_evidence_status": self.capability_evidence_status,
+                "terminal_disposition": self.terminal_disposition,
+            }
+        )
+
+    def github_outputs(self) -> dict[str, str]:
+        return {
+            "capability-id": self.capability_id,
+            "effect-fingerprint": self.effect_fingerprint,
+            "evidence-artifact-ref": self.evidence_artifact_ref,
+            "supervision-mode": self.supervision_mode,
+            "capability-evidence-status": self.capability_evidence_status,
+            "terminal-disposition": self.terminal_disposition,
+        }
+
+
+def normalize_capability_effect_evidence(
+    *,
+    capability_id: str = "",
+    effect_fingerprint: str = "",
+    evidence_artifact_ref: str = "",
+    supervision_mode: str = "",
+    capability_evidence_status: str = "",
+    terminal_disposition: str = "",
+) -> CapabilityEffectEvidence:
+    """Validate optional runner capability evidence without inferring from prose."""
+    values = {
+        "capability_id": str(capability_id or "").strip().lower(),
+        "effect_fingerprint": str(effect_fingerprint or "").strip().lower(),
+        "evidence_artifact_ref": str(evidence_artifact_ref or "").strip(),
+        "supervision_mode": str(supervision_mode or "").strip().lower(),
+        "capability_evidence_status": str(capability_evidence_status or "").strip().lower(),
+        "terminal_disposition": str(terminal_disposition or "").strip().lower(),
+    }
+    _validate_capability_effect_evidence_values(values)
+    return CapabilityEffectEvidence(**values)
 
 
 class RunnerDispatchStorage(Protocol):
@@ -1084,6 +1203,21 @@ def _cmd_record_completion(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_normalize_evidence(args: argparse.Namespace) -> int:
+    evidence = normalize_capability_effect_evidence(
+        capability_id=args.capability_id,
+        effect_fingerprint=args.effect_fingerprint,
+        evidence_artifact_ref=args.evidence_artifact_ref,
+        supervision_mode=args.supervision_mode,
+        capability_evidence_status=args.capability_evidence_status,
+        terminal_disposition=args.terminal_disposition,
+    )
+    outputs = evidence.github_outputs()
+    _write_github_output(outputs)
+    print(json.dumps(outputs, sort_keys=True))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -1129,6 +1263,17 @@ def build_parser() -> argparse.ArgumentParser:
     complete.add_argument("--summary", default="")
     complete.add_argument("--exit-code", default=None)
     complete.set_defaults(func=_cmd_record_completion)
+
+    evidence = subparsers.add_parser(
+        "normalize-evidence", help="validate optional capability/effect evidence"
+    )
+    evidence.add_argument("--capability-id", default="")
+    evidence.add_argument("--effect-fingerprint", default="")
+    evidence.add_argument("--evidence-artifact-ref", default="")
+    evidence.add_argument("--supervision-mode", default="")
+    evidence.add_argument("--capability-evidence-status", default="")
+    evidence.add_argument("--terminal-disposition", default="")
+    evidence.set_defaults(func=_cmd_normalize_evidence)
     return parser
 
 

--- a/scripts/sync_dev_dependencies.py
+++ b/scripts/sync_dev_dependencies.py
@@ -13,7 +13,7 @@ Usage:
     python sync_dev_dependencies.py --check           # Verify versions match
     python sync_dev_dependencies.py --apply           # Update pyproject.toml
     python sync_dev_dependencies.py --apply --create-if-missing  # Create dev deps if missing
-    python sync_dev_dependencies.py --apply  # Syncs requirements.lock automatically if it exists
+    python sync_dev_dependencies.py --apply  # Syncs supported requirements lockfiles when present
 """
 
 from __future__ import annotations
@@ -26,7 +26,13 @@ from pathlib import Path
 # Default paths (can be overridden for testing)
 PIN_FILE = Path(".github/workflows/autofix-versions.env")
 PYPROJECT_FILE = Path("pyproject.toml")
-LOCKFILE_FILE = Path("requirements.lock")
+# Direct requirement files can be installed by CI independently of pyproject.
+# Keep every supported dev-tool surface aligned with the canonical pin file.
+LOCKFILE_FILES = (
+    Path("requirements.lock"),
+    Path("requirements-dev.lock"),
+    Path("requirements-dev.txt"),
+)
 
 # Map env file keys to package names
 # Format: ENV_KEY -> (package_name, optional_alternative_names)
@@ -53,7 +59,9 @@ CORE_DEV_TOOLS = [
 ]
 
 LOCKFILE_PATTERN = re.compile(
-    r"^(?P<lead>\s*)(?P<name>[A-Za-z0-9_.-]+)==(?P<version>[^\s#]+)(?P<trail>\s*(?:#.*)?)$"
+    r"^(?P<lead>\s*)(?P<name>[A-Za-z0-9_.-]+)(?P<extras>\[[^]]+\])?"
+    r"(?P<specifier>(?:===|==|!=|<=|>=|~=|<|>)[^\s;#]+)?"
+    r"(?P<marker>\s*;[^#]+?)?(?P<trail>\s*(?:#.*)?)$"
 )
 
 
@@ -280,8 +288,10 @@ def sync_pyproject(
             if pkg_lower in current_packages:
                 actual_pkg, current_op, current_ver = current_packages[pkg_lower]
 
-                # Check if version differs
-                if current_ver != target_version:
+                # Normalize both the version and the operator. A dependency that
+                # already has the target version but still uses ">=" is not in
+                # sync with the reproducible, exact-pin contract.
+                if current_ver != target_version or (use_exact_pins and current_op != "=="):
                     new_section, changed = update_dependency_in_section(
                         new_section, actual_pkg, target_version, use_exact_pins
                     )
@@ -316,7 +326,7 @@ def _build_lockfile_targets(pins: dict[str, str]) -> dict[str, str]:
 def sync_lockfile(
     lockfile_path: Path, pins: dict[str, str], apply: bool = False
 ) -> tuple[list[str], list[str]]:
-    """Sync versions from pin file to requirements.lock."""
+    """Sync direct tool pins in one supported requirements lockfile."""
     if not lockfile_path.exists():
         return [], []
 
@@ -333,13 +343,20 @@ def sync_lockfile(
             continue
 
         name = match.group("name")
-        version = match.group("version")
         target_version = targets.get(name.lower())
-        if target_version and version != target_version:
-            changes.append(f"requirements.lock:{name}: {version} -> =={target_version}")
+        current_requirement = f"{match.group('specifier') or ''}{match.group('marker') or ''}"
+        target_requirement = f"=={target_version}{match.group('marker') or ''}"
+        if target_version and current_requirement != target_requirement:
+            current_version = match.group("specifier") or "(unversioned)"
+            if current_version.startswith("=="):
+                current_version = current_version[2:]
+            changes.append(
+                f"{lockfile_path.name}:{name}: " f"{current_version} -> =={target_version}"
+            )
             if apply:
                 updated_lines.append(
-                    f"{match.group('lead')}{name}=={target_version}{match.group('trail')}"
+                    f"{match.group('lead')}{name}{match.group('extras') or ''}"
+                    f"=={target_version}{match.group('marker') or ''}{match.group('trail')}"
                 )
             else:
                 updated_lines.append(line)
@@ -368,7 +385,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--apply",
         action="store_true",
-        help="Apply version updates to pyproject.toml",
+        help="Apply version updates to pyproject.toml and supported requirements lockfiles",
     )
     parser.add_argument(
         "--create-if-missing",
@@ -383,7 +400,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--lockfile",
         action="store_true",
-        help="Force lockfile sync even if requirements.lock doesn't exist (no-op)",
+        help="Compatibility flag; supported requirements lockfiles are always checked",
     )
     parser.add_argument(
         "--pin-file",
@@ -421,9 +438,8 @@ def main(argv: list[str] | None = None) -> int:
         create_if_missing=args.create_if_missing,
     )
 
-    lockfile_enabled = args.lockfile or LOCKFILE_FILE.exists()
-    if lockfile_enabled:
-        lock_changes, lock_errors = sync_lockfile(LOCKFILE_FILE, pins, apply=args.apply)
+    for lockfile_path in LOCKFILE_FILES:
+        lock_changes, lock_errors = sync_lockfile(lockfile_path, pins, apply=args.apply)
         changes.extend(lock_changes)
         errors.extend(lock_errors)
 

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -1,27 +1,9 @@
 #!/usr/bin/env python3
-"""Model-registry freshness gate.
+"""Offline model-registry decision and freshness gate.
 
-Offline, deterministic, stdlib-only. Detects when the canonical LLM model
-configuration has drifted into staleness so old models do not get stuck as the
-primary ones indefinitely. It does NOT change model selection — it only reports.
-
-Inputs (defaults resolve relative to the repo root):
-  - config/model_registry.json  : curated models with per-tier quality scores.
-  - config/llm_slots.json        : provider/model slot pins consumed by
-                                   tools/llm_registry.py.
-
-Findings:
-  review_overdue : registry `review_by` (or `last_updated` + --max-age-days) is
-                   in the past relative to --today. The registry is hand-curated;
-                   without a periodic review, new GA models never enter it.
-  blocked_pin    : a slot pins a model the registry marks `blocked: true`.
-  unknown_pin    : a slot pins a model absent from the registry.
-  dominated_pin  : a slot pins a model whose best per-tier quality is strictly
-                   lower than another non-blocked model from the SAME provider in
-                   the registry — i.e. the registry's own data already says a
-                   better model exists, but the pin keeps the old one primary.
-
-Exit codes: 0 = fresh, 1 = stale findings, 2 = config/usage error.
+The gate validates dated model facts, explicit profile selections, evidence
+references, and slot resolution. Provider discovery is a separate advisory tool;
+it proposes catalog candidates but never changes a selection.
 """
 
 from __future__ import annotations
@@ -36,32 +18,50 @@ from typing import Any
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 DEFAULT_SLOTS_PATH = _REPO_ROOT / "config" / "llm_slots.json"
-DEFAULT_MAX_AGE_DAYS = 60
+DEFAULT_POLICY_PATH = _REPO_ROOT / "config" / "model_selection_policy.json"
+DEFAULT_MAX_AGE_DAYS = 30
+VALID_SELECTION_STATUSES = {"provisional", "approved"}
 
 
 def _normalize_provider(provider: str) -> str:
-    p = (provider or "").strip().lower()
-    if p in {"anthropic", "claude"}:
+    normalized = (provider or "").strip().lower()
+    if normalized in {"anthropic", "claude"}:
         return "anthropic"
-    if p in {"openai", "azure-openai"}:
+    if normalized in {"openai", "azure-openai"}:
         return "openai"
-    if p in {"github", "github-models", "github_models"}:
-        return "github"
-    return p
-
-
-def _headline_quality(entry: dict[str, Any]) -> float:
-    quality = entry.get("quality") or {}
-    values = [float(v) for v in quality.values() if isinstance(v, (int, float))]
-    return max(values) if values else 0.0
-
-
-def _normalize_tier(value: str) -> str:
-    return value.strip().upper()
+    if normalized in {"github", "github-models", "github_models"}:
+        return "github-models"
+    return normalized
 
 
 def _parse_date(value: str) -> _dt.date:
     return _dt.date.fromisoformat(str(value).strip())
+
+
+def _finding(kind: str, detail: str) -> dict[str, str]:
+    return {"kind": kind, "detail": detail}
+
+
+def _review_date(
+    registry: dict[str, Any], max_age_days: int, findings: list[dict[str, str]]
+) -> _dt.date | None:
+    raw = registry.get("review_by")
+    try:
+        if raw:
+            return _parse_date(str(raw))
+        as_of = registry.get("as_of") or registry.get("last_updated")
+        if as_of:
+            return _parse_date(str(as_of)) + _dt.timedelta(days=max_age_days)
+    except ValueError as exc:
+        findings.append(_finding("review_overdue", f"unparseable registry date: {exc}"))
+        return None
+    findings.append(
+        _finding(
+            "review_overdue",
+            "registry has neither review_by nor as_of; freshness cannot be proved.",
+        )
+    )
+    return None
 
 
 def evaluate(
@@ -70,159 +70,352 @@ def evaluate(
     *,
     today: _dt.date,
     max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+    policy: dict[str, Any] | None = None,
 ) -> list[dict[str, str]]:
-    """Return a list of finding dicts (empty == fresh). Pure function."""
+    """Return deterministic findings; an empty list means configuration is fresh."""
     findings: list[dict[str, str]] = []
-
-    models = registry.get("models") or []
-    # Index by (provider, model_id).
-    by_key: dict[tuple[str, str], dict[str, Any]] = {}
-    by_provider: dict[str, list[dict[str, Any]]] = {}
-    for m in models:
-        prov = _normalize_provider(str(m.get("provider", "")))
-        mid = str(m.get("model_id", "")).strip()
-        if not mid:
-            continue
-        by_key[(prov, mid)] = m
-        by_provider.setdefault(prov, []).append(m)
-
-    # 1. review_overdue -------------------------------------------------------
-    review_by_raw = registry.get("review_by")
-    try:
-        if review_by_raw:
-            review_by = _parse_date(review_by_raw)
-        else:
-            last_updated = registry.get("last_updated")
-            if not last_updated:
-                findings.append(
-                    {
-                        "kind": "review_overdue",
-                        "detail": "registry has neither `review_by` nor `last_updated`; "
-                        "cannot prove freshness.",
-                    }
-                )
-                review_by = None
-            else:
-                review_by = _parse_date(last_updated) + _dt.timedelta(days=max_age_days)
-    except ValueError as exc:
-        findings.append({"kind": "review_overdue", "detail": f"unparseable date: {exc}"})
-        review_by = None
-
+    review_by = _review_date(registry, max_age_days, findings)
     if review_by is not None and review_by < today:
-        days = (today - review_by).days
         findings.append(
-            {
-                "kind": "review_overdue",
-                "detail": f"model registry review is overdue by {days} day(s) "
-                f"(review_by={review_by.isoformat()}, today={today.isoformat()}). "
-                "Re-check provider model lists and refresh quality scores.",
-            }
+            _finding(
+                "review_overdue",
+                f"registry review is overdue by {(today - review_by).days} day(s) "
+                f"(review_by={review_by}, today={today}).",
+            )
         )
 
-    # Slot pins ---------------------------------------------------------------
-    for slot in slots.get("slots") or []:
-        name = str(slot.get("name", "?"))
-        prov = _normalize_provider(str(slot.get("provider", "")))
-        model = str(slot.get("model", "")).strip()
-        if not model:
-            # Tier-derived slot: model comes from the registry at runtime — this is
-            # the non-ossifying shape, nothing to flag here.
+    models = registry.get("models")
+    if not isinstance(models, list):
+        return findings + [_finding("invalid_registry", "models must be a list.")]
+
+    raw_sources = registry.get("sources")
+    sources = raw_sources if isinstance(raw_sources, list) else []
+    source_by_id = {
+        str(item.get("source_id", "")).strip(): item
+        for item in sources
+        if isinstance(item, dict) and str(item.get("source_id", "")).strip()
+    }
+    if not source_by_id:
+        findings.append(_finding("missing_source", "registry has no dated model sources."))
+
+    model_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    for raw in models:
+        if not isinstance(raw, dict):
+            findings.append(_finding("invalid_model", "model entries must be objects."))
             continue
-        entry = by_key.get((prov, model))
-        if entry is None:
+        provider = _normalize_provider(str(raw.get("provider", "")))
+        model_id = str(raw.get("model_id", "")).strip()
+        if not provider or not model_id:
             findings.append(
-                {
-                    "kind": "unknown_pin",
-                    "detail": f"slot {name!r} pins {prov}/{model} which is absent from "
-                    "the model registry (cannot verify it is current or unblocked).",
-                }
+                _finding("invalid_model", "model entry is missing provider or model_id.")
             )
             continue
-        if entry.get("blocked"):
+        key = (provider, model_id)
+        if key in model_by_key:
+            findings.append(_finding("duplicate_model", f"duplicate model {provider}/{model_id}."))
+        model_by_key[key] = raw
+        if str(raw.get("lifecycle", "")).strip().lower() == "current":
+            source_ids = raw.get("source_ids")
+            if not isinstance(source_ids, list) or not source_ids:
+                findings.append(
+                    _finding(
+                        "missing_source",
+                        f"current model {provider}/{model_id} has no source_ids.",
+                    )
+                )
+            else:
+                missing_sources = [
+                    str(item) for item in source_ids if str(item) not in source_by_id
+                ]
+                if missing_sources:
+                    findings.append(
+                        _finding(
+                            "missing_source",
+                            f"current model {provider}/{model_id} references absent sources: "
+                            f"{missing_sources}.",
+                        )
+                    )
+            pricing = raw.get("pricing")
+            if not isinstance(pricing, dict) or not pricing.get("as_of"):
+                findings.append(
+                    _finding(
+                        "missing_pricing_date",
+                        f"current model {provider}/{model_id} lacks dated pricing facts.",
+                    )
+                )
+
+    raw_evidence = registry.get("evidence")
+    evidence = raw_evidence if isinstance(raw_evidence, list) else []
+    evidence_by_id = {
+        str(item.get("evidence_id", "")).strip(): item
+        for item in evidence
+        if isinstance(item, dict) and str(item.get("evidence_id", "")).strip()
+    }
+    for evidence_id, item in evidence_by_id.items():
+        evidence_sources = item.get("source_ids", [])
+        if isinstance(evidence_sources, list):
+            missing_sources = [
+                str(source) for source in evidence_sources if str(source) not in source_by_id
+            ]
+            if missing_sources:
+                findings.append(
+                    _finding(
+                        "missing_source",
+                        f"evidence {evidence_id} references absent sources: {missing_sources}.",
+                    )
+                )
+
+    selections = registry.get("selections")
+    if not isinstance(selections, list):
+        return findings + [_finding("invalid_registry", "selections must be a list.")]
+
+    selection_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    policy_profiles = (policy or {}).get("profiles", {})
+    if not isinstance(policy_profiles, dict):
+        policy_profiles = {}
+
+    for raw in selections:
+        if not isinstance(raw, dict):
+            findings.append(_finding("invalid_selection", "selection entries must be objects."))
+            continue
+        profile = str(raw.get("profile", "")).strip()
+        provider = _normalize_provider(str(raw.get("provider", "")))
+        model_id = str(raw.get("model_id", "")).strip()
+        key = (profile, provider)
+        if not profile or not provider or not model_id:
             findings.append(
-                {
-                    "kind": "blocked_pin",
-                    "detail": f"slot {name!r} pins {prov}/{model} which is marked "
-                    "blocked in the registry.",
-                }
+                _finding(
+                    "invalid_selection",
+                    "selection is missing profile, provider, or model_id.",
+                )
             )
             continue
-        tier = _normalize_tier(str(slot.get("quality_tier", "")))
-
-        def _slot_quality(model_entry: dict[str, Any], slot_tier: str = tier) -> float:
-            if not slot_tier:
-                return _headline_quality(model_entry)
-            quality = model_entry.get("quality") or {}
-            value = quality.get(slot_tier)
-            return float(value) if isinstance(value, (int, float)) else float("-inf")
-
-        pinned_q = _slot_quality(entry)
-        better = [
-            m
-            for m in by_provider.get(prov, [])
-            if not m.get("blocked") and _slot_quality(m) > pinned_q
-        ]
-        if better:
-            best = max(better, key=_slot_quality)
+        if key in selection_by_key:
             findings.append(
-                {
-                    "kind": "dominated_pin",
-                    "detail": f"slot {name!r} pins {prov}/{model} "
-                    f"(quality {pinned_q:.2f}) but the registry rates "
-                    f"{prov}/{best.get('model_id')} higher "
-                    f"({_slot_quality(best):.2f}); the pin keeps an older model primary.",
-                }
+                _finding(
+                    "duplicate_selection",
+                    f"multiple selections exist for profile/provider {profile}/{provider}.",
+                )
+            )
+        selection_by_key[key] = raw
+
+        if policy is not None and profile not in policy_profiles:
+            findings.append(
+                _finding("unknown_profile", f"selection references unknown profile {profile!r}.")
+            )
+
+        model = model_by_key.get((provider, model_id))
+        if model is None:
+            findings.append(
+                _finding(
+                    "unknown_selection",
+                    f"selection {profile}/{provider} references absent model {model_id}.",
+                )
+            )
+        else:
+            if model.get("blocked"):
+                findings.append(
+                    _finding(
+                        "blocked_selection",
+                        f"selection {profile}/{provider} uses blocked model {model_id}.",
+                    )
+                )
+            lifecycle = str(model.get("lifecycle", "")).strip().lower()
+            if lifecycle != "current":
+                findings.append(
+                    _finding(
+                        "inactive_selection",
+                        f"selection {profile}/{provider} uses lifecycle={lifecycle or 'missing'} "
+                        f"model {model_id}.",
+                    )
+                )
+
+        status = str(raw.get("status", "")).strip().lower()
+        if status not in VALID_SELECTION_STATUSES:
+            findings.append(
+                _finding(
+                    "invalid_selection_status",
+                    f"selection {profile}/{provider} has status {status!r}.",
+                )
+            )
+
+        evidence_ids = raw.get("evidence_ids")
+        if not isinstance(evidence_ids, list) or not evidence_ids:
+            findings.append(
+                _finding(
+                    "missing_evidence",
+                    f"selection {profile}/{provider} has no evidence_ids.",
+                )
+            )
+            evidence_ids = []
+        missing = [str(item) for item in evidence_ids if str(item) not in evidence_by_id]
+        if missing:
+            findings.append(
+                _finding(
+                    "missing_evidence",
+                    f"selection {profile}/{provider} references absent evidence: {missing}.",
+                )
+            )
+        if status == "approved":
+            benchmark_evidence = [
+                evidence_by_id[str(item)]
+                for item in evidence_ids
+                if str(item) in evidence_by_id
+                and evidence_by_id[str(item)].get("kind") == "workload-benchmark"
+                and evidence_by_id[str(item)].get("status") == "passed"
+                and evidence_by_id[str(item)].get("schema")
+                == "workflows-model-benchmark-evidence/v1"
+                and evidence_by_id[str(item)].get("profile") == profile
+                and evidence_by_id[str(item)].get("model_id") == model_id
+                and evidence_by_id[str(item)].get("policy_id") == (policy or {}).get("policy_id")
+                and evidence_by_id[str(item)].get("corpus_version")
+                and evidence_by_id[str(item)].get("prompt_version")
+                and evidence_by_id[str(item)].get("measured_at")
+                and isinstance(evidence_by_id[str(item)].get("gate_results"), dict)
+                and all(evidence_by_id[str(item)]["gate_results"].values())
+            ]
+            if not benchmark_evidence:
+                findings.append(
+                    _finding(
+                        "unproved_approval",
+                        f"approved selection {profile}/{provider} lacks passed workload-benchmark evidence.",
+                    )
+                )
+
+        try:
+            selection_review = _parse_date(str(raw.get("review_by", "")))
+        except ValueError:
+            findings.append(
+                _finding(
+                    "selection_review_overdue",
+                    f"selection {profile}/{provider} has missing or invalid review_by.",
+                )
+            )
+        else:
+            if selection_review < today:
+                kind = (
+                    "provisional_overdue" if status == "provisional" else "selection_review_overdue"
+                )
+                findings.append(
+                    _finding(
+                        kind,
+                        f"selection {profile}/{provider} review was due {selection_review}.",
+                    )
+                )
+
+    raw_slots = slots.get("slots")
+    if not isinstance(raw_slots, list):
+        return findings + [_finding("invalid_slots", "slots must be a list.")]
+    for raw in raw_slots:
+        if not isinstance(raw, dict):
+            findings.append(_finding("invalid_slot", "slot entries must be objects."))
+            continue
+        name = str(raw.get("name", "?")).strip()
+        provider = _normalize_provider(str(raw.get("provider", "")))
+        profile = str(raw.get("profile", "")).strip()
+        explicit_model = str(raw.get("model", "")).strip()
+        if not provider:
+            findings.append(_finding("invalid_slot", f"slot {name!r} has no provider."))
+            continue
+        if explicit_model:
+            model = model_by_key.get((provider, explicit_model))
+            # Explicit-profile pins must match their reviewed decision.  A
+            # legacy pin without a profile is also valid at runtime when the
+            # pin is a current, unblocked catalog model.
+            effective_profile = profile or "verifier-balanced"
+            selected = selection_by_key.get((effective_profile, provider))
+            legacy_pin_is_current = bool(
+                not profile
+                and model is not None
+                and not model.get("blocked")
+                and str(model.get("lifecycle", "")).strip().lower() == "current"
+            )
+            if (
+                selected
+                and selected.get("model_id") != explicit_model
+                and not legacy_pin_is_current
+            ):
+                findings.append(
+                    _finding(
+                        "selection_override",
+                        f"slot {name!r} pins {provider}/{explicit_model} instead of reviewed "
+                        f"selection {selected.get('model_id')} for {effective_profile}.",
+                    )
+                )
+            if model is None:
+                findings.append(
+                    _finding(
+                        "unknown_pin",
+                        f"slot {name!r} pins absent model {provider}/{explicit_model}.",
+                    )
+                )
+            elif model.get("blocked"):
+                findings.append(
+                    _finding(
+                        "blocked_pin",
+                        f"slot {name!r} pins blocked model {provider}/{explicit_model}.",
+                    )
+                )
+            continue
+        if not profile:
+            findings.append(
+                _finding(
+                    "missing_profile",
+                    f"slot {name!r} has neither an explicit model nor a profile.",
+                )
+            )
+        elif (profile, provider) not in selection_by_key:
+            findings.append(
+                _finding(
+                    "missing_selection",
+                    f"slot {name!r} has no selection for {profile}/{provider}.",
+                )
             )
 
     return findings
 
 
 def _load_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Model-registry freshness gate.")
+    parser = argparse.ArgumentParser(description="Model-registry decision freshness gate.")
     parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY_PATH)
     parser.add_argument("--slots", type=Path, default=DEFAULT_SLOTS_PATH)
-    parser.add_argument(
-        "--max-age-days",
-        type=int,
-        default=DEFAULT_MAX_AGE_DAYS,
-        help="Used only when the registry has no explicit `review_by`.",
-    )
-    parser.add_argument(
-        "--today",
-        type=str,
-        default=None,
-        help="ISO date override (testing); defaults to system date.",
-    )
-    parser.add_argument("--json", action="store_true", help="Emit findings as JSON.")
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY_PATH)
+    parser.add_argument("--max-age-days", type=int, default=DEFAULT_MAX_AGE_DAYS)
+    parser.add_argument("--today", type=str, default=None)
+    parser.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
 
     try:
         registry = _load_json(args.registry)
         slots = _load_json(args.slots)
-    except (OSError, json.JSONDecodeError) as exc:
-        print(f"config error: {exc}", file=sys.stderr)
-        return 2
-
-    try:
+        policy = _load_json(args.policy)
         today = _parse_date(args.today) if args.today else _dt.date.today()
-    except ValueError as exc:
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"config error: {exc}", file=sys.stderr)
         return 2
-    findings = evaluate(registry, slots, today=today, max_age_days=args.max_age_days)
 
+    findings = evaluate(
+        registry,
+        slots,
+        today=today,
+        max_age_days=args.max_age_days,
+        policy=policy,
+    )
     if args.json:
         print(json.dumps({"fresh": not findings, "findings": findings}, indent=2))
+    elif findings:
+        print(f"Model registry freshness: {len(findings)} finding(s):")
+        for finding in findings:
+            print(f"  [{finding['kind']}] {finding['detail']}")
     else:
-        if not findings:
-            print("Model registry is fresh: no stale or dominated pins.")
-        else:
-            print(f"Model registry freshness: {len(findings)} finding(s):")
-            for f in findings:
-                print(f"  [{f['kind']}] {f['detail']}")
+        print("Model registry is fresh: decisions, evidence, and slots are consistent.")
     return 1 if findings else 0
 
 

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -292,28 +292,34 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
     if not github_token and not openai_token:
         return None
 
-    from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
+    from tools.llm_provider import GITHUB_MODELS_BASE_URL
+    from tools.llm_registry import configured_model_for_provider
 
     if github_token:
-        return (
-            cast(
-                _LLMClient,
-                ChatOpenAI(
-                    model=DEFAULT_MODEL,
-                    base_url=GITHUB_MODELS_BASE_URL,
-                    api_key=cast(Any, github_token),
-                    temperature=0.1,
+        model = configured_model_for_provider("github-models")
+        if model:
+            return (
+                cast(
+                    _LLMClient,
+                    ChatOpenAI(
+                        model=model,
+                        base_url=GITHUB_MODELS_BASE_URL,
+                        api_key=cast(Any, github_token),
+                        temperature=0.1,
+                    ),
                 ),
-            ),
-            "github-models",
-        )
-    if openai_token is None:
+                "github-models",
+            )
+    if not openai_token:
+        return None
+    model = configured_model_for_provider("openai")
+    if not model:
         return None
     return (
         cast(
             _LLMClient,
             ChatOpenAI(
-                model=DEFAULT_MODEL,
+                model=model,
                 api_key=cast(Any, openai_token),
                 temperature=0.1,
             ),

--- a/tools/discover_model_catalog.py
+++ b/tools/discover_model_catalog.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Discover provider catalog drift without changing model selections.
+
+GitHub Models is public. OpenAI and Anthropic discovery run only when their API
+keys are available. Newly observed models are review candidates, not evidence
+that they are better than an approved selection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
+PROVIDERS = ("openai", "anthropic", "github-models")
+CATALOG_URLS = frozenset(
+    {
+        "https://models.github.ai/catalog/models",
+        "https://api.openai.com/v1/models",
+        "https://api.anthropic.com/v1/models?limit=1000",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CatalogModel:
+    model_id: str
+    created_at: dt.datetime | None = None
+
+
+def _request_json(url: str, headers: dict[str, str]) -> Any:
+    if url not in CATALOG_URLS:
+        raise ValueError(f"unsupported catalog URL: {url}")
+    request = Request(url, headers=headers)
+    with urlopen(request, timeout=30) as response:  # noqa: S310 - validated static catalog URL
+        return json.load(response)
+
+
+def _parse_timestamp(value: object) -> dt.datetime | None:
+    if isinstance(value, (int, float)):
+        return dt.datetime.fromtimestamp(value, tz=dt.UTC)
+    if isinstance(value, str) and value.strip():
+        normalized = value.strip().replace("Z", "+00:00")
+        try:
+            parsed = dt.datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.UTC)
+    return None
+
+
+def parse_catalog(provider: str, payload: Any) -> list[CatalogModel]:
+    if provider == "github-models":
+        if not isinstance(payload, list):
+            raise ValueError("GitHub Models catalog must be a list")
+        return [
+            CatalogModel(str(item["id"]), _parse_timestamp(item.get("created_at")))
+            for item in payload
+            if isinstance(item, dict)
+            and item.get("id")
+            and item.get("publisher") == "OpenAI"
+            and item.get("capabilities")
+        ]
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        raise ValueError(f"{provider} catalog must contain a data list")
+    return [
+        CatalogModel(
+            str(item["id"]),
+            _parse_timestamp(item.get("created") or item.get("created_at")),
+        )
+        for item in payload["data"]
+        if isinstance(item, dict) and item.get("id")
+    ]
+
+
+def catalog_diff(
+    *,
+    provider: str,
+    models: list[CatalogModel],
+    baseline: dict[str, Any],
+) -> dict[str, Any]:
+    known = {str(item) for item in baseline.get("model_ids", [])}
+    checked_at = _parse_timestamp(baseline.get("checked_at"))
+    current = {model.model_id for model in models}
+    additions = []
+    for model in models:
+        if model.model_id in known:
+            continue
+        # Credentialed provider APIs contain long-lived historical catalogs.
+        # Only post-baseline additions are actionable. A missing timestamp is
+        # retained because silently ignoring it would hide real drift.
+        if (
+            provider != "github-models"
+            and checked_at
+            and model.created_at
+            and model.created_at <= checked_at
+        ):
+            continue
+        additions.append(model.model_id)
+    removed = sorted(known - current)
+    return {
+        "provider": provider,
+        "status": "drift" if additions or removed else "current",
+        "added_candidates": sorted(set(additions)),
+        "removed_from_catalog": removed,
+        "observed_count": len(current),
+        "note": "Catalog changes require benchmark review; they do not auto-promote models.",
+    }
+
+
+def fetch_provider(provider: str) -> tuple[list[CatalogModel] | None, str | None]:
+    try:
+        if provider == "github-models":
+            payload = _request_json("https://models.github.ai/catalog/models", {})
+        elif provider == "openai":
+            token = os.environ.get("OPENAI_API_KEY")
+            if not token:
+                return None, "OPENAI_API_KEY unavailable"
+            payload = _request_json(
+                "https://api.openai.com/v1/models",
+                {"Authorization": f"Bearer {token}"},
+            )
+        elif provider == "anthropic":
+            token = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_API_STRANSKE")
+            if not token:
+                return None, "ANTHROPIC_API_KEY/CLAUDE_API_STRANSKE unavailable"
+            payload = _request_json(
+                "https://api.anthropic.com/v1/models?limit=1000",
+                {"x-api-key": token, "anthropic-version": "2023-06-01"},
+            )
+        else:  # pragma: no cover - argparse constrains values
+            raise ValueError(f"unsupported provider: {provider}")
+        return parse_catalog(provider, payload), None
+    except (OSError, URLError, ValueError) as exc:
+        return None, str(exc)
+
+
+def build_report(registry: dict[str, Any], providers: list[str]) -> dict[str, Any]:
+    baselines = registry.get("catalog_baselines", {})
+    results: list[dict[str, Any]] = []
+    for provider in providers:
+        baseline = baselines.get(provider) if isinstance(baselines, dict) else None
+        if not isinstance(baseline, dict):
+            results.append({"provider": provider, "status": "error", "error": "missing baseline"})
+            continue
+        models, error = fetch_provider(provider)
+        if models is None:
+            results.append({"provider": provider, "status": "skipped", "reason": error})
+            continue
+        results.append(catalog_diff(provider=provider, models=models, baseline=baseline))
+    return {
+        "schema": "workflows-model-catalog-discovery/v1",
+        "generated_at": dt.datetime.now(tz=dt.UTC).isoformat(),
+        "drift": any(item.get("status") == "drift" for item in results),
+        "providers": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Discover model catalog drift.")
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY_PATH)
+    parser.add_argument("--provider", action="append", choices=PROVIDERS)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        registry = json.loads(args.registry.read_text(encoding="utf-8"))
+        if not isinstance(registry, dict):
+            raise ValueError("registry must be a JSON object")
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"config error: {exc}", file=sys.stderr)
+        return 2
+
+    report = build_report(registry, args.provider or list(PROVIDERS))
+    rendered = json.dumps(report, indent=2)
+    print(rendered)
+    if args.output:
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 1 if report["drift"] else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Evaluate paired model candidates against the repository selection policy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from statistics import NormalDist
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_POLICY_PATH = _REPO_ROOT / "config" / "model_selection_policy.json"
+Z_95 = 1.959963984540054
+
+
+def wilson_interval(successes: int, total: int, *, z: float = Z_95) -> tuple[float, float]:
+    if total <= 0:
+        return 0.0, 1.0
+    rate = successes / total
+    denominator = 1 + (z * z / total)
+    center = (rate + z * z / (2 * total)) / denominator
+    margin = z * math.sqrt((rate * (1 - rate) + z * z / (4 * total)) / total) / denominator
+    return max(0.0, center - margin), min(1.0, center + margin)
+
+
+def _nearest_rank_p95(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(0.95 * len(ordered)) - 1)]
+
+
+def _case_outcome(case: dict[str, Any]) -> tuple[str, str, bool]:
+    expected = str(case.get("expected_verdict", "")).strip().upper()
+    actual = str(case.get("actual_verdict", "")).strip().upper()
+    schema_valid = case.get("schema_valid") is True
+    if expected not in {"PASS", "NON_PASS"}:
+        raise ValueError(f"case {case.get('case_id')} has invalid expected_verdict")
+    if actual not in {"PASS", "NON_PASS"}:
+        raise ValueError(f"case {case.get('case_id')} has invalid actual_verdict")
+    return expected, actual, schema_valid
+
+
+def _metrics(cases: list[dict[str, Any]], *, z: float = Z_95) -> dict[str, Any]:
+    success = false_pass = false_fail = schema_error = 0
+    expected_pass = expected_non_pass = 0
+    categories: dict[str, int] = {}
+    total_cost = 0.0
+    latencies: list[float] = []
+    case_success: dict[str, bool] = {}
+    for case in cases:
+        case_id = str(case.get("case_id", "")).strip()
+        category = str(case.get("category", "")).strip()
+        if not case_id or not category:
+            raise ValueError("every case requires case_id and category")
+        if case_id in case_success:
+            raise ValueError(f"duplicate case_id {case_id}")
+        expected, actual, schema_valid = _case_outcome(case)
+        correct = schema_valid and expected == actual
+        case_success[case_id] = correct
+        success += int(correct)
+        schema_error += int(not schema_valid)
+        expected_pass += int(expected == "PASS")
+        expected_non_pass += int(expected == "NON_PASS")
+        false_pass += int(expected == "NON_PASS" and actual == "PASS")
+        false_fail += int(expected == "PASS" and actual == "NON_PASS")
+        categories[category] = categories.get(category, 0) + 1
+        cost = float(case.get("total_cost_usd", 0.0))
+        latency = float(case.get("latency_ms", 0.0))
+        if not math.isfinite(cost) or cost < 0:
+            raise ValueError(f"case {case_id} has invalid total_cost_usd")
+        if not math.isfinite(latency) or latency < 0:
+            raise ValueError(f"case {case_id} has invalid latency_ms")
+        total_cost += cost
+        latencies.append(latency)
+
+    count = len(cases)
+    success_interval = wilson_interval(success, count, z=z)
+    false_pass_interval = wilson_interval(false_pass, expected_non_pass, z=z)
+    false_fail_interval = wilson_interval(false_fail, expected_pass, z=z)
+    schema_interval = wilson_interval(schema_error, count, z=z)
+    return {
+        "sample_count": count,
+        "category_counts": categories,
+        "task_success_rate": success / count if count else 0.0,
+        "task_success_rate_wilson_lower_bound": success_interval[0],
+        "false_pass_rate": false_pass / expected_non_pass if expected_non_pass else 0.0,
+        "false_pass_rate_wilson_upper_bound": false_pass_interval[1],
+        "false_fail_rate": false_fail / expected_pass if expected_pass else 0.0,
+        "false_fail_rate_wilson_upper_bound": false_fail_interval[1],
+        "schema_error_rate": schema_error / count if count else 0.0,
+        "schema_error_rate_wilson_upper_bound": schema_interval[1],
+        "total_cost_usd": total_cost,
+        "cost_per_accepted_review_usd": total_cost / success if success else None,
+        "p95_latency_ms": _nearest_rank_p95(latencies),
+        "case_success": case_success,
+    }
+
+
+def _validate_paired_cases(candidates: list[Any]) -> None:
+    expected_ids: set[str] | None = None
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            raise ValueError("each candidate must be an object")
+        cases = candidate.get("cases")
+        if not isinstance(cases, list):
+            raise ValueError("each candidate requires a cases list")
+        case_ids = {str(case.get("case_id", "")) for case in cases if isinstance(case, dict)}
+        if len(case_ids) != len(cases) or "" in case_ids:
+            raise ValueError("candidate cases require unique non-empty case_id values")
+        if expected_ids is None:
+            expected_ids = case_ids
+        elif case_ids != expected_ids:
+            raise ValueError("all candidates must evaluate the same paired case IDs")
+
+
+def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[str, Any]:
+    profile = str(payload.get("profile", "")).strip()
+    profiles = policy.get("profiles", {})
+    if not isinstance(profiles, dict) or profile not in profiles:
+        raise ValueError(f"unknown benchmark profile: {profile}")
+    profile_policy = profiles[profile]
+    approval = profile_policy["approval_stage"]
+    gates = approval["quality_gates"]
+    confidence_level = float(approval.get("confidence_level", 0.95))
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("approval_stage.confidence_level must be between 0 and 1")
+    # Keep the inverse CDF strictly inside its finite domain even when a
+    # valid float extremely close to 0 or 1 rounds at machine precision.
+    probability = min(1.0 - 1e-15, max(1e-15, (1.0 + confidence_level) / 2.0))
+    z = NormalDist().inv_cdf(probability)
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) < 2:
+        raise ValueError("benchmark requires a baseline and at least one candidate")
+    _validate_paired_cases(candidates)
+
+    baseline_model = str(payload.get("baseline_model_id", "")).strip()
+    results: list[dict[str, Any]] = []
+    metrics_by_model: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        model_id = str(candidate.get("model_id", "")).strip()
+        provider = str(candidate.get("provider", "")).strip()
+        if not model_id or not provider or model_id in metrics_by_model:
+            raise ValueError("candidate provider/model_id values must be non-empty and unique")
+        metrics_by_model[model_id] = _metrics(candidate["cases"], z=z)
+    if baseline_model not in metrics_by_model:
+        raise ValueError("baseline_model_id must identify one candidate")
+
+    baseline = metrics_by_model[baseline_model]
+    required_categories = profile_policy["candidate_stage"]["required_case_categories"]
+    minimum_cases = int(approval["minimum_adjudicated_cases"])
+    minimum_per_category = int(approval["minimum_cases_per_category"])
+    noninferiority_margin = float(gates["paired_success_noninferiority_margin"])
+
+    for candidate in candidates:
+        model_id = str(candidate["model_id"]).strip()
+        metrics = metrics_by_model[model_id]
+        gate_results = {
+            "minimum_adjudicated_cases": metrics["sample_count"] >= minimum_cases,
+            "minimum_cases_per_category": all(
+                metrics["category_counts"].get(category, 0) >= minimum_per_category
+                for category in required_categories
+            ),
+            "task_success_rate_wilson_lower_bound": metrics["task_success_rate_wilson_lower_bound"]
+            >= float(gates["task_success_rate_wilson_lower_bound"]),
+            "false_pass_rate_wilson_upper_bound": metrics["false_pass_rate_wilson_upper_bound"]
+            <= float(gates["false_pass_rate_wilson_upper_bound"]),
+            "false_fail_rate_wilson_upper_bound": metrics["false_fail_rate_wilson_upper_bound"]
+            <= float(gates["false_fail_rate_wilson_upper_bound"]),
+            "schema_error_rate_wilson_upper_bound": metrics["schema_error_rate_wilson_upper_bound"]
+            <= float(gates["schema_error_rate_wilson_upper_bound"]),
+            "paired_success_noninferiority": (
+                metrics["task_success_rate"] - baseline["task_success_rate"]
+            )
+            >= -noninferiority_margin,
+        }
+        public_metrics = {key: value for key, value in metrics.items() if key != "case_success"}
+        results.append(
+            {
+                "provider": str(candidate["provider"]),
+                "model_id": model_id,
+                "status": "passed" if all(gate_results.values()) else "failed",
+                "gate_results": gate_results,
+                "metrics": public_metrics,
+            }
+        )
+
+    passing = [result for result in results if result["status"] == "passed"]
+    ranked = sorted(
+        passing,
+        key=lambda item: (
+            (
+                float("inf")
+                if item["metrics"]["cost_per_accepted_review_usd"] is None
+                else item["metrics"]["cost_per_accepted_review_usd"]
+            ),
+            item["metrics"]["p95_latency_ms"],
+        ),
+    )
+    benchmark_id = str(payload.get("benchmark_id", "")).strip()
+    corpus_version = str(payload.get("corpus_version", "")).strip()
+    prompt_version = str(payload.get("prompt_version", "")).strip()
+    measured_at = str(payload.get("measured_at", "")).strip()
+    if not benchmark_id or not corpus_version or not prompt_version or not measured_at:
+        raise ValueError(
+            "benchmark_id, corpus_version, prompt_version, and measured_at are required"
+        )
+    registry_evidence = [
+        {
+            "evidence_id": f"{benchmark_id}:{result['provider']}:{result['model_id']}",
+            "schema": "workflows-model-benchmark-evidence/v1",
+            "kind": "workload-benchmark",
+            "status": result["status"],
+            "measured_at": measured_at,
+            "policy_id": str(policy.get("policy_id", "")).strip(),
+            "profile": profile,
+            "corpus_version": corpus_version,
+            "prompt_version": prompt_version,
+            "provider": result["provider"],
+            "model_id": result["model_id"],
+            "gate_results": result["gate_results"],
+            "metrics": result["metrics"],
+        }
+        for result in results
+    ]
+    return {
+        "schema": "workflows-model-benchmark-evidence/v1",
+        "benchmark_id": benchmark_id,
+        "policy_id": str(policy.get("policy_id", "")).strip(),
+        "profile": profile,
+        "corpus_version": corpus_version,
+        "prompt_version": prompt_version,
+        "measured_at": measured_at,
+        "baseline_model_id": baseline_model,
+        "results": results,
+        "registry_evidence": registry_evidence,
+        "recommended_model_id": ranked[0]["model_id"] if ranked else None,
+        "recommendation_rule": "quality gates, then cost per accepted review, then p95 latency",
+    }
+
+
+def _load_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Evaluate a paired model benchmark.")
+    parser.add_argument("benchmark", type=Path)
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY_PATH)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        report = evaluate_benchmark(_load_object(args.benchmark), _load_object(args.policy))
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        print(f"benchmark error: {exc}", file=sys.stderr)
+        return 2
+    rendered = json.dumps(report, indent=2)
+    print(rendered)
+    if args.output:
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if report["recommended_model_id"] else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -21,6 +21,7 @@ from tools.llm_registry import (
     ModelRegistryEntry,
     SlotDefinition,
     apply_slot_env_overrides,
+    configured_model_for_provider,
     default_slots,
     is_model_blocked,
     load_model_registry,
@@ -228,6 +229,11 @@ def build_chat_client(
     selected_provider, provider_explicit = _resolve_provider(provider, force_openai=force_openai)
     if provider_explicit and selected_provider is None:
         return None
+    if selected_provider and not selected_model:
+        selected_model = configured_model_for_provider(selected_provider)
+    if selected_provider and not selected_model:
+        logger.warning("No reviewed model is configured for provider %s", selected_provider)
+        return None
     if selected_provider and _is_model_blocked(selected_provider, selected_model):
         logger.warning("Refusing blocked LLM model: %s/%s", selected_provider, selected_model)
         return None
@@ -287,6 +293,8 @@ def build_chat_client(
             logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)
             used_override = True
             slot_model = slot.model
+        if not slot_model:
+            continue
         if _is_model_blocked(slot.provider, slot_model):
             logger.warning("Skipping blocked LLM model: %s/%s", slot.provider, slot_model)
             continue
@@ -499,6 +507,8 @@ def build_chat_clients(
     for idx, slot in enumerate(candidate_slots):
         slot_model = model_overrides[idx] if idx < len(model_overrides) else None
         slot_model = slot_model or slot.model
+        if not slot_model:
+            continue
         if _is_model_blocked(slot.provider, slot_model, registry=registry):
             logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)
             continue

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -31,17 +31,15 @@ from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
-# GitHub Models API endpoint (OpenAI-compatible)
-GITHUB_MODELS_BASE_URL = "https://models.inference.ai.azure.com"
-# Legacy/default model identifier:
-# - Not used for issuing requests to primary providers (OpenAI/Anthropic/GitHub Models)
-# - Still used internally (e.g., default slot model in langchain_client.py)
-# - Kept for backward compatibility with external code that references it
-DEFAULT_MODEL = "codex-mini-latest"
+# GitHub Models API endpoint (OpenAI-compatible).
+GITHUB_MODELS_BASE_URL = "https://models.github.ai/inference"
+# Model versions live only in config/model_registry.json. Empty constants keep
+# import compatibility while ensuring a missing registry fails closed.
+DEFAULT_MODEL = ""
 ANTHROPIC_API_KEY_ENV = "CLAUDE_API_STRANSKE"
 SHORT_ANALYSIS_CONFIDENCE_CAP = 0.4
-DEFAULT_OPENAI_ANALYSIS_MODEL = "gpt-5.4"
-DEFAULT_ANTHROPIC_ANALYSIS_MODEL = "claude-sonnet-4-6"
+DEFAULT_OPENAI_ANALYSIS_MODEL = ""
+DEFAULT_ANTHROPIC_ANALYSIS_MODEL = ""
 
 
 def _configured_langchain_model(provider: str, *, fallback: str) -> str:
@@ -233,7 +231,7 @@ class CompletionAnalysis:
     confidence: float  # 0.0 to 1.0
     reasoning: str  # Explanation of the analysis
     provider_used: str  # Which provider generated this
-    model_name: str = "unknown"  # Specific model used (e.g., gpt-4o, claude-3.5-sonnet)
+    model_name: str = "unknown"  # Specific model used by the selected provider.
 
     # Quality metrics for BS detection
     raw_confidence: float | None = None  # Original confidence before adjustment
@@ -335,7 +333,10 @@ class GitHubModelsProvider(LLMProvider):
         return "github-models"
 
     def is_available(self) -> bool:
-        return bool(os.environ.get("GITHUB_TOKEN"))
+        return bool(
+            os.environ.get("GITHUB_TOKEN")
+            and _configured_langchain_model("github-models", fallback=DEFAULT_MODEL)
+        )
 
     def supports_quality_context(self) -> bool:
         return True
@@ -348,8 +349,13 @@ class GitHubModelsProvider(LLMProvider):
             logger.warning("langchain_openai not installed")
             return None
 
+        model_name = _configured_langchain_model("github-models", fallback=DEFAULT_MODEL)
+        if not model_name:
+            logger.warning("No reviewed GitHub Models selection is configured")
+            return None
+        self._model_name = model_name
         return ChatOpenAI(
-            model="gpt-4.1",  # Battle-tested, reliable, available on GitHub Models
+            model=model_name,
             base_url=GITHUB_MODELS_BASE_URL,
             api_key=os.environ.get("GITHUB_TOKEN"),
             temperature=0.1,  # Low temperature for consistent analysis
@@ -364,7 +370,9 @@ class GitHubModelsProvider(LLMProvider):
     ) -> CompletionAnalysis:
         client = self._get_client()
         if not client:
-            raise RuntimeError("LangChain OpenAI not available")
+            raise RuntimeError(
+                "GitHub Models client unavailable: install langchain-openai or configure a reviewed model"
+            )
 
         prompt = self._build_analysis_prompt(session_output, tasks, context)
 
@@ -561,7 +569,7 @@ Be conservative - if unsure, don't mark as completed."""
                 confidence=adjusted_confidence,
                 reasoning=reasoning,
                 provider_used=self.name,
-                model_name="gpt-4.1",  # Actual model used by GitHubModelsProvider
+                model_name=getattr(self, "_model_name", "unknown"),
                 raw_confidence=raw_confidence if adjusted_confidence != raw_confidence else None,
                 confidence_adjusted=adjusted_confidence != raw_confidence,
                 quality_warnings=warnings if warnings else None,
@@ -576,7 +584,7 @@ Be conservative - if unsure, don't mark as completed."""
                 confidence=0.0,
                 reasoning=f"Failed to parse response: {e}",
                 provider_used=self.name,
-                model_name="gpt-4.1",  # Actual model used by GitHubModelsProvider
+                model_name=getattr(self, "_model_name", "unknown"),
             )
 
 
@@ -588,7 +596,10 @@ class OpenAIProvider(LLMProvider):
         return "openai"
 
     def is_available(self) -> bool:
-        return bool(os.environ.get("OPENAI_API_KEY"))
+        return bool(
+            os.environ.get("OPENAI_API_KEY")
+            and _configured_langchain_model("openai", fallback=DEFAULT_OPENAI_ANALYSIS_MODEL)
+        )
 
     def supports_quality_context(self) -> bool:
         return True
@@ -662,7 +673,10 @@ class AnthropicProvider(LLMProvider):
         return "anthropic"
 
     def is_available(self) -> bool:
-        return bool(os.environ.get(ANTHROPIC_API_KEY_ENV))
+        return bool(
+            os.environ.get(ANTHROPIC_API_KEY_ENV)
+            and _configured_langchain_model("anthropic", fallback=DEFAULT_ANTHROPIC_ANALYSIS_MODEL)
+        )
 
     def supports_quality_context(self) -> bool:
         return True
@@ -984,7 +998,7 @@ def get_llm_provider(force_provider: str | None = None) -> LLMProvider:
     Returns a FallbackChainProvider that tries:
     1. Anthropic configured slot model (if CLAUDE_API_STRANSKE set) - Best reasoning
     2. OpenAI configured slot model (if OPENAI_API_KEY set) - Code analysis
-    3. GitHub Models gpt-4.1 (if GITHUB_TOKEN set) - Always available, reliable
+    3. GitHub Models configured slot model (if GITHUB_TOKEN set)
     4. Regex fallback (always available) - 30% confidence baseline
     """
     # Force a specific provider for testing
@@ -1012,7 +1026,7 @@ def get_llm_provider(force_provider: str | None = None) -> LLMProvider:
     providers = [
         AnthropicProvider(),  # Primary: configured Anthropic slot model
         OpenAIProvider(),  # Secondary: configured OpenAI slot model
-        GitHubModelsProvider(),  # Tertiary: gpt-4.1 via GITHUB_TOKEN (always available)
+        GitHubModelsProvider(),  # Tertiary: configured GitHub Models slot
         RegexFallbackProvider(),  # Last resort: 30% confidence pattern matching
     ]
 

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -1,4 +1,8 @@
-"""Shared LLM slot and model-registry resolution helpers."""
+"""Shared LLM slot and model-registry resolution helpers.
+
+The registry records model facts separately from explicit workload-profile
+selection decisions. Runtime selection never manufactures quality or cost scores.
+"""
 
 from __future__ import annotations
 
@@ -16,6 +20,7 @@ ENV_SLOT_CONFIG = "LANGCHAIN_SLOT_CONFIG"
 PROVIDER_OPENAI = "openai"
 PROVIDER_ANTHROPIC = "anthropic"
 PROVIDER_GITHUB = "github-models"
+DEFAULT_SELECTION_PROFILE = "verifier-balanced"
 
 DEFAULT_SLOT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "llm_slots.json"
 DEFAULT_MODEL_REGISTRY_CONFIG_PATH = (
@@ -23,15 +28,29 @@ DEFAULT_MODEL_REGISTRY_CONFIG_PATH = (
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ModelRegistryEntry:
     provider: str
     model: str
     blocked: bool
-    quality: dict[str, float]
+    lifecycle: str = "unknown"
+    # Retained as empty compatibility attributes for callers migrating from v1.
+    # They are deliberately not inputs to model selection.
+    quality: dict[str, float] | None = None
+    cost_score: float | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
+class SelectionDecision:
+    profile: str
+    provider: str
+    model: str
+    status: str
+    review_by: str
+    evidence_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class SlotDefinition:
     name: str
     provider: str
@@ -51,6 +70,30 @@ def normalize_provider(value: str | None) -> str | None:
     return None
 
 
+def _registry_path() -> Path:
+    configured = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
+    return Path(configured) if configured else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+
+
+def _slot_path() -> Path:
+    configured = os.environ.get(ENV_SLOT_CONFIG)
+    return Path(configured) if configured else DEFAULT_SLOT_CONFIG_PATH
+
+
+def _load_object(path: Path, *, label: str) -> dict[str, object] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        logger.warning("Could not read %s %s", label, path)
+        return None
+    if not isinstance(payload, dict):
+        logger.warning("Invalid %s format in %s; expected object", label, path)
+        return None
+    return payload
+
+
 def _slot_entries(payload: dict[str, object], path: Path) -> list[dict[str, object]]:
     raw_slots = payload.get("slots", [])
     if not isinstance(raw_slots, list):
@@ -66,19 +109,10 @@ def _slot_entries(payload: dict[str, object], path: Path) -> list[dict[str, obje
 
 
 def load_model_registry() -> list[ModelRegistryEntry]:
-    config_path = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
-    path = Path(config_path) if config_path else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
-    if not path.is_file():
+    path = _registry_path()
+    payload = _load_object(path, label="model registry")
+    if payload is None:
         return []
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        logger.warning("Could not read model registry %s; continuing without registry", path)
-        return []
-    if not isinstance(payload, dict):
-        logger.warning("Invalid model registry format in %s; expected object", path)
-        return []
-
     raw_models = payload.get("models", [])
     if not isinstance(raw_models, list):
         logger.warning("Invalid model registry format in %s; expected models list", path)
@@ -93,44 +127,57 @@ def load_model_registry() -> list[ModelRegistryEntry]:
         model = str(raw_entry.get("model_id", "")).strip()
         if not provider or not model:
             continue
-        quality_payload = raw_entry.get("quality", {})
-        if not isinstance(quality_payload, dict):
-            logger.warning(
-                "Ignoring invalid quality scores for %s/%s in %s; expected object",
-                provider,
-                model,
-                path,
-            )
-            quality_payload = {}
-        quality = {
-            str(tier).upper(): float(score)
-            for tier, score in quality_payload.items()
-            if isinstance(score, (int, float)) and not isinstance(score, bool)
-        }
         entries.append(
             ModelRegistryEntry(
                 provider=provider,
                 model=model,
                 blocked=bool(raw_entry.get("blocked", False)),
-                quality=quality,
+                lifecycle=str(raw_entry.get("lifecycle", "unknown")).strip().lower(),
             )
         )
     return entries
 
 
+def load_selection_decisions() -> list[SelectionDecision]:
+    path = _registry_path()
+    payload = _load_object(path, label="model registry")
+    if payload is None:
+        return []
+    raw_selections = payload.get("selections", [])
+    if not isinstance(raw_selections, list):
+        logger.warning("Invalid model registry format in %s; expected selections list", path)
+        return []
+
+    decisions: list[SelectionDecision] = []
+    for raw in raw_selections:
+        if not isinstance(raw, dict):
+            continue
+        provider = normalize_provider(str(raw.get("provider", "")))
+        profile = str(raw.get("profile", "")).strip()
+        model = str(raw.get("model_id", "")).strip()
+        evidence = raw.get("evidence_ids", [])
+        if not provider or not profile or not model or not isinstance(evidence, list):
+            continue
+        decisions.append(
+            SelectionDecision(
+                profile=profile,
+                provider=provider,
+                model=model,
+                status=str(raw.get("status", "")).strip().lower(),
+                review_by=str(raw.get("review_by", "")).strip(),
+                evidence_ids=tuple(str(item).strip() for item in evidence if str(item).strip()),
+            )
+        )
+    return decisions
+
+
 def _model_registry_format_valid() -> bool:
-    config_path = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
-    path = Path(config_path) if config_path else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
-    if not path.is_file():
-        return True
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    if not isinstance(payload, dict):
-        return False
-    raw_models = payload.get("models", [])
-    return isinstance(raw_models, list)
+    payload = _load_object(_registry_path(), label="model registry")
+    return bool(
+        payload is not None
+        and isinstance(payload.get("models"), list)
+        and isinstance(payload.get("selections"), list)
+    )
 
 
 def registry_entry_for(
@@ -139,10 +186,14 @@ def registry_entry_for(
     entries = registry if registry is not None else load_model_registry()
     normalized_provider = normalize_provider(provider)
     normalized_model = model.strip()
-    for entry in entries:
-        if entry.provider == normalized_provider and entry.model == normalized_model:
-            return entry
-    return None
+    return next(
+        (
+            entry
+            for entry in entries
+            if entry.provider == normalized_provider and entry.model == normalized_model
+        ),
+        None,
+    )
 
 
 def is_model_blocked(
@@ -152,94 +203,118 @@ def is_model_blocked(
     return bool(entry and entry.blocked)
 
 
+def select_model_for_profile(
+    *,
+    provider: str,
+    profile: str = DEFAULT_SELECTION_PROFILE,
+    registry: list[ModelRegistryEntry] | None = None,
+    decisions: list[SelectionDecision] | None = None,
+) -> str | None:
+    """Resolve the one explicit reviewed decision for provider/profile."""
+    entries = registry if registry is not None else load_model_registry()
+    selections = decisions if decisions is not None else load_selection_decisions()
+    normalized_provider = normalize_provider(provider)
+    matches = [
+        decision
+        for decision in selections
+        if decision.provider == normalized_provider and decision.profile == profile
+    ]
+    if len(matches) != 1:
+        if matches:
+            logger.warning(
+                "Ambiguous model selections for %s/%s; expected exactly one",
+                normalized_provider,
+                profile,
+            )
+        return None
+    decision = matches[0]
+    if not decision.evidence_ids:
+        logger.warning(
+            "Model selection %s/%s has no evidence; refusing to use it",
+            normalized_provider,
+            profile,
+        )
+        return None
+    entry = registry_entry_for(decision.provider, decision.model, registry=entries)
+    if entry is None or entry.blocked or entry.lifecycle != "current":
+        return None
+    if decision.status not in {"provisional", "approved"}:
+        return None
+    return decision.model
+
+
 def select_model_for_tier(
     *,
     provider: str,
     tier: str,
     registry: list[ModelRegistryEntry] | None = None,
+    **_ignored: object,
 ) -> str | None:
-    entries = registry if registry is not None else load_model_registry()
-    normalized_provider = normalize_provider(provider)
-    normalized_tier = tier.strip().upper()
-    candidates = [
-        entry
-        for entry in entries
-        if entry.provider == normalized_provider
-        and not entry.blocked
-        and normalized_tier in entry.quality
-    ]
-    if not candidates:
-        return None
-    selected = max(candidates, key=lambda entry: entry.quality[normalized_tier])
-    return selected.model
+    """Compatibility adapter for v1 callers; tiers no longer rank models."""
+    logger.warning(
+        "quality tier %s is deprecated; resolving profile %s",
+        tier,
+        DEFAULT_SELECTION_PROFILE,
+    )
+    return select_model_for_profile(provider=provider, registry=registry)
 
 
 def configured_model_for_provider(
     provider: str,
     *,
-    fallback: str,
-    tier: str = "T3",
+    fallback: str = "",
+    profile: str = DEFAULT_SELECTION_PROFILE,
+    tier: str | None = None,
     registry: list[ModelRegistryEntry] | None = None,
 ) -> str:
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
+    # An explicit slot config is an execution allowlist, including when its
+    # path is missing or malformed. Never broaden execution because a
+    # configured allowlist cannot be read or does not contain this provider.
+    if os.environ.get(ENV_SLOT_CONFIG):
+        configured_slots = load_slot_config()
+        if not configured_slots:
+            return ""
+        for slot in apply_slot_env_overrides(configured_slots):
+            if (
+                slot.provider == normalized_provider
+                and slot.model
+                and not is_model_blocked(slot.provider, slot.model, registry=entries)
+            ):
+                return slot.model
+        return ""
 
-    config_path = os.environ.get(ENV_SLOT_CONFIG)
-    path = Path(config_path) if config_path else DEFAULT_SLOT_CONFIG_PATH
-    if path.is_file():
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            payload = {}
-        if not isinstance(payload, dict):
-            logger.warning("Invalid slot config format in %s; expected object", path)
-            payload = {}
-        for slot in _slot_entries(payload, path):
-            slot_provider = normalize_provider(str(slot.get("provider", "")))
-            if slot_provider != normalized_provider:
-                continue
-            model = str(slot.get("model", "")).strip()
-            slot_tier = str(slot.get("quality_tier") or slot.get("tier") or tier).strip()
-            if not model and slot_tier:
-                model = (
-                    select_model_for_tier(
-                        provider=slot_provider or "",
-                        tier=slot_tier,
-                        registry=entries,
-                    )
-                    or ""
-                )
-            if model and not is_model_blocked(slot_provider or "", model, registry=entries):
-                return model
-
-    selected = select_model_for_tier(provider=provider, tier=tier, registry=entries)
+    selected = select_model_for_profile(provider=provider, profile=profile, registry=entries)
     if selected:
         return selected
-    if not is_model_blocked(provider, fallback, registry=entries):
+    if fallback and not is_model_blocked(provider, fallback, registry=entries):
         return fallback
     return ""
 
 
-def default_slots(*, github_default_model: str) -> list[SlotDefinition]:
-    return [
-        SlotDefinition(name="slot1", provider=PROVIDER_OPENAI, model="gpt-5.4"),
-        SlotDefinition(name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-sonnet-4-6"),
-        SlotDefinition(name="slot3", provider=PROVIDER_GITHUB, model=github_default_model),
-    ]
+def default_slots(*, github_default_model: str = "") -> list[SlotDefinition]:
+    """Build no-slot-config defaults from registry decisions, never version constants."""
+    slots: list[SlotDefinition] = []
+    for index, provider in enumerate(
+        (PROVIDER_OPENAI, PROVIDER_ANTHROPIC, PROVIDER_GITHUB), start=1
+    ):
+        model = select_model_for_profile(provider=provider)
+        if not model and provider == PROVIDER_GITHUB:
+            model = github_default_model.strip()
+        slots.append(SlotDefinition(name=f"slot{index}", provider=provider, model=model or ""))
+    return slots
 
 
-def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
-    config_path = os.environ.get(ENV_SLOT_CONFIG)
-    path = Path(config_path) if config_path else DEFAULT_SLOT_CONFIG_PATH
+def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
+    path = _slot_path()
+    payload = _load_object(path, label="slot config")
     fallback_slots = default_slots(github_default_model=github_default_model)
-    if not path.is_file():
-        return fallback_slots
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return fallback_slots
-    if not isinstance(payload, dict):
-        logger.warning("Invalid slot config format in %s; expected object", path)
+    if payload is None:
+        # An unreadable or missing explicitly configured slot file must fail
+        # closed. Only an unconfigured default path permits default slots.
+        if os.environ.get(ENV_SLOT_CONFIG):
+            return []
         return fallback_slots
 
     registry = load_model_registry()
@@ -247,26 +322,69 @@ def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
     if not _model_registry_format_valid() and any(
         str(entry.get("provider", "")).strip()
         and not str(entry.get("model", "")).strip()
-        and str(entry.get("quality_tier") or entry.get("tier") or "").strip()
+        and str(
+            entry.get("profile") or entry.get("quality_tier") or entry.get("tier") or ""
+        ).strip()
         for entry in slot_entries
     ):
-        return fallback_slots
+        return [] if os.environ.get(ENV_SLOT_CONFIG) else fallback_slots
+
     slots: list[SlotDefinition] = []
-    fallback_by_position = dict(enumerate(fallback_slots, start=1))
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
     for idx, entry in enumerate(slot_entries, start=1):
         provider = normalize_provider(str(entry.get("provider", "")))
-        model = str(entry.get("model", "")).strip()
-        tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()
-        if provider and not model and tier:
-            model = select_model_for_tier(provider=provider, tier=tier, registry=registry) or ""
+        explicit_model = str(entry.get("model", "")).strip()
+        configured_profile = str(entry.get("profile") or "").strip()
+        profile = configured_profile or DEFAULT_SELECTION_PROFILE
+        model = ""
+        if provider:
+            model = (
+                select_model_for_profile(provider=provider, profile=profile, registry=registry)
+                or ""
+            )
+        explicit_entry = (
+            registry_entry_for(provider, explicit_model, registry=registry)
+            if provider and explicit_model
+            else None
+        )
+        if (
+            provider
+            and explicit_model
+            and not configured_profile
+            and explicit_entry
+            and not (explicit_entry.blocked or explicit_entry.lifecycle != "current")
+        ):
+            model = explicit_model
+        elif provider and explicit_model and explicit_model != model:
+            # A caller-supplied slot file is an allowlist and must fail closed.
+            # The repository's bundled legacy file is advisory: ignore a stale
+            # pin and retain the reviewed registry selection for that provider.
+            if os.environ.get(ENV_SLOT_CONFIG):
+                logger.warning(
+                    "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
+                    provider,
+                    explicit_model,
+                    profile,
+                    model or "unavailable",
+                )
+                continue
+            logger.debug(
+                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection before fallback is %s",
+                provider,
+                explicit_model,
+                profile,
+                model or "unavailable",
+            )
+        if provider and configured_profile and not model:
+            logger.warning(
+                "Skipping slot with unresolved reviewed profile: %s/%s",
+                configured_profile,
+                provider,
+            )
+            continue
         if provider and not model:
-            fallback_slot = fallback_by_position.get(idx)
-            if fallback_slot and fallback_slot.provider != provider:
-                fallback_slot = fallback_by_provider.get(provider)
-            fallback_slot = fallback_slot or fallback_by_provider.get(provider)
-            if fallback_slot and fallback_slot.provider == provider:
-                model = fallback_slot.model
+            fallback_slot = fallback_by_provider.get(provider)
+            model = fallback_slot.model if fallback_slot else ""
         if not provider or not model:
             continue
         if is_model_blocked(provider, model, registry=registry):
@@ -274,8 +392,9 @@ def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
             continue
         name = str(entry.get("name") or f"slot{idx}").strip() or f"slot{idx}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
-
-    return slots or fallback_slots
+    # A present slot file is an allowlist.  If every configured slot is
+    # unusable, fail closed instead of broadening execution to default providers.
+    return slots
 
 
 def apply_slot_env_overrides(
@@ -287,10 +406,8 @@ def apply_slot_env_overrides(
     registry = load_model_registry()
     updated: list[SlotDefinition] = []
     for idx, slot in enumerate(slots, start=1):
-        provider_key = f"{env_slot_prefix}{idx}_PROVIDER"
-        model_key = f"{env_slot_prefix}{idx}_MODEL"
-        provider_override = normalize_provider(os.environ.get(provider_key))
-        model_override = os.environ.get(model_key)
+        provider_override = normalize_provider(os.environ.get(f"{env_slot_prefix}{idx}_PROVIDER"))
+        model_override = os.environ.get(f"{env_slot_prefix}{idx}_MODEL")
         if idx == 1:
             model_override = model_override or os.environ.get(env_model_name)
         provider = provider_override or slot.provider
@@ -303,24 +420,34 @@ def apply_slot_env_overrides(
             ):
                 updated.append(slot)
             continue
-        updated.append(
-            SlotDefinition(
-                name=slot.name,
-                provider=provider,
-                model=model,
-            )
-        )
+        updated.append(SlotDefinition(name=slot.name, provider=provider, model=model))
     return updated
 
 
 def resolve_slots(
     *,
-    github_default_model: str,
+    github_default_model: str = "",
     env_model_name: str = "LANGCHAIN_MODEL",
     env_slot_prefix: str = "LANGCHAIN_SLOT",
 ) -> list[SlotDefinition]:
+    slots = load_slot_config(github_default_model=github_default_model)
+    # Preserve LANGCHAIN_MODEL as an emergency bootstrap only when neither an
+    # explicit ENV_SLOT_CONFIG/LANGCHAIN_SLOT_CONFIG allowlist nor the bundled
+    # default slot file is available. Otherwise empty resolved slots fail closed.
+    if (
+        not slots
+        and not os.environ.get(ENV_SLOT_CONFIG)
+        and not _slot_path().exists()
+        and os.environ.get(env_model_name)
+    ):
+        slots = [
+            SlotDefinition(name=f"slot{index}", provider=provider, model="")
+            for index, provider in enumerate(
+                (PROVIDER_OPENAI, PROVIDER_ANTHROPIC, PROVIDER_GITHUB), start=1
+            )
+        ]
     return apply_slot_env_overrides(
-        load_slot_config(github_default_model=github_default_model),
+        slots,
         env_model_name=env_model_name,
         env_slot_prefix=env_slot_prefix,
     )


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-weekly-metrics.yml: Weekly metrics - aggregates auto-pilot, keepalive, autofix and verifier metrics into summary reports
- backplane-conformance.yml: Backplane conformance caller stub - calls reusable-backplane-conformance.yml@main to validate a repo's emitted run-contract/v1 envelope (producer) or ingested object (consumer). No-op for non-participants (opt-in). Template lives under templates/consumer-repo/.github/workflows/.
- sync_dev_dependencies.py: Syncs dev dependency versions from autofix-versions.env to pyproject.toml
- ci_failure_triage.py: Classifies CI failure logs - required by pr-00-gate.yml summary generation
- runner_lib/ (2 files): Shared runner prompt assembly, output parsing, and dispatch debounce helpers
- check_test_dependencies.sh: Checks test dependencies match - required by reusable CI workflow
- registry.yml: Agent registry - source of truth for agent keys and runner workflow mapping
- agent_registry.js: Agent registry helper - loads registry and resolves agent key from labels
- keepalive_loop.js: Core keepalive loop logic
- keepalive_prompt_composer.js: Composes prompts for keepalive Codex calls
- capability_bundle.js: Validates and selects capability-bundle/v1 fragments for keepalive prompts and metrics
- gate_summary.py: Gate summary renderer - generates PR gate check summary
- api_client.py: Shared GitHub API client used by synced Python automation scripts
- llm_provider.py: LLM provider configuration - GitHub Models and OpenAI client setup
- langchain_client.py: LangChain client builder - multi-provider client with slot-based fallback and configuration
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement
- check_model_registry_freshness.py: Model-registry freshness gate - validates dated decisions, evidence, lifecycle, and profile-based slots
- discover_model_catalog.py: Advisory provider-catalog discovery - proposes new model candidates without changing reviewed selections
- evaluate_model_benchmark.py: Deterministic paired model benchmark evaluator - computes confidence-bound quality gates and cost/latency ranking
- agent-run-base/ (1 files): Shared agent runner setup action - required by reusable-codex-run.yml and reusable-claude-run.yml
- MODEL_SELECTION_POLICY.md: Auditable auxiliary-model evaluation, selection, and refresh policy
- agent-runner-output.md: Agent runner output contract specification - required for implementing new agent runners
- run-contract-v1.md: Research-backplane run-contract/v1 wire-format spec - participants need it to implement an emitter/ingest adapter
- identity-map-conventions.md: Canonical entity-ID conventions for run-contract/v1 identity_refs / evidence entity_ref - participants emit against these
- capability-bundle-v1.md: Capability-bundle/v1 prompt-fragment and gate metadata contract for Workflows Keepalive
- capability-bundle-v1.schema.json: JSON Schema (draft 2020-12) for capability-bundle/v1 keepalive prompt fragments and gate metadata
- run-contract-v1.schema.json: JSON Schema (draft 2020-12) for run-contract/v1 run envelopes - loaded by the validator and local helpers so participants validate without a Workflows checkout
- artifact-manifest-v1.schema.json: JSON Schema (draft 2020-12) for artifact-manifest/v1 - the named-artifact manifest a run envelope references
- evidence-object-v1.schema.json: JSON Schema (draft 2020-12) for evidence-object/v1 - attributable evidence objects (the satellite schema consumers like the LMS would ingest)
- SETUP_CHECKLIST.md: Consumer repo setup checklist. Includes the default_workflow_permissions=write step in section 3.3.1 that prevents a Gate startup_failure on fresh consumers (see #2157). Synced so it no longer drifts across the fleet.
- model_registry.json: Model registry - available LLM models and their capabilities
- model_selection_policy.json: Model selection policy - benchmark gates, measurements, optimization order, and review triggers
- .coderabbit.yaml: CodeRabbit auto-review config - skips maintenance-bot PRs (renovate/dependabot/github-actions/keepalive) and generated sync/draft PRs, while keeping substantial agent-authored PR reviews enabled. Advisory/non-gating per fleet rule.

### Files Skipped
- .github/workflows/pr-00-gate.yml: Maintains a fully custom Gate workflow; never overwrite (replaces the hard-coded custom_gate_repos list in maint-68).
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `42a9940479ce7160ce008377d1119ecfa6237187`
**Template hash:** `04b25eebf847`
**Sync branch:** `sync/workflows-04b25eebf847`
**Consumer repo:** `stranske/Manager-Database`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Manager-Database","source_repository":"stranske/Workflows","source_sha":"42a9940479ce7160ce008377d1119ecfa6237187","template_hash":"04b25eebf847","sync_branch":"sync/workflows-04b25eebf847","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"29805505229","run_attempt":"1","changes_count":33} -->