### PR TITLE
feat: add manager similarity surface

### DIFF
--- a/alembic/versions/012_manager_similarity.py
+++ b/alembic/versions/012_manager_similarity.py
@@ -17,13 +17,16 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "manager_similarity",
-        sa.Column("manager_id_a", sa.BigInteger(), nullable=False),
-        sa.Column("manager_id_b", sa.BigInteger(), nullable=False),
-        sa.Column("jaccard", sa.Float(), nullable=False),
+        sa.Column("manager_id_a", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False),
+        sa.Column("manager_id_b", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False),
+        sa.Column("jaccard", sa.REAL(), nullable=False),
         sa.Column("overlap_count", sa.Integer(), nullable=False),
         sa.Column("union_count", sa.Integer(), nullable=False),
         sa.Column(
-            "computed_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP")
+            "computed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
         ),
         sa.PrimaryKeyConstraint("manager_id_a", "manager_id_b"),
         sa.CheckConstraint("manager_id_a < manager_id_b"),

--- a/alembic/versions/012_manager_similarity.py
+++ b/alembic/versions/012_manager_similarity.py
@@ -3,7 +3,9 @@
 Revision ID: 012
 Revises: 011
 """
+
 import sqlalchemy as sa
+
 from alembic import op
 
 revision = "012"
@@ -11,19 +13,24 @@ down_revision = "011"
 branch_labels = None
 depends_on = None
 
+
 def upgrade() -> None:
-    op.create_table("manager_similarity",
+    op.create_table(
+        "manager_similarity",
         sa.Column("manager_id_a", sa.BigInteger(), nullable=False),
         sa.Column("manager_id_b", sa.BigInteger(), nullable=False),
         sa.Column("jaccard", sa.Float(), nullable=False),
         sa.Column("overlap_count", sa.Integer(), nullable=False),
         sa.Column("union_count", sa.Integer(), nullable=False),
-        sa.Column("computed_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column(
+            "computed_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP")
+        ),
         sa.PrimaryKeyConstraint("manager_id_a", "manager_id_b"),
         sa.CheckConstraint("manager_id_a < manager_id_b"),
     )
     op.create_index("idx_manager_similarity_a", "manager_similarity", ["manager_id_a"])
     op.create_index("idx_manager_similarity_b", "manager_similarity", ["manager_id_b"])
+
 
 def downgrade() -> None:
     op.drop_table("manager_similarity")

--- a/alembic/versions/012_manager_similarity.py
+++ b/alembic/versions/012_manager_similarity.py
@@ -1,0 +1,29 @@
+"""Add manager similarity table.
+
+Revision ID: 012
+Revises: 011
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "012"
+down_revision = "011"
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table("manager_similarity",
+        sa.Column("manager_id_a", sa.BigInteger(), nullable=False),
+        sa.Column("manager_id_b", sa.BigInteger(), nullable=False),
+        sa.Column("jaccard", sa.Float(), nullable=False),
+        sa.Column("overlap_count", sa.Integer(), nullable=False),
+        sa.Column("union_count", sa.Integer(), nullable=False),
+        sa.Column("computed_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.PrimaryKeyConstraint("manager_id_a", "manager_id_b"),
+        sa.CheckConstraint("manager_id_a < manager_id_b"),
+    )
+    op.create_index("idx_manager_similarity_a", "manager_similarity", ["manager_id_a"])
+    op.create_index("idx_manager_similarity_b", "manager_similarity", ["manager_id_b"])
+
+def downgrade() -> None:
+    op.drop_table("manager_similarity")

--- a/alembic/versions/012_manager_similarity.py
+++ b/alembic/versions/012_manager_similarity.py
@@ -17,8 +17,12 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "manager_similarity",
-        sa.Column("manager_id_a", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False),
-        sa.Column("manager_id_b", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False),
+        sa.Column(
+            "manager_id_a", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False
+        ),
+        sa.Column(
+            "manager_id_b", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False
+        ),
         sa.Column("jaccard", sa.REAL(), nullable=False),
         sa.Column("overlap_count", sa.Integer(), nullable=False),
         sa.Column("union_count", sa.Integer(), nullable=False),

--- a/alembic/versions/013_manager_similarity.py
+++ b/alembic/versions/013_manager_similarity.py
@@ -1,15 +1,15 @@
 """Add manager similarity table.
 
-Revision ID: 012
-Revises: 011
+Revision ID: 013
+Revises: 012
 """
 
 import sqlalchemy as sa
 
 from alembic import op
 
-revision = "012"
-down_revision = "011"
+revision = "013"
+down_revision = "012"
 branch_labels = None
 depends_on = None
 

--- a/api/managers.py
+++ b/api/managers.py
@@ -18,6 +18,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from adapters.base import connect_db
+from etl.manager_similarity_flow import ensure_manager_similarity_table
 from adapters.base import resolve_manager_id_column as shared_manager_id_column
 from api.cache import cache_query, invalidate_cache_prefix
 from api.models import (
@@ -1345,6 +1346,35 @@ async def get_manager(
     if row is None:
         raise HTTPException(status_code=404, detail="Manager not found")
     return _to_manager_response(row)
+
+
+@router.get("/managers/{id}/similar", summary="List similar managers")
+async def get_similar_managers(
+    id: int = Path(..., ge=1, description="Manager identifier"),
+    limit: int = Query(10, ge=1, le=100),
+):
+    """Return the strongest deterministic holding-overlap peers for a manager."""
+    conn = None
+    try:
+        conn = connect_db()
+        _ensure_manager_table(conn)
+        manager_column = _manager_id_column(conn)
+        if conn.execute(f"SELECT 1 FROM managers WHERE {manager_column} = {'?' if isinstance(conn, sqlite3.Connection) else '%s'}", (id,)).fetchone() is None:
+            raise HTTPException(status_code=404, detail="Manager not found")
+        ensure_manager_similarity_table(conn)
+        ph = "?" if isinstance(conn, sqlite3.Connection) else "%s"
+        rows = conn.execute(
+            "SELECT CASE WHEN manager_id_a = " + ph + " THEN manager_id_b ELSE manager_id_a END, jaccard, overlap_count, union_count "
+            "FROM manager_similarity WHERE manager_id_a = " + ph + " OR manager_id_b = " + ph + " "
+            "ORDER BY jaccard DESC, overlap_count DESC LIMIT " + ph,
+            (id, id, id, limit),
+        ).fetchall()
+        return {"items": [{"manager_id": int(row[0]), "jaccard": float(row[1]), "overlap_count": int(row[2]), "union_count": int(row[3])} for row in rows]}
+    except DB_ERROR_TYPES as exc:
+        _raise_db_unavailable(exc)
+    finally:
+        if conn is not None:
+            conn.close()
 
 
 @router.patch(

--- a/api/managers.py
+++ b/api/managers.py
@@ -18,7 +18,6 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from adapters.base import connect_db
-from etl.manager_similarity_flow import ensure_manager_similarity_table
 from adapters.base import resolve_manager_id_column as shared_manager_id_column
 from api.cache import cache_query, invalidate_cache_prefix
 from api.models import (
@@ -31,6 +30,7 @@ from api.models import (
     ManagerStatsResponse,
     UniverseImportResponse,
 )
+from etl.manager_similarity_flow import ensure_manager_similarity_table
 from utils.identifiers import normalize_cik
 
 router = APIRouter()
@@ -1359,17 +1359,35 @@ async def get_similar_managers(
         conn = connect_db()
         _ensure_manager_table(conn)
         manager_column = _manager_id_column(conn)
-        if conn.execute(f"SELECT 1 FROM managers WHERE {manager_column} = {'?' if isinstance(conn, sqlite3.Connection) else '%s'}", (id,)).fetchone() is None:
+        if (
+            conn.execute(
+                f"SELECT 1 FROM managers WHERE {manager_column} = {'?' if isinstance(conn, sqlite3.Connection) else '%s'}",
+                (id,),
+            ).fetchone()
+            is None
+        ):
             raise HTTPException(status_code=404, detail="Manager not found")
         ensure_manager_similarity_table(conn)
         ph = "?" if isinstance(conn, sqlite3.Connection) else "%s"
         rows = conn.execute(
-            "SELECT CASE WHEN manager_id_a = " + ph + " THEN manager_id_b ELSE manager_id_a END, jaccard, overlap_count, union_count "
+            "SELECT CASE WHEN manager_id_a = "
+            + ph
+            + " THEN manager_id_b ELSE manager_id_a END, jaccard, overlap_count, union_count "
             "FROM manager_similarity WHERE manager_id_a = " + ph + " OR manager_id_b = " + ph + " "
             "ORDER BY jaccard DESC, overlap_count DESC LIMIT " + ph,
             (id, id, id, limit),
         ).fetchall()
-        return {"items": [{"manager_id": int(row[0]), "jaccard": float(row[1]), "overlap_count": int(row[2]), "union_count": int(row[3])} for row in rows]}
+        return {
+            "items": [
+                {
+                    "manager_id": int(row[0]),
+                    "jaccard": float(row[1]),
+                    "overlap_count": int(row[2]),
+                    "union_count": int(row[3]),
+                }
+                for row in rows
+            ]
+        }
     except DB_ERROR_TYPES as exc:
         _raise_db_unavailable(exc)
     finally:

--- a/etl/manager_similarity_flow.py
+++ b/etl/manager_similarity_flow.py
@@ -35,17 +35,21 @@ def compute_manager_similarity(conn: Any) -> int:
         FROM filings f
     )
     SELECT r.manager_id, COALESCE(NULLIF(h.resolved_ticker, ''), h.cusip)
-    FROM ranked r JOIN holdings h ON h.filing_id = r.filing_id
-    WHERE r.rn = 1 AND COALESCE(NULLIF(h.resolved_ticker, ''), h.cusip) IS NOT NULL""").fetchall()
+    FROM ranked r LEFT JOIN holdings h ON h.filing_id = r.filing_id
+    WHERE r.rn = 1""").fetchall()
     holdings: dict[int, set[str]] = {}
     for manager_id, security in rows:
-        holdings.setdefault(int(manager_id), set()).add(str(security))
+        securities = holdings.setdefault(int(manager_id), set())
+        if security is not None:
+            securities.add(str(security))
     conn.execute("DELETE FROM manager_similarity")
     ph = get_placeholder(conn)
     count = 0
     for left, right in combinations(sorted(holdings), 2):
         union = holdings[left] | holdings[right]
         overlap = holdings[left] & holdings[right]
+        if not union:
+            continue
         conn.execute(
             "INSERT INTO manager_similarity (manager_id_a, manager_id_b, jaccard, overlap_count, union_count) "
             f"VALUES ({ph}, {ph}, {ph}, {ph}, {ph})",

--- a/etl/manager_similarity_flow.py
+++ b/etl/manager_similarity_flow.py
@@ -1,0 +1,51 @@
+"""Compute deterministic manager similarity from latest disclosed holdings."""
+
+from __future__ import annotations
+
+import sqlite3
+from itertools import combinations
+from typing import Any
+
+from adapters.base import get_placeholder
+
+
+def ensure_manager_similarity_table(conn: Any) -> None:
+    if isinstance(conn, sqlite3.Connection):
+        conn.execute("""CREATE TABLE IF NOT EXISTS manager_similarity (
+            manager_id_a INTEGER NOT NULL, manager_id_b INTEGER NOT NULL,
+            jaccard REAL NOT NULL, overlap_count INTEGER NOT NULL, union_count INTEGER NOT NULL,
+            computed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (manager_id_a, manager_id_b),
+            CHECK (manager_id_a < manager_id_b)
+        )""")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_manager_similarity_a ON manager_similarity(manager_id_a)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_manager_similarity_b ON manager_similarity(manager_id_b)")
+
+
+def compute_manager_similarity(conn: Any) -> int:
+    """Replace pairwise similarities using each manager's latest filing."""
+    ensure_manager_similarity_table(conn)
+    rows = conn.execute("""WITH ranked AS (
+        SELECT f.manager_id, f.filing_id,
+               ROW_NUMBER() OVER (PARTITION BY f.manager_id ORDER BY f.period_end DESC, f.filing_id DESC) AS rn
+        FROM filings f
+    )
+    SELECT r.manager_id, COALESCE(NULLIF(h.resolved_ticker, ''), h.cusip)
+    FROM ranked r JOIN holdings h ON h.filing_id = r.filing_id
+    WHERE r.rn = 1 AND COALESCE(NULLIF(h.resolved_ticker, ''), h.cusip) IS NOT NULL""").fetchall()
+    holdings: dict[int, set[str]] = {}
+    for manager_id, security in rows:
+        holdings.setdefault(int(manager_id), set()).add(str(security))
+    conn.execute("DELETE FROM manager_similarity")
+    ph = get_placeholder(conn)
+    count = 0
+    for left, right in combinations(sorted(holdings), 2):
+        union = holdings[left] | holdings[right]
+        overlap = holdings[left] & holdings[right]
+        conn.execute(
+            "INSERT INTO manager_similarity (manager_id_a, manager_id_b, jaccard, overlap_count, union_count) "
+            f"VALUES ({ph}, {ph}, {ph}, {ph}, {ph})",
+            (left, right, len(overlap) / len(union), len(overlap), len(union)),
+        )
+        count += 1
+    return count

--- a/etl/manager_similarity_flow.py
+++ b/etl/manager_similarity_flow.py
@@ -6,13 +6,15 @@ import sqlite3
 from itertools import combinations
 from typing import Any
 
-from adapters.base import get_placeholder
+from adapters.base import get_placeholder, get_table_columns
 
 
 def ensure_manager_similarity_table(conn: Any) -> None:
     if isinstance(conn, sqlite3.Connection):
+        conn.execute("PRAGMA foreign_keys = ON")
         conn.execute("""CREATE TABLE IF NOT EXISTS manager_similarity (
-            manager_id_a INTEGER NOT NULL, manager_id_b INTEGER NOT NULL,
+            manager_id_a INTEGER NOT NULL REFERENCES managers(id),
+            manager_id_b INTEGER NOT NULL REFERENCES managers(id),
             jaccard REAL NOT NULL, overlap_count INTEGER NOT NULL, union_count INTEGER NOT NULL,
             computed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (manager_id_a, manager_id_b),
@@ -29,31 +31,48 @@ def ensure_manager_similarity_table(conn: Any) -> None:
 def compute_manager_similarity(conn: Any) -> int:
     """Replace pairwise similarities using each manager's latest filing."""
     ensure_manager_similarity_table(conn)
-    rows = conn.execute("""WITH ranked AS (
+    current_holding_filter = (
+        " AND h.superseded_at IS NULL"
+        if "superseded_at" in get_table_columns(conn, "holdings")
+        else ""
+    )
+    rows = conn.execute(
+        """WITH ranked AS (
         SELECT f.manager_id, f.filing_id,
                ROW_NUMBER() OVER (PARTITION BY f.manager_id ORDER BY f.period_end DESC, f.filing_id DESC) AS rn
         FROM filings f
     )
     SELECT r.manager_id, COALESCE(NULLIF(h.resolved_ticker, ''), NULLIF(h.cusip, ''))
-    FROM ranked r LEFT JOIN holdings h ON h.filing_id = r.filing_id
-    WHERE r.rn = 1""").fetchall()
+    FROM ranked r LEFT JOIN holdings h ON h.filing_id = r.filing_id"""
+        + current_holding_filter
+        + """
+    WHERE r.rn = 1"""
+    ).fetchall()
     holdings: dict[int, set[str]] = {}
     for manager_id, security in rows:
         securities = holdings.setdefault(int(manager_id), set())
         if security is not None:
             securities.add(str(security))
-    conn.execute("DELETE FROM manager_similarity")
-    ph = get_placeholder(conn)
-    count = 0
-    for left, right in combinations(sorted(holdings), 2):
-        union = holdings[left] | holdings[right]
-        overlap = holdings[left] & holdings[right]
-        if not union:
-            continue
-        conn.execute(
-            "INSERT INTO manager_similarity (manager_id_a, manager_id_b, jaccard, overlap_count, union_count) "
-            f"VALUES ({ph}, {ph}, {ph}, {ph}, {ph})",
-            (left, right, len(overlap) / len(union), len(overlap), len(union)),
-        )
-        count += 1
-    return count
+
+    def replace_rows() -> int:
+        conn.execute("DELETE FROM manager_similarity")
+        ph = get_placeholder(conn)
+        count = 0
+        for left, right in combinations(sorted(holdings), 2):
+            union = holdings[left] | holdings[right]
+            overlap = holdings[left] & holdings[right]
+            if not union:
+                continue
+            conn.execute(
+                "INSERT INTO manager_similarity (manager_id_a, manager_id_b, jaccard, overlap_count, union_count) "
+                f"VALUES ({ph}, {ph}, {ph}, {ph}, {ph})",
+                (left, right, len(overlap) / len(union), len(overlap), len(union)),
+            )
+            count += 1
+        return count
+
+    if isinstance(conn, sqlite3.Connection):
+        with conn:
+            return replace_rows()
+    with conn.transaction():
+        return replace_rows()

--- a/etl/manager_similarity_flow.py
+++ b/etl/manager_similarity_flow.py
@@ -18,8 +18,12 @@ def ensure_manager_similarity_table(conn: Any) -> None:
             PRIMARY KEY (manager_id_a, manager_id_b),
             CHECK (manager_id_a < manager_id_b)
         )""")
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_manager_similarity_a ON manager_similarity(manager_id_a)")
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_manager_similarity_b ON manager_similarity(manager_id_b)")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_manager_similarity_a ON manager_similarity(manager_id_a)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_manager_similarity_b ON manager_similarity(manager_id_b)"
+        )
 
 
 def compute_manager_similarity(conn: Any) -> int:

--- a/etl/manager_similarity_flow.py
+++ b/etl/manager_similarity_flow.py
@@ -34,7 +34,7 @@ def compute_manager_similarity(conn: Any) -> int:
                ROW_NUMBER() OVER (PARTITION BY f.manager_id ORDER BY f.period_end DESC, f.filing_id DESC) AS rn
         FROM filings f
     )
-    SELECT r.manager_id, COALESCE(NULLIF(h.resolved_ticker, ''), h.cusip)
+    SELECT r.manager_id, COALESCE(NULLIF(h.resolved_ticker, ''), NULLIF(h.cusip, ''))
     FROM ranked r LEFT JOIN holdings h ON h.filing_id = r.filing_id
     WHERE r.rn = 1""").fetchall()
     holdings: dict[int, set[str]] = {}

--- a/schema.sql
+++ b/schema.sql
@@ -161,6 +161,19 @@ SELECT *
 FROM holdings
 WHERE superseded_at IS NULL;
 
+CREATE TABLE IF NOT EXISTS manager_similarity (
+    manager_id_a bigint NOT NULL REFERENCES managers(manager_id),
+    manager_id_b bigint NOT NULL REFERENCES managers(manager_id),
+    jaccard real NOT NULL,
+    overlap_count integer NOT NULL,
+    union_count integer NOT NULL,
+    computed_at timestamptz DEFAULT now(),
+    PRIMARY KEY (manager_id_a, manager_id_b),
+    CHECK (manager_id_a < manager_id_b)
+);
+CREATE INDEX IF NOT EXISTS idx_manager_similarity_a ON manager_similarity (manager_id_a);
+CREATE INDEX IF NOT EXISTS idx_manager_similarity_b ON manager_similarity (manager_id_b);
+
 CREATE TABLE IF NOT EXISTS identifier_resolution_cache (
     cusip text PRIMARY KEY,
     ticker text,

--- a/schema.sql
+++ b/schema.sql
@@ -167,7 +167,7 @@ CREATE TABLE IF NOT EXISTS manager_similarity (
     jaccard real NOT NULL,
     overlap_count integer NOT NULL,
     union_count integer NOT NULL,
-    computed_at timestamptz DEFAULT now(),
+    computed_at timestamptz NOT NULL DEFAULT now(),
     PRIMARY KEY (manager_id_a, manager_id_b),
     CHECK (manager_id_a < manager_id_b)
 );

--- a/tests/test_manager_similarity_flow.py
+++ b/tests/test_manager_similarity_flow.py
@@ -1,0 +1,15 @@
+import sqlite3
+
+from etl.manager_similarity_flow import compute_manager_similarity
+
+
+def test_similarity_uses_union_denominator_and_latest_filings():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""CREATE TABLE filings (filing_id INTEGER PRIMARY KEY, manager_id INTEGER, period_end TEXT);
+    CREATE TABLE holdings (filing_id INTEGER, cusip TEXT, resolved_ticker TEXT);
+    INSERT INTO filings VALUES (1, 1, '2025-03-31'), (2, 2, '2025-03-31'), (3, 3, '2025-03-31');
+    INSERT INTO holdings VALUES (1,'A',NULL),(1,'B',NULL),(1,'C',NULL),(1,'D',NULL),
+      (2,'C',NULL),(2,'D',NULL),(2,'E',NULL),(2,'F',NULL),(3,'Z',NULL);""")
+    assert compute_manager_similarity(conn) == 3
+    assert conn.execute("SELECT jaccard, overlap_count, union_count FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=2").fetchone() == (2 / 6, 2, 6)
+    assert conn.execute("SELECT jaccard FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=3").fetchone() == (0.0,)

--- a/tests/test_manager_similarity_flow.py
+++ b/tests/test_manager_similarity_flow.py
@@ -36,7 +36,9 @@ async def _get_similar_manager(manager_id: int, limit: int):
     await cast(Any, app.router).startup()
     try:
         transport = httpx.ASGITransport(app=cast(Any, app))
-        async with httpx.AsyncClient(transport=transport, base_url="http://test", timeout=5.0) as client:
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test", timeout=5.0
+        ) as client:
             return await client.get(f"/managers/{manager_id}/similar", params={"limit": limit})
     finally:
         await cast(Any, app.router).shutdown()
@@ -47,7 +49,9 @@ def test_similar_manager_endpoint_orders_canonical_pairs_and_returns_404(tmp_pat
     monkeypatch.setenv("DB_PATH", str(db_path))
     conn = sqlite3.connect(db_path)
     managers_module._ensure_manager_table(conn)
-    conn.executemany("INSERT INTO managers (id, name) VALUES (?, ?)", [(1, "One"), (2, "Two"), (3, "Three")])
+    conn.executemany(
+        "INSERT INTO managers (id, name) VALUES (?, ?)", [(1, "One"), (2, "Two"), (3, "Three")]
+    )
     conn.execute(
         "CREATE TABLE manager_similarity (manager_id_a INTEGER, manager_id_b INTEGER, jaccard REAL, overlap_count INTEGER, union_count INTEGER)"
     )

--- a/tests/test_manager_similarity_flow.py
+++ b/tests/test_manager_similarity_flow.py
@@ -5,11 +5,17 @@ from etl.manager_similarity_flow import compute_manager_similarity
 
 def test_similarity_uses_union_denominator_and_latest_filings():
     conn = sqlite3.connect(":memory:")
-    conn.executescript("""CREATE TABLE filings (filing_id INTEGER PRIMARY KEY, manager_id INTEGER, period_end TEXT);
+    conn.executescript(
+        """CREATE TABLE filings (filing_id INTEGER PRIMARY KEY, manager_id INTEGER, period_end TEXT);
     CREATE TABLE holdings (filing_id INTEGER, cusip TEXT, resolved_ticker TEXT);
     INSERT INTO filings VALUES (1, 1, '2025-03-31'), (2, 2, '2025-03-31'), (3, 3, '2025-03-31');
     INSERT INTO holdings VALUES (1,'A',NULL),(1,'B',NULL),(1,'C',NULL),(1,'D',NULL),
-      (2,'C',NULL),(2,'D',NULL),(2,'E',NULL),(2,'F',NULL),(3,'Z',NULL);""")
+      (2,'C',NULL),(2,'D',NULL),(2,'E',NULL),(2,'F',NULL),(3,'Z',NULL);"""
+    )
     assert compute_manager_similarity(conn) == 3
-    assert conn.execute("SELECT jaccard, overlap_count, union_count FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=2").fetchone() == (2 / 6, 2, 6)
-    assert conn.execute("SELECT jaccard FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=3").fetchone() == (0.0,)
+    assert conn.execute(
+        "SELECT jaccard, overlap_count, union_count FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=2"
+    ).fetchone() == (2 / 6, 2, 6)
+    assert conn.execute(
+        "SELECT jaccard FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=3"
+    ).fetchone() == (0.0,)

--- a/tests/test_manager_similarity_flow.py
+++ b/tests/test_manager_similarity_flow.py
@@ -63,4 +63,9 @@ def test_similar_manager_endpoint_orders_canonical_pairs_and_returns_404(tmp_pat
     assert response.json() == {
         "items": [{"manager_id": 3, "jaccard": 0.75, "overlap_count": 3, "union_count": 4}]
     }
+    reverse_response = asyncio.run(_get_similar_manager(2, 10))
+    assert reverse_response.status_code == 200
+    assert reverse_response.json() == {
+        "items": [{"manager_id": 1, "jaccard": 0.5, "overlap_count": 2, "union_count": 4}]
+    }
     assert asyncio.run(_get_similar_manager(999, 10)).status_code == 404

--- a/tests/test_manager_similarity_flow.py
+++ b/tests/test_manager_similarity_flow.py
@@ -13,12 +13,15 @@ from etl.manager_similarity_flow import compute_manager_similarity
 def test_similarity_uses_union_denominator_and_latest_filings():
     conn = sqlite3.connect(":memory:")
     conn.executescript(
-        """CREATE TABLE filings (filing_id INTEGER PRIMARY KEY, manager_id INTEGER, period_end TEXT);
-    CREATE TABLE holdings (filing_id INTEGER, cusip TEXT, resolved_ticker TEXT);
+        """PRAGMA foreign_keys = ON;
+    CREATE TABLE managers (id INTEGER PRIMARY KEY);
+    CREATE TABLE filings (filing_id INTEGER PRIMARY KEY, manager_id INTEGER, period_end TEXT);
+    CREATE TABLE holdings (filing_id INTEGER, cusip TEXT, resolved_ticker TEXT, superseded_at TEXT);
+    INSERT INTO managers VALUES (1), (2), (3), (4);
     INSERT INTO filings VALUES (0, 1, '2024-12-31'), (1, 1, '2025-03-31'), (2, 2, '2025-03-31'),
       (3, 3, '2025-03-31'), (4, 4, '2025-03-31');
-    INSERT INTO holdings VALUES (0,'OLD',NULL),(1,'CUSIP-A','A'),(1,'B',NULL),(1,'C',NULL),(1,'D',NULL),
-      (2,'C',NULL),(2,'D',NULL),(2,'E',NULL),(2,'F',NULL),(3,'Z',NULL);"""
+    INSERT INTO holdings VALUES (0,'OLD',NULL,NULL),(1,'CUSIP-A','A',NULL),(1,'B',NULL,NULL),(1,'C',NULL,NULL),(1,'D',NULL,NULL),
+      (1,'STALE',NULL,'2025-04-01'),(2,'C',NULL,NULL),(2,'D',NULL,NULL),(2,'E',NULL,NULL),(2,'F',NULL,NULL),(3,'Z',NULL,NULL);"""
     )
     assert compute_manager_similarity(conn) == 6
     assert conn.execute(
@@ -30,6 +33,31 @@ def test_similarity_uses_union_denominator_and_latest_filings():
     assert conn.execute(
         "SELECT jaccard FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=4"
     ).fetchone() == (0.0,)
+    assert {row[2] for row in conn.execute("PRAGMA foreign_key_list(manager_similarity)")} == {
+        "managers"
+    }
+
+
+def test_similarity_rebuild_rolls_back_on_insert_failure():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""PRAGMA foreign_keys = ON;
+    CREATE TABLE managers (id INTEGER PRIMARY KEY);
+    CREATE TABLE filings (filing_id INTEGER PRIMARY KEY, manager_id INTEGER, period_end TEXT);
+    CREATE TABLE holdings (filing_id INTEGER, cusip TEXT, resolved_ticker TEXT, superseded_at TEXT);
+    INSERT INTO managers VALUES (1), (2);
+    INSERT INTO filings VALUES (1, 1, '2025-03-31'), (2, 2, '2025-03-31');
+    INSERT INTO holdings VALUES (1, 'A', NULL, NULL), (2, 'B', NULL, NULL);""")
+    assert compute_manager_similarity(conn) == 1
+    before = conn.execute("SELECT * FROM manager_similarity").fetchall()
+    conn.execute("""CREATE TRIGGER fail_similarity_insert BEFORE INSERT ON manager_similarity
+        BEGIN SELECT RAISE(ABORT, 'injected write failure'); END""")
+    try:
+        compute_manager_similarity(conn)
+    except sqlite3.IntegrityError as error:
+        assert "injected write failure" in str(error)
+    else:
+        raise AssertionError("expected injected manager similarity write failure")
+    assert conn.execute("SELECT * FROM manager_similarity").fetchall() == before
 
 
 async def _get_similar_manager(manager_id: int, limit: int):

--- a/tests/test_manager_similarity_flow.py
+++ b/tests/test_manager_similarity_flow.py
@@ -1,5 +1,12 @@
+import asyncio
 import sqlite3
+from pathlib import Path
+from typing import Any, cast
 
+import httpx
+
+from api import managers as managers_module
+from api.chat import app
 from etl.manager_similarity_flow import compute_manager_similarity
 
 
@@ -8,14 +15,52 @@ def test_similarity_uses_union_denominator_and_latest_filings():
     conn.executescript(
         """CREATE TABLE filings (filing_id INTEGER PRIMARY KEY, manager_id INTEGER, period_end TEXT);
     CREATE TABLE holdings (filing_id INTEGER, cusip TEXT, resolved_ticker TEXT);
-    INSERT INTO filings VALUES (1, 1, '2025-03-31'), (2, 2, '2025-03-31'), (3, 3, '2025-03-31');
-    INSERT INTO holdings VALUES (1,'A',NULL),(1,'B',NULL),(1,'C',NULL),(1,'D',NULL),
+    INSERT INTO filings VALUES (0, 1, '2024-12-31'), (1, 1, '2025-03-31'), (2, 2, '2025-03-31'),
+      (3, 3, '2025-03-31'), (4, 4, '2025-03-31');
+    INSERT INTO holdings VALUES (0,'OLD',NULL),(1,'CUSIP-A','A'),(1,'B',NULL),(1,'C',NULL),(1,'D',NULL),
       (2,'C',NULL),(2,'D',NULL),(2,'E',NULL),(2,'F',NULL),(3,'Z',NULL);"""
     )
-    assert compute_manager_similarity(conn) == 3
+    assert compute_manager_similarity(conn) == 6
     assert conn.execute(
         "SELECT jaccard, overlap_count, union_count FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=2"
     ).fetchone() == (2 / 6, 2, 6)
     assert conn.execute(
         "SELECT jaccard FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=3"
     ).fetchone() == (0.0,)
+    assert conn.execute(
+        "SELECT jaccard FROM manager_similarity WHERE manager_id_a=1 AND manager_id_b=4"
+    ).fetchone() == (0.0,)
+
+
+async def _get_similar_manager(manager_id: int, limit: int):
+    await cast(Any, app.router).startup()
+    try:
+        transport = httpx.ASGITransport(app=cast(Any, app))
+        async with httpx.AsyncClient(transport=transport, base_url="http://test", timeout=5.0) as client:
+            return await client.get(f"/managers/{manager_id}/similar", params={"limit": limit})
+    finally:
+        await cast(Any, app.router).shutdown()
+
+
+def test_similar_manager_endpoint_orders_canonical_pairs_and_returns_404(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "similarity.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    conn = sqlite3.connect(db_path)
+    managers_module._ensure_manager_table(conn)
+    conn.executemany("INSERT INTO managers (id, name) VALUES (?, ?)", [(1, "One"), (2, "Two"), (3, "Three")])
+    conn.execute(
+        "CREATE TABLE manager_similarity (manager_id_a INTEGER, manager_id_b INTEGER, jaccard REAL, overlap_count INTEGER, union_count INTEGER)"
+    )
+    conn.executemany(
+        "INSERT INTO manager_similarity VALUES (?, ?, ?, ?, ?)",
+        [(1, 2, 0.5, 2, 4), (1, 3, 0.75, 3, 4)],
+    )
+    conn.commit()
+    conn.close()
+
+    response = asyncio.run(_get_similar_manager(1, 1))
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [{"manager_id": 3, "jaccard": 0.75, "overlap_count": 3, "union_count": 4}]
+    }
+    assert asyncio.run(_get_similar_manager(999, 10)).status_code == 404


### PR DESCRIPTION
Closes #1460

## Summary
- compute pairwise latest-holdings Jaccard similarity
- add SQLite/Postgres schema and Alembic migration
- expose GET /managers/{id}/similar

## Validation
- python3 -m pytest tests/test_manager_similarity_flow.py -q
- python3 -m compileall -q etl/manager_similarity_flow.py api/managers.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manager similarity endpoint at `GET /managers/{id}/similar`.
  * Added persistent storage for pairwise similarity metrics between managers.
  * Added automated computation of similarity scores from each manager’s latest filings.
* **Bug Fixes**
  * Unknown manager requests now return a clear not-found response.
  * Similar managers are returned using a canonical pair ordering regardless of request direction.
* **Tests**
  * Added end-to-end tests for similarity computation and the HTTP endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->