### PR TITLE
test(llm): pin hermetic blocked-model registry; resync dependency helper

### DIFF
--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -131,11 +131,7 @@ if [ "$all_ok" = true ]; then
     echo -e "${GREEN}All required dependencies are available!${NC}"
     echo ""
     echo "You can run the full test suite with:"
-    if [ -x ./scripts/run_tests.sh ]; then
-        echo "  ./scripts/run_tests.sh"
-    else
-        echo "  python -m pytest"
-    fi
+    echo "  python -m pytest"
     exit 0
 else
     echo -e "${RED}Some required dependencies are missing!${NC}"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -4,6 +4,41 @@ import json
 
 from llm import client as llm_client
 
+# Tests that exercise the blocked-model guard must pin their own model registry.
+# The guard filters a model only when the registry marks it ``blocked``; it does
+# not maintain a hardcoded denylist of legacy model ids. Relying on the ambient
+# config/model_registry.json is fragile — a catalog refresh that drops a legacy
+# id (as the 2026-07-24 refresh dropped gpt-4o-mini) silently turns a "blocked"
+# fixture into an "unknown, therefore allowed" one. Pin a hermetic registry so
+# the guard is tested against a model that is unambiguously blocked.
+ENV_MODEL_REGISTRY_CONFIG = "LANGCHAIN_MODEL_REGISTRY_CONFIG"
+
+
+def _write_blocked_model_registry(tmp_path) -> str:
+    registry_path = tmp_path / "model_registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "model_id": "gpt-4o-mini",
+                        "provider": "openai",
+                        "lifecycle": "deprecated",
+                        "blocked": True,
+                    },
+                    {
+                        "model_id": "gpt-5.4",
+                        "provider": "openai",
+                        "lifecycle": "current",
+                    },
+                ],
+                "selections": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(registry_path)
+
 
 class _FakeClient:
     pass
@@ -97,6 +132,7 @@ def test_blocked_slot_model_is_not_selected(monkeypatch, tmp_path):
         )
     )
     monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
+    monkeypatch.setenv(ENV_MODEL_REGISTRY_CONFIG, _write_blocked_model_registry(tmp_path))
     monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
     monkeypatch.delenv("MANAGER_DB_ANTHROPIC_API_KEY", raising=False)
     captured = []
@@ -130,6 +166,7 @@ def test_blocked_slot_env_model_falls_back_to_slot_model(monkeypatch, tmp_path):
     )
     monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
     monkeypatch.setenv("LANGCHAIN_SLOT1_MODEL", "gpt-4o-mini")
+    monkeypatch.setenv(ENV_MODEL_REGISTRY_CONFIG, _write_blocked_model_registry(tmp_path))
     monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
     monkeypatch.delenv("MANAGER_DB_ANTHROPIC_API_KEY", raising=False)
     captured = []


### PR DESCRIPTION
## What
Fixes the two red test files without changing any guard logic.

- **`tests/test_llm_client.py`** — `test_blocked_slot_model_is_not_selected` and `test_blocked_slot_env_model_falls_back_to_slot_model` relied on the *ambient* `config/model_registry.json` marking `gpt-4o-mini` blocked. The 2026-07-24 catalog refresh dropped `gpt-4o-mini` entirely, so it became "unknown → allowed" under the intentional blocklist semantics and reached `create_llm`. Both tests now pin a **hermetic** registry that marks `gpt-4o-mini` blocked and `gpt-5.4` current.
- **`scripts/check_test_dependencies.sh`** — resync of the Workflows source fix (drop dead `run_tests.sh` path) so `tests/test_validate_dependency_test_setup.py` passes.

## Why this is stale, not a regression
The blocked-model guard is unchanged and verified correct: given a registry that marks `gpt-4o-mini` blocked, resolution logs `Skipping blocked LLM model in slot config: openai/gpt-4o-mini` and only `gpt-5.4` reaches `create_llm`. MgrDB's blocklist semantics (unknown model → allowed) are intentional — see the passing `test_slot_config_loading_from_json_file`, which expects an unknown `claude-test` to pass through.

## Verify
`tests/test_llm_client.py` → 10 passed · `tests/test_validate_dependency_test_setup.py` → 5 passed (locally, off-Dropbox clone).

Pairs with stranske/Workflows#(helper source fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)