### PR TITLE
fix: remove #1461 bootstrap leftover after verifier CONCERNS

### DIFF
--- a/agents/codex-1461.md
+++ b/agents/codex-1461.md
@@ -1,1 +1,0 @@
-<!-- bootstrap for codex on issue #1461 -->


### PR DESCRIPTION
## Summary
- Removes out-of-scope `agents/codex-1461.md` left from the #1462 Form-4 merge.
- Addresses Agents Verifier run 30127787263 FAIL/CONCERNS claim: "scope contains an out-of-scope bootstrap file".
- CI-incomplete claim was timing-only at verify time; Form-4 implementation/tests remain on main.

Follow-up for #1461 / merged #1462.

## Test plan
- [ ] Confirm `agents/codex-1461.md` absent on PR head
- [ ] Gate / required checks green
- [ ] Re-run or accept verify:compare disposition on #1462 after merge