### PR TITLE
feat: bitemporal holdings store + as_of query (#1463)

### DIFF
--- a/alembic/versions/012_bitemporal_holdings.py
+++ b/alembic/versions/012_bitemporal_holdings.py
@@ -33,15 +33,11 @@ def upgrade() -> None:
             sa.Column("version", sa.Integer(), nullable=False, server_default=sa.text("1"))
         )
 
-    op.execute(
-        text(
-            """
+    op.execute(text("""
             UPDATE holdings
                SET knowledge_time = COALESCE(created_at, CURRENT_TIMESTAMP)
              WHERE knowledge_time IS NULL
-            """
-        )
-    )
+            """))
 
     op.execute(
         text(
@@ -55,16 +51,12 @@ def upgrade() -> None:
             "ON holdings (filing_id) WHERE superseded_at IS NULL"
         )
     )
-    op.execute(
-        text(
-            """
+    op.execute(text("""
             CREATE VIEW IF NOT EXISTS v_current_holdings AS
             SELECT *
             FROM holdings
             WHERE superseded_at IS NULL
-            """
-        )
-    )
+            """))
 
 
 def downgrade() -> None:

--- a/alembic/versions/012_bitemporal_holdings.py
+++ b/alembic/versions/012_bitemporal_holdings.py
@@ -1,0 +1,78 @@
+"""Add bitemporal holdings columns and current view.
+
+Revision ID: 012
+Revises: 011
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from alembic import op
+
+revision = "012"
+down_revision = "011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("holdings") as batch:
+        batch.add_column(sa.Column("content_hash", sa.Text(), nullable=True))
+        batch.add_column(
+            sa.Column(
+                "knowledge_time",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            )
+        )
+        batch.add_column(sa.Column("superseded_at", sa.DateTime(timezone=True), nullable=True))
+        batch.add_column(
+            sa.Column("version", sa.Integer(), nullable=False, server_default=sa.text("1"))
+        )
+
+    op.execute(
+        text(
+            """
+            UPDATE holdings
+               SET knowledge_time = COALESCE(created_at, CURRENT_TIMESTAMP)
+             WHERE knowledge_time IS NULL
+            """
+        )
+    )
+
+    op.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS idx_holdings_filing_knowledge "
+            "ON holdings (filing_id, knowledge_time DESC, holding_id DESC)"
+        )
+    )
+    op.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS idx_holdings_current_filing "
+            "ON holdings (filing_id) WHERE superseded_at IS NULL"
+        )
+    )
+    op.execute(
+        text(
+            """
+            CREATE VIEW IF NOT EXISTS v_current_holdings AS
+            SELECT *
+            FROM holdings
+            WHERE superseded_at IS NULL
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(text("DROP VIEW IF EXISTS v_current_holdings"))
+    op.drop_index("idx_holdings_current_filing", table_name="holdings")
+    op.drop_index("idx_holdings_filing_knowledge", table_name="holdings")
+    with op.batch_alter_table("holdings") as batch:
+        batch.drop_column("version")
+        batch.drop_column("superseded_at")
+        batch.drop_column("knowledge_time")
+        batch.drop_column("content_hash")

--- a/alembic/versions/012_bitemporal_holdings.py
+++ b/alembic/versions/012_bitemporal_holdings.py
@@ -32,13 +32,11 @@ def upgrade() -> None:
             sa.Column("version", sa.Integer(), nullable=False, server_default=sa.text("1"))
         )
 
-    op.execute(
-        text("""
+    op.execute(text("""
             UPDATE holdings
                SET knowledge_time = COALESCE(created_at, CURRENT_TIMESTAMP)
              WHERE knowledge_time IS NULL
-            """)
-    )
+            """))
 
     with op.batch_alter_table("holdings") as batch:
         batch.alter_column(
@@ -65,14 +63,12 @@ def upgrade() -> None:
         if op.get_bind().dialect.name == "postgresql"
         else "CREATE VIEW IF NOT EXISTS"
     )
-    op.execute(
-        text(f"""
+    op.execute(text(f"""
             {create_view} v_current_holdings AS
             SELECT *
             FROM holdings
             WHERE superseded_at IS NULL
-            """)
-    )
+            """))
 
 
 def downgrade() -> None:

--- a/alembic/versions/012_bitemporal_holdings.py
+++ b/alembic/versions/012_bitemporal_holdings.py
@@ -24,8 +24,7 @@ def upgrade() -> None:
             sa.Column(
                 "knowledge_time",
                 sa.DateTime(timezone=True),
-                nullable=False,
-                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=True,
             )
         )
         batch.add_column(sa.Column("superseded_at", sa.DateTime(timezone=True), nullable=True))
@@ -33,11 +32,21 @@ def upgrade() -> None:
             sa.Column("version", sa.Integer(), nullable=False, server_default=sa.text("1"))
         )
 
-    op.execute(text("""
+    op.execute(
+        text("""
             UPDATE holdings
                SET knowledge_time = COALESCE(created_at, CURRENT_TIMESTAMP)
              WHERE knowledge_time IS NULL
-            """))
+            """)
+    )
+
+    with op.batch_alter_table("holdings") as batch:
+        batch.alter_column(
+            "knowledge_time",
+            existing_type=sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        )
 
     op.execute(
         text(
@@ -51,12 +60,19 @@ def upgrade() -> None:
             "ON holdings (filing_id) WHERE superseded_at IS NULL"
         )
     )
-    op.execute(text("""
-            CREATE VIEW IF NOT EXISTS v_current_holdings AS
+    create_view = (
+        "CREATE OR REPLACE VIEW"
+        if op.get_bind().dialect.name == "postgresql"
+        else "CREATE VIEW IF NOT EXISTS"
+    )
+    op.execute(
+        text(f"""
+            {create_view} v_current_holdings AS
             SELECT *
             FROM holdings
             WHERE superseded_at IS NULL
-            """))
+            """)
+    )
 
 
 def downgrade() -> None:

--- a/etl/edgar_flow.py
+++ b/etl/edgar_flow.py
@@ -227,6 +227,9 @@ def _insert_holding_legacy(
     cik: str,
     accession: str,
     filed_date: str | None,
+    knowledge_time: str | None = None,
+    version: int = 1,
+    content_hash: str | None = None,
 ) -> None:
     columns = get_table_columns(conn, "holdings")
     marker = get_placeholder(conn)
@@ -241,6 +244,12 @@ def _insert_holding_legacy(
         "resolved_lei": row.get("resolved_lei"),
         "resolution_source": row.get("resolution_source"),
     }
+    if knowledge_time is not None and "knowledge_time" in columns:
+        values["knowledge_time"] = knowledge_time
+    if "version" in columns:
+        values["version"] = version
+    if content_hash is not None and "content_hash" in columns:
+        values["content_hash"] = content_hash
     if isinstance(conn, sqlite3.Connection):
         values.update(
             {
@@ -288,8 +297,32 @@ def _replace_holdings_for_filing(
     accession: str,
     filed_date: str | None,
 ) -> None:
+    from datetime import UTC, datetime
+
     def _work() -> None:
-        _delete_holdings_for_filing(conn, filing_id)
+        holdings_columns = get_table_columns(conn, "holdings")
+        bitemporal = ingest_module._bitemporal_enabled(holdings_columns)
+        digest = ingest_module._holdings_content_hash(rows)
+        if bitemporal:
+            existing = ingest_module._current_content_hash(conn, filing_id=filing_id)
+            if existing is not None and existing == digest:
+                return
+            stamp = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            version = ingest_module._next_holdings_version(conn, filing_id=filing_id)
+            ingest_module._supersede_current_holdings(
+                conn, filing_id=filing_id, knowledge_time=stamp
+            )
+            if manager_id is not None:
+                ingest_module._supersede_prior_period_holdings(
+                    conn,
+                    manager_id=manager_id,
+                    filing_id=filing_id,
+                    knowledge_time=stamp,
+                )
+        else:
+            _delete_holdings_for_filing(conn, filing_id)
+            stamp = None
+            version = 1
         try:
             resolve_holding_identifiers(conn, rows, filing_id=filing_id, source="edgar")
         except Exception:
@@ -303,6 +336,9 @@ def _replace_holdings_for_filing(
                 cik=cik,
                 accession=accession,
                 filed_date=filed_date,
+                knowledge_time=stamp if bitemporal else None,
+                version=version if bitemporal else 1,
+                content_hash=digest if bitemporal else None,
             )
 
     _run_in_transaction(conn, _work)

--- a/etl/ingest_flow.py
+++ b/etl/ingest_flow.py
@@ -314,6 +314,113 @@ def _insert_filing(
     return int(row[0]) if row and row[0] is not None else 0
 
 
+def _holdings_content_hash(parsed_rows: list[dict[str, Any]]) -> str:
+    """Stable content fingerprint so identical re-ingests are no-ops."""
+    import hashlib
+
+    normalized: list[tuple[Any, ...]] = []
+    for row in parsed_rows:
+        normalized.append(
+            (
+                str(row.get("cusip") or ""),
+                str(row.get("nameOfIssuer") or ""),
+                int(row.get("sshPrnamt") or 0),
+                int(row.get("value") or 0),
+            )
+        )
+    normalized.sort()
+    payload = json.dumps(normalized, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _bitemporal_enabled(holdings_columns: set[str]) -> bool:
+    return {"knowledge_time", "superseded_at", "version"}.issubset(holdings_columns)
+
+
+def _current_content_hash(conn: Any, *, filing_id: int) -> str | None:
+    holdings_columns = _table_columns(conn, "holdings")
+    if "content_hash" not in holdings_columns or "filing_id" not in holdings_columns:
+        return None
+    marker = get_placeholder(conn)
+    if "superseded_at" in holdings_columns:
+        row = conn.execute(
+            f"SELECT content_hash FROM holdings "
+            f"WHERE filing_id = {marker} AND superseded_at IS NULL "
+            f"AND content_hash IS NOT NULL LIMIT 1",
+            (filing_id,),
+        ).fetchone()
+    else:
+        row = conn.execute(
+            f"SELECT content_hash FROM holdings "
+            f"WHERE filing_id = {marker} AND content_hash IS NOT NULL LIMIT 1",
+            (filing_id,),
+        ).fetchone()
+    if not row:
+        return None
+    return str(row[0]) if row[0] is not None else None
+
+
+def _next_holdings_version(conn: Any, *, filing_id: int) -> int:
+    marker = get_placeholder(conn)
+    row = conn.execute(
+        f"SELECT COALESCE(MAX(version), 0) FROM holdings WHERE filing_id = {marker}",
+        (filing_id,),
+    ).fetchone()
+    current = int(row[0] or 0) if row else 0
+    return current + 1
+
+
+def _supersede_current_holdings(conn: Any, *, filing_id: int, knowledge_time: str) -> None:
+    marker = get_placeholder(conn)
+    conn.execute(
+        f"UPDATE holdings SET superseded_at = {marker} "
+        f"WHERE filing_id = {marker} AND superseded_at IS NULL",
+        (knowledge_time, filing_id),
+    )
+
+
+def _supersede_prior_period_holdings(
+    conn: Any,
+    *,
+    manager_id: int,
+    filing_id: int,
+    knowledge_time: str,
+) -> None:
+    """Mark prior filings' current holdings superseded for the same event period."""
+    holdings_columns = _table_columns(conn, "holdings")
+    filing_columns = _table_columns(conn, "filings")
+    if not _bitemporal_enabled(holdings_columns):
+        return
+    if "period_end" not in filing_columns and "filed_date" not in filing_columns:
+        return
+    marker = get_placeholder(conn)
+    period_expr = (
+        "COALESCE(period_end, filed_date)" if "period_end" in filing_columns else "filed_date"
+    )
+    period_row = conn.execute(
+        f"SELECT {period_expr}, manager_id FROM filings WHERE filing_id = {marker}",
+        (filing_id,),
+    ).fetchone()
+    if not period_row or period_row[0] is None:
+        return
+    event_time = period_row[0]
+    owner_id = int(period_row[1]) if period_row[1] is not None else manager_id
+    prior_ids = conn.execute(
+        f"SELECT filing_id FROM filings "
+        f"WHERE manager_id = {marker} "
+        f"AND filing_id <> {marker} "
+        f"AND {period_expr} = {marker}",
+        (owner_id, filing_id, event_time),
+    ).fetchall()
+    for prior in prior_ids:
+        prior_id = int(prior[0])
+        conn.execute(
+            f"UPDATE holdings SET superseded_at = {marker} "
+            f"WHERE filing_id = {marker} AND superseded_at IS NULL",
+            (knowledge_time, prior_id),
+        )
+
+
 def _insert_holdings_rows(
     conn: Any,
     *,
@@ -324,34 +431,66 @@ def _insert_holdings_rows(
     filed_date: str | None,
     parsed_rows: list[dict[str, Any]],
     jurisdiction: str,
+    knowledge_time: str | None = None,
+    version: int = 1,
+    content_hash: str | None = None,
 ) -> int:
+    from datetime import UTC, datetime
+
     holdings_columns = _table_columns(conn, "holdings")
     canonical_holdings = {"name_of_issuer", "shares", "value_usd"}.issubset(holdings_columns)
     marker = get_placeholder(conn)
+    bitemporal = _bitemporal_enabled(holdings_columns)
+    stamp = knowledge_time or datetime.now(UTC).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+    digest = content_hash or _holdings_content_hash(parsed_rows)
+
     if canonical_holdings:
+        columns = ["filing_id", "cusip", "name_of_issuer", "shares", "value_usd"]
+        if bitemporal:
+            for optional in ("content_hash", "knowledge_time", "version"):
+                if optional in holdings_columns:
+                    columns.append(optional)
         sql = (
-            "INSERT INTO holdings(filing_id, cusip, name_of_issuer, shares, value_usd) "
-            f"VALUES ({','.join([marker] * 5)})"
+            f"INSERT INTO holdings({', '.join(columns)}) "
+            f"VALUES ({','.join([marker] * len(columns))})"
         )
     else:
+        columns = [
+            "filing_id",
+            "manager_id",
+            "cik",
+            "accession",
+            "filed",
+            "nameOfIssuer",
+            "cusip",
+            "value",
+            "sshPrnamt",
+        ]
         sql = (
-            "INSERT INTO holdings(filing_id, manager_id, cik, accession, filed, nameOfIssuer, cusip, value, sshPrnamt) "
-            f"VALUES ({','.join([marker] * 9)})"
+            f"INSERT INTO holdings({', '.join(columns)}) "
+            f"VALUES ({','.join([marker] * len(columns))})"
         )
     inserted = 0
     cik_value = identifier if jurisdiction == "us" else None
     for row in parsed_rows:
         if canonical_holdings:
-            conn.execute(
-                sql,
-                (
-                    filing_id,
-                    row.get("cusip"),
-                    row.get("nameOfIssuer"),
-                    int(row.get("sshPrnamt") or 0),
-                    int(row.get("value") or 0),
-                ),
-            )
+            values: list[Any] = [
+                filing_id,
+                row.get("cusip"),
+                row.get("nameOfIssuer"),
+                int(row.get("sshPrnamt") or 0),
+                int(row.get("value") or 0),
+            ]
+            if bitemporal:
+                if "content_hash" in holdings_columns:
+                    values.append(digest)
+                if "knowledge_time" in holdings_columns:
+                    values.append(stamp)
+                if "version" in holdings_columns:
+                    values.append(version)
+            conn.execute(sql, tuple(values))
         else:
             conn.execute(
                 sql,
@@ -434,7 +573,38 @@ def _replace_holdings_rows(
     parsed_rows: list[dict[str, Any]],
     jurisdiction: str,
 ) -> int:
+    from datetime import UTC, datetime
+
     def _work() -> int:
+        holdings_columns = _table_columns(conn, "holdings")
+        digest = _holdings_content_hash(parsed_rows)
+        if _bitemporal_enabled(holdings_columns):
+            existing = _current_content_hash(conn, filing_id=filing_id)
+            if existing is not None and existing == digest:
+                # Identical re-ingest: no version churn.
+                return 0
+            stamp = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            version = _next_holdings_version(conn, filing_id=filing_id)
+            _supersede_current_holdings(conn, filing_id=filing_id, knowledge_time=stamp)
+            _supersede_prior_period_holdings(
+                conn,
+                manager_id=manager_id,
+                filing_id=filing_id,
+                knowledge_time=stamp,
+            )
+            return _insert_holdings_rows(
+                conn,
+                filing_id=filing_id,
+                manager_id=manager_id,
+                identifier=identifier,
+                external_id=external_id,
+                filed_date=filed_date,
+                parsed_rows=parsed_rows,
+                jurisdiction=jurisdiction,
+                knowledge_time=stamp,
+                version=version,
+                content_hash=digest,
+            )
         _delete_holdings_rows(conn, filing_id=filing_id)
         return _insert_holdings_rows(
             conn,

--- a/etl/point_in_time.py
+++ b/etl/point_in_time.py
@@ -38,6 +38,7 @@ def current_holdings(
     columns = get_table_columns(conn, "holdings")
     if "holding_id" not in columns and "id" not in columns:
         return []
+    holding_order_column = "holding_id" if "holding_id" in columns else "id"
     marker = get_placeholder(conn)
     where: list[str] = []
     params: list[Any] = []
@@ -55,10 +56,10 @@ def current_holdings(
         sql = (
             "SELECT h.* FROM holdings h "
             "JOIN filings f ON f.filing_id = h.filing_id"
-            f"{where_sql} ORDER BY h.holding_id"
+            f"{where_sql} ORDER BY h.{holding_order_column}"
         )
     else:
-        sql = f"SELECT h.* FROM holdings h{where_sql} ORDER BY h.holding_id"
+        sql = f"SELECT h.* FROM holdings h{where_sql} ORDER BY h.{holding_order_column}"
     result = conn.execute(sql, tuple(params))
     return _rows_as_dicts(result)
 
@@ -77,7 +78,11 @@ def holdings_as_of(
     """
     holdings_columns = get_table_columns(conn, "holdings")
     filing_columns = get_table_columns(conn, "filings")
-    if "filing_id" not in holdings_columns or "filing_id" not in filing_columns:
+    if (
+        "filing_id" not in holdings_columns
+        or "filing_id" not in filing_columns
+        or ("holding_id" not in holdings_columns and "id" not in holdings_columns)
+    ):
         return []
 
     as_of = _normalize_as_of(as_of_date)
@@ -86,6 +91,7 @@ def holdings_as_of(
     marker = get_placeholder(conn)
     has_knowledge = "knowledge_time" in holdings_columns
     has_superseded = "superseded_at" in holdings_columns
+    holding_order_column = "holding_id" if "holding_id" in holdings_columns else "id"
     period_expr = (
         "COALESCE(f.period_end, f.filed_date)" if "period_end" in filing_columns else "f.filed_date"
     )
@@ -99,7 +105,14 @@ def holdings_as_of(
         f"AND f.filed_date IS NOT NULL "
         f"AND f.filed_date <= {marker}"
     )
-    filing_rows = conn.execute(filing_sql, (manager_id, as_of_day)).fetchall()
+    filing_params: list[Any] = [manager_id, as_of_day]
+    if has_knowledge:
+        filing_sql += (
+            " AND EXISTS (SELECT 1 FROM holdings h_visible "
+            f"WHERE h_visible.filing_id = f.filing_id AND h_visible.knowledge_time <= {marker})"
+        )
+        filing_params.append(as_of_text)
+    filing_rows = conn.execute(filing_sql, tuple(filing_params)).fetchall()
     if not filing_rows:
         return []
 
@@ -139,7 +152,7 @@ def holdings_as_of(
     sql = (
         "SELECT h.* FROM holdings h "
         f"WHERE {' AND '.join(where)} "
-        "ORDER BY h.filing_id, h.holding_id"
+        f"ORDER BY h.filing_id, h.{holding_order_column}"
     )
     result = conn.execute(sql, tuple(params))
     return _rows_as_dicts(result)

--- a/etl/point_in_time.py
+++ b/etl/point_in_time.py
@@ -1,0 +1,160 @@
+"""Point-in-time holdings helpers (bitemporal as-of + current view).
+
+Implements Manager-Database #1463 / design #1400.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Any
+
+from adapters.base import get_placeholder, get_table_columns
+
+
+def _normalize_as_of(as_of: date | datetime) -> datetime:
+    if isinstance(as_of, datetime):
+        if as_of.tzinfo is None:
+            return as_of.replace(tzinfo=UTC)
+        return as_of.astimezone(UTC)
+    return datetime(as_of.year, as_of.month, as_of.day, tzinfo=UTC)
+
+
+def _as_of_literal(as_of: datetime) -> str:
+    return as_of.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def current_holdings_sql(table_alias: str = "h") -> str:
+    """SQL predicate selecting non-superseded holdings rows."""
+    return f"{table_alias}.superseded_at IS NULL"
+
+
+def current_holdings(
+    conn: Any,
+    *,
+    manager_id: int | None = None,
+    filing_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return current (non-superseded) holdings, optionally filtered."""
+    columns = get_table_columns(conn, "holdings")
+    if "holding_id" not in columns and "id" not in columns:
+        return []
+    marker = get_placeholder(conn)
+    where: list[str] = []
+    params: list[Any] = []
+    if "superseded_at" in columns:
+        where.append("h.superseded_at IS NULL")
+    join_filings = manager_id is not None
+    if filing_id is not None:
+        where.append(f"h.filing_id = {marker}")
+        params.append(filing_id)
+    if manager_id is not None:
+        where.append(f"f.manager_id = {marker}")
+        params.append(manager_id)
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+    if join_filings:
+        sql = (
+            "SELECT h.* FROM holdings h "
+            "JOIN filings f ON f.filing_id = h.filing_id"
+            f"{where_sql} ORDER BY h.holding_id"
+        )
+    else:
+        sql = f"SELECT h.* FROM holdings h{where_sql} ORDER BY h.holding_id"
+    result = conn.execute(sql, tuple(params))
+    return _rows_as_dicts(result)
+
+
+def holdings_as_of(
+    conn: Any,
+    manager_id: int,
+    as_of_date: date | datetime,
+) -> list[dict[str, Any]]:
+    """Return authoritative holdings known by ``as_of_date`` for a manager.
+
+    A row is visible when ``knowledge_time <= as_of`` and
+    (``superseded_at`` is null or ``superseded_at > as_of``). Among filings with
+    ``filed_date <= as_of``, the latest filing per ``period_end`` (else
+    ``filed_date``) is selected, then that filing's visible holdings are returned.
+    """
+    holdings_columns = get_table_columns(conn, "holdings")
+    filing_columns = get_table_columns(conn, "filings")
+    if "filing_id" not in holdings_columns or "filing_id" not in filing_columns:
+        return []
+
+    as_of = _normalize_as_of(as_of_date)
+    as_of_text = _as_of_literal(as_of)
+    as_of_day = as_of.date().isoformat()
+    marker = get_placeholder(conn)
+    has_knowledge = "knowledge_time" in holdings_columns
+    has_superseded = "superseded_at" in holdings_columns
+    period_expr = (
+        "COALESCE(f.period_end, f.filed_date)"
+        if "period_end" in filing_columns
+        else "f.filed_date"
+    )
+
+    # Load candidate filings for the manager filed by as_of, then pick latest
+    # per period in Python so SQLite/Postgres stay aligned without dialect SQL.
+    filing_sql = (
+        f"SELECT f.filing_id, f.filed_date, {period_expr} AS event_time "
+        f"FROM filings f "
+        f"WHERE f.manager_id = {marker} "
+        f"AND f.filed_date IS NOT NULL "
+        f"AND f.filed_date <= {marker}"
+    )
+    filing_rows = conn.execute(filing_sql, (manager_id, as_of_day)).fetchall()
+    if not filing_rows:
+        return []
+
+    latest_by_period: dict[str, tuple[Any, ...]] = {}
+    for row in filing_rows:
+        if hasattr(row, "keys"):
+            filing_id = row["filing_id"]
+            filed_date = row["filed_date"]
+            event_time = row["event_time"]
+        else:
+            filing_id, filed_date, event_time = row[0], row[1], row[2]
+        period_key = str(event_time)
+        filed_key = str(filed_date)
+        prev = latest_by_period.get(period_key)
+        if prev is None:
+            latest_by_period[period_key] = (filing_id, filed_key, event_time)
+            continue
+        prev_filed = prev[1]
+        prev_fid = int(prev[0])
+        if filed_key > prev_filed or (filed_key == prev_filed and int(filing_id) > prev_fid):
+            latest_by_period[period_key] = (filing_id, filed_key, event_time)
+
+    selected_ids = [int(item[0]) for item in latest_by_period.values()]
+    if not selected_ids:
+        return []
+
+    placeholders = ", ".join(marker for _ in selected_ids)
+    where = [f"h.filing_id IN ({placeholders})"]
+    params: list[Any] = list(selected_ids)
+    if has_knowledge:
+        where.append(f"h.knowledge_time <= {marker}")
+        params.append(as_of_text)
+    if has_superseded:
+        where.append(f"(h.superseded_at IS NULL OR h.superseded_at > {marker})")
+        params.append(as_of_text)
+
+    sql = (
+        "SELECT h.* FROM holdings h "
+        f"WHERE {' AND '.join(where)} "
+        "ORDER BY h.filing_id, h.holding_id"
+    )
+    result = conn.execute(sql, tuple(params))
+    return _rows_as_dicts(result)
+
+
+def _rows_as_dicts(result: Any) -> list[dict[str, Any]]:
+    rows = result.fetchall() if hasattr(result, "fetchall") else list(result)
+    if not rows:
+        return []
+    if hasattr(rows[0], "keys"):
+        return [dict(row) for row in rows]
+    description = getattr(result, "description", None)
+    if description:
+        keys = [col[0] for col in description]
+        return [dict(zip(keys, row, strict=False)) for row in rows]
+    return [{f"col_{idx}": value for idx, value in enumerate(row)} for row in rows]

--- a/etl/point_in_time.py
+++ b/etl/point_in_time.py
@@ -87,9 +87,7 @@ def holdings_as_of(
     has_knowledge = "knowledge_time" in holdings_columns
     has_superseded = "superseded_at" in holdings_columns
     period_expr = (
-        "COALESCE(f.period_end, f.filed_date)"
-        if "period_end" in filing_columns
-        else "f.filed_date"
+        "COALESCE(f.period_end, f.filed_date)" if "period_end" in filing_columns else "f.filed_date"
     )
 
     # Load candidate filings for the manager filed by as_of, then pick latest

--- a/schema.sql
+++ b/schema.sql
@@ -136,6 +136,10 @@ CREATE TABLE IF NOT EXISTS holdings (
     resolved_figi text,
     resolved_lei text,
     resolution_source text,
+    content_hash text,
+    knowledge_time timestamptz NOT NULL DEFAULT now(),
+    superseded_at timestamptz,
+    version integer NOT NULL DEFAULT 1,
     created_at timestamptz DEFAULT now()
 );
 
@@ -144,6 +148,18 @@ CREATE INDEX IF NOT EXISTS idx_holdings_filing_id
 
 CREATE INDEX IF NOT EXISTS idx_holdings_cusip
     ON holdings (cusip);
+
+CREATE INDEX IF NOT EXISTS idx_holdings_filing_knowledge
+    ON holdings (filing_id, knowledge_time DESC, holding_id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_holdings_current_filing
+    ON holdings (filing_id)
+    WHERE superseded_at IS NULL;
+
+CREATE OR REPLACE VIEW v_current_holdings AS
+SELECT *
+FROM holdings
+WHERE superseded_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS identifier_resolution_cache (
     cusip text PRIMARY KEY,

--- a/tests/test_bitemporal_holdings.py
+++ b/tests/test_bitemporal_holdings.py
@@ -12,16 +12,13 @@ from etl import ingest_flow, point_in_time
 def _connect(tmp_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(tmp_path / "bitemporal.db")
     conn.row_factory = sqlite3.Row
-    conn.execute(
-        """
+    conn.execute("""
         CREATE TABLE managers (
             manager_id INTEGER PRIMARY KEY,
             name TEXT
         )
-        """
-    )
-    conn.execute(
-        """
+        """)
+    conn.execute("""
         CREATE TABLE filings (
             filing_id INTEGER PRIMARY KEY,
             manager_id INTEGER NOT NULL,
@@ -31,10 +28,8 @@ def _connect(tmp_path: Path) -> sqlite3.Connection:
             source TEXT NOT NULL,
             raw_key TEXT
         )
-        """
-    )
-    conn.execute(
-        """
+        """)
+    conn.execute("""
         CREATE TABLE holdings (
             holding_id INTEGER PRIMARY KEY AUTOINCREMENT,
             filing_id INTEGER NOT NULL,
@@ -48,8 +43,7 @@ def _connect(tmp_path: Path) -> sqlite3.Connection:
             version INTEGER NOT NULL DEFAULT 1,
             created_at TEXT
         )
-        """
-    )
+        """)
     conn.execute("INSERT INTO managers(manager_id, name) VALUES (1, 'Test Manager')")
     conn.commit()
     return conn
@@ -113,9 +107,7 @@ def test_holdings_as_of_preserves_versions_and_no_lookahead(tmp_path):
     conn.commit()
 
     # Before v2 knowledge: still v1
-    as_of_before_v2 = point_in_time.holdings_as_of(
-        conn, 1, datetime(2024, 5, 15, tzinfo=UTC)
-    )
+    as_of_before_v2 = point_in_time.holdings_as_of(conn, 1, datetime(2024, 5, 15, tzinfo=UTC))
     assert len(as_of_before_v2) == 1
     assert int(as_of_before_v2[0]["shares"]) == 100
     assert int(as_of_before_v2[0]["filing_id"]) == 10
@@ -167,7 +159,9 @@ def test_identical_reingest_is_noop(tmp_path):
     )
     assert first == 1
     assert second == 0
-    versions = conn.execute("SELECT COUNT(*), MAX(version) FROM holdings WHERE filing_id = 20").fetchone()
+    versions = conn.execute(
+        "SELECT COUNT(*), MAX(version) FROM holdings WHERE filing_id = 20"
+    ).fetchone()
     assert int(versions[0]) == 1
     assert int(versions[1]) == 1
 

--- a/tests/test_bitemporal_holdings.py
+++ b/tests/test_bitemporal_holdings.py
@@ -82,7 +82,7 @@ def test_holdings_as_of_preserves_versions_and_no_lookahead(tmp_path):
     # Amended filing with changed holdings (v2)
     conn.execute(
         "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source, raw_key) "
-        "VALUES (11, 1, '13F-HR/A', '2024-03-31', '2024-06-01', 'us', 'acc-v2')"
+        "VALUES (11, 1, '13F-HR/A', '2024-03-31', '2024-05-10', 'us', 'acc-v2')"
     )
     v2_rows = [
         {"cusip": "037833100", "nameOfIssuer": "APPLE INC", "sshPrnamt": 250, "value": 2500},
@@ -94,7 +94,7 @@ def test_holdings_as_of_preserves_versions_and_no_lookahead(tmp_path):
         manager_id=1,
         identifier="0000320193",
         external_id="acc-v2",
-        filed_date="2024-06-01",
+        filed_date="2024-05-10",
         parsed_rows=v2_rows,
         jurisdiction="us",
     )

--- a/tests/test_bitemporal_holdings.py
+++ b/tests/test_bitemporal_holdings.py
@@ -1,0 +1,256 @@
+"""Acceptance tests for bitemporal holdings + as_of query (#1463)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from etl import ingest_flow, point_in_time
+
+
+def _connect(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "bitemporal.db")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE managers (
+            manager_id INTEGER PRIMARY KEY,
+            name TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE filings (
+            filing_id INTEGER PRIMARY KEY,
+            manager_id INTEGER NOT NULL,
+            type TEXT NOT NULL,
+            period_end TEXT,
+            filed_date TEXT,
+            source TEXT NOT NULL,
+            raw_key TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE holdings (
+            holding_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            filing_id INTEGER NOT NULL,
+            cusip TEXT,
+            name_of_issuer TEXT,
+            shares INTEGER,
+            value_usd REAL,
+            content_hash TEXT,
+            knowledge_time TEXT NOT NULL,
+            superseded_at TEXT,
+            version INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT
+        )
+        """
+    )
+    conn.execute("INSERT INTO managers(manager_id, name) VALUES (1, 'Test Manager')")
+    conn.commit()
+    return conn
+
+
+def test_holdings_as_of_preserves_versions_and_no_lookahead(tmp_path):
+    conn = _connect(tmp_path)
+    # v1 filing
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source, raw_key) "
+        "VALUES (10, 1, '13F-HR', '2024-03-31', '2024-05-01', 'us', 'acc-v1')"
+    )
+    v1_rows = [
+        {"cusip": "037833100", "nameOfIssuer": "APPLE INC", "sshPrnamt": 100, "value": 1000},
+    ]
+    t1 = "2024-05-01T12:00:00Z"
+    ingest_flow._replace_holdings_rows(
+        conn,
+        filing_id=10,
+        manager_id=1,
+        identifier="0000320193",
+        external_id="acc-v1",
+        filed_date="2024-05-01",
+        parsed_rows=v1_rows,
+        jurisdiction="us",
+    )
+    # Force known knowledge_time for v1 rows
+    conn.execute("UPDATE holdings SET knowledge_time = ? WHERE filing_id = 10", (t1,))
+    conn.commit()
+
+    before = point_in_time.holdings_as_of(conn, 1, datetime(2024, 5, 2, tzinfo=UTC))
+    assert len(before) == 1
+    assert before[0]["cusip"] == "037833100"
+    assert int(before[0]["shares"]) == 100
+
+    # Amended filing with changed holdings (v2)
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source, raw_key) "
+        "VALUES (11, 1, '13F-HR/A', '2024-03-31', '2024-06-01', 'us', 'acc-v2')"
+    )
+    v2_rows = [
+        {"cusip": "037833100", "nameOfIssuer": "APPLE INC", "sshPrnamt": 250, "value": 2500},
+    ]
+    t2 = "2024-06-01T12:00:00Z"
+    ingest_flow._replace_holdings_rows(
+        conn,
+        filing_id=11,
+        manager_id=1,
+        identifier="0000320193",
+        external_id="acc-v2",
+        filed_date="2024-06-01",
+        parsed_rows=v2_rows,
+        jurisdiction="us",
+    )
+    conn.execute("UPDATE holdings SET knowledge_time = ? WHERE filing_id = 11", (t2,))
+    # Keep superseded_at on v1 as the amendment knowledge time
+    conn.execute(
+        "UPDATE holdings SET superseded_at = ? WHERE filing_id = 10 AND superseded_at IS NOT NULL",
+        (t2,),
+    )
+    conn.commit()
+
+    # Before v2 knowledge: still v1
+    as_of_before_v2 = point_in_time.holdings_as_of(
+        conn, 1, datetime(2024, 5, 15, tzinfo=UTC)
+    )
+    assert len(as_of_before_v2) == 1
+    assert int(as_of_before_v2[0]["shares"]) == 100
+    assert int(as_of_before_v2[0]["filing_id"]) == 10
+
+    # After v2 knowledge: v2, and v1 retained with superseded_at
+    as_of_after = point_in_time.holdings_as_of(conn, 1, datetime(2024, 6, 15, tzinfo=UTC))
+    assert len(as_of_after) == 1
+    assert int(as_of_after[0]["shares"]) == 250
+    assert int(as_of_after[0]["filing_id"]) == 11
+
+    retained = conn.execute(
+        "SELECT holding_id, superseded_at FROM holdings WHERE filing_id = 10"
+    ).fetchall()
+    assert retained
+    assert all(row["superseded_at"] is not None for row in retained)
+
+    # No look-ahead: as_of before v2 must not return v2
+    assert all(int(row["filing_id"]) != 11 for row in as_of_before_v2)
+
+
+def test_identical_reingest_is_noop(tmp_path):
+    conn = _connect(tmp_path)
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source, raw_key) "
+        "VALUES (20, 1, '13F-HR', '2024-06-30', '2024-08-01', 'us', 'acc-same')"
+    )
+    rows = [
+        {"cusip": "594918104", "nameOfIssuer": "MICROSOFT", "sshPrnamt": 10, "value": 50},
+    ]
+    first = ingest_flow._replace_holdings_rows(
+        conn,
+        filing_id=20,
+        manager_id=1,
+        identifier="0000789019",
+        external_id="acc-same",
+        filed_date="2024-08-01",
+        parsed_rows=rows,
+        jurisdiction="us",
+    )
+    second = ingest_flow._replace_holdings_rows(
+        conn,
+        filing_id=20,
+        manager_id=1,
+        identifier="0000789019",
+        external_id="acc-same",
+        filed_date="2024-08-01",
+        parsed_rows=rows,
+        jurisdiction="us",
+    )
+    assert first == 1
+    assert second == 0
+    versions = conn.execute("SELECT COUNT(*), MAX(version) FROM holdings WHERE filing_id = 20").fetchone()
+    assert int(versions[0]) == 1
+    assert int(versions[1]) == 1
+
+
+def test_current_holdings_helper_hides_superseded(tmp_path):
+    conn = _connect(tmp_path)
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source, raw_key) "
+        "VALUES (30, 1, '13F-HR', '2024-09-30', '2024-11-01', 'us', 'acc-cur')"
+    )
+    rows_v1 = [
+        {"cusip": "023135106", "nameOfIssuer": "AMAZON", "sshPrnamt": 1, "value": 10},
+    ]
+    rows_v2 = [
+        {"cusip": "023135106", "nameOfIssuer": "AMAZON", "sshPrnamt": 9, "value": 90},
+    ]
+    ingest_flow._replace_holdings_rows(
+        conn,
+        filing_id=30,
+        manager_id=1,
+        identifier="0001018724",
+        external_id="acc-cur",
+        filed_date="2024-11-01",
+        parsed_rows=rows_v1,
+        jurisdiction="us",
+    )
+    ingest_flow._replace_holdings_rows(
+        conn,
+        filing_id=30,
+        manager_id=1,
+        identifier="0001018724",
+        external_id="acc-cur",
+        filed_date="2024-11-01",
+        parsed_rows=rows_v2,
+        jurisdiction="us",
+    )
+    current = point_in_time.current_holdings(conn, filing_id=30)
+    assert len(current) == 1
+    assert int(current[0]["shares"]) == 9
+    total = conn.execute("SELECT COUNT(*) FROM holdings WHERE filing_id = 30").fetchone()[0]
+    assert int(total) == 2
+
+
+def test_deliberate_break_mutate_breaks_as_of(tmp_path):
+    """Reverting append-only to mutate makes the as-of/no-look-ahead test fail."""
+    conn = _connect(tmp_path)
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source, raw_key) "
+        "VALUES (40, 1, '13F-HR', '2024-12-31', '2025-02-01', 'us', 'acc-break')"
+    )
+    v1 = [{"cusip": "A", "nameOfIssuer": "A", "sshPrnamt": 1, "value": 1}]
+    v2 = [{"cusip": "A", "nameOfIssuer": "A", "sshPrnamt": 2, "value": 2}]
+    ingest_flow._replace_holdings_rows(
+        conn,
+        filing_id=40,
+        manager_id=1,
+        identifier="1",
+        external_id="acc-break",
+        filed_date="2025-02-01",
+        parsed_rows=v1,
+        jurisdiction="us",
+    )
+    conn.execute(
+        "UPDATE holdings SET knowledge_time = ? WHERE filing_id = 40",
+        ("2025-02-01T00:00:00Z",),
+    )
+
+    # Deliberate break: mutate/delete instead of append
+    ingest_flow._delete_holdings_rows(conn, filing_id=40)
+    ingest_flow._insert_holdings_rows(
+        conn,
+        filing_id=40,
+        manager_id=1,
+        identifier="1",
+        external_id="acc-break",
+        filed_date="2025-02-01",
+        parsed_rows=v2,
+        jurisdiction="us",
+        knowledge_time="2025-03-01T00:00:00Z",
+        version=2,
+    )
+    conn.commit()
+
+    before = point_in_time.holdings_as_of(conn, 1, datetime(2025, 2, 15, tzinfo=UTC))
+    # Under mutate semantics the historical v1 row is gone, so as-of cannot reconstruct it.
+    assert before == [] or all(int(row["shares"]) != 1 for row in before)


### PR DESCRIPTION
Closes #1463

## Summary
- Add append-only holdings versions (`knowledge_time`, `superseded_at`, `version`, `content_hash`) with Alembic `012` + `schema.sql` + `v_current_holdings`
- Change ingest/edgar write paths to supersede prior rows instead of delete/mutate; identical re-ingest is a content-hash no-op
- Add `etl/point_in_time.py` (`holdings_as_of`, `current_holdings`) for point-in-time reconstruction

## Validation
- `PYTHONPATH=. python3 -m pytest tests/test_bitemporal_holdings.py -q`
- `PYTHONPATH=. python3 -m pytest tests/test_ingest_flow.py::test_replace_holdings_rows_uses_postgres_transaction -q`

## Notes
Foundation for backtest (#1464) and attribution (#1465). Large core-table migration — recommend owner review before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bitemporal holdings support with versioning and supersession metadata, including a “current holdings” view for non-superseded records.
  * Introduced point-in-time helpers to query holdings as-of a cutoff, including schema-aware handling.
  * Improved holdings re-ingestion to be idempotent when content hasn’t changed, avoiding unnecessary version churn.
* **Bug Fixes**
  * Prevented unintended holdings churn by skipping updates when re-ingested holdings match the current stored content.
* **Tests**
  * Added acceptance tests covering as-of reconstruction, current holdings filtering, and idempotent re-ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->