### PR TITLE
fix: enforce current registry models for chat

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -504,19 +504,16 @@ def _build_chat_client_info():
     try:
         llm_client_module = importlib.import_module("llm.client")
     except ModuleNotFoundError as exc:
-        # Fall back only when the llm client module is not installed.
+        # The chat path must not bypass the local registry-enforcing client.
         if exc.name not in {"llm", "llm.client"}:
             raise
+        return None
 
     if llm_client_module is not None:
         build_fn = getattr(llm_client_module, "build_chat_client", None)
         if callable(build_fn):
             return build_fn()
-        return None
-
-    from tools.langchain_client import build_chat_client
-
-    return build_chat_client()
+    return None
 
 
 # Closed-zone notice surfaced when the LLM boundary is disabled for this deployment.

--- a/llm/client.py
+++ b/llm/client.py
@@ -71,10 +71,27 @@ def _normalize_provider(value: str | None) -> str | None:
 
 
 def _default_slots() -> list[SlotDefinition]:
+    """Build defaults from the reviewed registry selections."""
     return [
-        SlotDefinition(name="slot1", provider="openai", model="gpt-5.4"),
-        SlotDefinition(name="slot2", provider="anthropic", model="claude-sonnet-4-6"),
+        SlotDefinition(name=slot.name, provider=slot.provider, model=slot.model)
+        for slot in _llm_registry.default_slots()
+        if slot.model
     ]
+
+
+def _is_model_eligible(
+    provider: str,
+    model: str,
+    *,
+    registry: list[_llm_registry.ModelRegistryEntry] | None = None,
+) -> bool:
+    """Allow only current, unblocked registry models on the chat path."""
+    entry = _llm_registry.registry_entry_for(provider, model, registry=registry)
+    return bool(
+        entry
+        and entry.lifecycle == "current"
+        and not is_model_blocked(provider, model, registry=registry)
+    )
 
 
 def _slot_config_path() -> Path:
@@ -85,23 +102,35 @@ def _slot_config_path() -> Path:
 
 
 def _load_slot_config() -> list[SlotDefinition]:
+    if ENV_SLOT_CONFIG not in os.environ:
+        # The bundled config is advisory.  Let the shared resolver replace
+        # stale pins with its reviewed current selections before this local
+        # client applies its final eligibility checks.
+        return [
+            SlotDefinition(name=slot.name, provider=slot.provider, model=slot.model)
+            for slot in _llm_registry.load_slot_config()
+            if slot.model
+        ]
+
     path = _slot_config_path()
     if not path.is_file():
-        return _default_slots()
+        logger.warning("Configured LLM slot config %s is unavailable; refusing fallback", path)
+        return []
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return _default_slots()
+        logger.warning("Configured LLM slot config %s is invalid; refusing fallback", path)
+        return []
 
     registry = load_model_registry()
     if not isinstance(payload, dict):
         logger.warning("Invalid LLM slot config %s; expected object", path)
-        return _default_slots()
+        return []
 
     raw_slots = payload.get("slots", [])
     if not isinstance(raw_slots, list):
         logger.warning("Invalid LLM slot config %s; expected slots list", path)
-        return _default_slots()
+        return []
 
     slots: list[SlotDefinition] = []
     for index, entry in enumerate(raw_slots, start=1):
@@ -115,12 +144,14 @@ def _load_slot_config() -> list[SlotDefinition]:
             model = select_model_for_tier(provider=provider, tier=tier, registry=registry) or ""
         if not provider or not model:
             continue
-        if is_model_blocked(provider, model, registry=registry):
-            logger.warning("Skipping blocked LLM model in slot config: %s/%s", provider, model)
+        if not _is_model_eligible(provider, model, registry=registry):
+            logger.warning("Skipping registry-ineligible LLM model in slot config: %s/%s", provider, model)
             continue
         name = str(entry.get("name") or f"slot{index}").strip() or f"slot{index}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
-    return slots or _default_slots()
+    # A configured slot file is an execution allowlist.  Never broaden it to
+    # defaults when every configured entry is malformed or registry-ineligible.
+    return slots
 
 
 def _apply_slot_env_overrides(slots: list[SlotDefinition]) -> list[SlotDefinition]:
@@ -139,12 +170,10 @@ def _apply_slot_env_overrides(slots: list[SlotDefinition]) -> list[SlotDefinitio
                 model = candidate_model
             else:
                 logger.warning("Ignoring blank LLM slot model override for %s", slot.name)
-        if is_model_blocked(provider, model, registry=registry):
-            logger.warning("Skipping blocked LLM slot override: %s/%s", provider, model)
+        if not _is_model_eligible(provider, model, registry=registry):
+            logger.warning("Skipping registry-ineligible LLM slot override: %s/%s", provider, model)
             override_requested = provider_override is not None or model_override is not None
-            if override_requested and not is_model_blocked(
-                slot.provider, slot.model, registry=registry
-            ):
+            if override_requested and _is_model_eligible(slot.provider, slot.model, registry=registry):
                 updated.append(slot)
             continue
         updated.append(
@@ -242,9 +271,12 @@ def build_chat_client(
     if selected_provider is not None:
         selected_model = (model or os.environ.get(ENV_MODEL) or "").strip()
         if not selected_model:
-            selected_model = _default_slots()[0].model
-        if is_model_blocked(selected_provider, selected_model):
-            logger.warning("Refusing blocked LLM model: %s/%s", selected_provider, selected_model)
+            defaults = _default_slots()
+            selected_model = defaults[0].model if defaults else ""
+        if not selected_model or not _is_model_eligible(
+            selected_provider, selected_model
+        ):
+            logger.warning("Refusing registry-ineligible LLM model: %s/%s", selected_provider, selected_model)
             return None
         return _build_for(selected_provider, selected_model, selected_timeout, selected_retries)
 
@@ -254,13 +286,13 @@ def build_chat_client(
         slot_model = slot.model
         if index == 1 and (model or os.environ.get(ENV_MODEL)):
             slot_model = (model or os.environ.get(ENV_MODEL) or slot.model).strip()
-            if is_model_blocked(slot.provider, slot_model, registry=registry):
+            if not _is_model_eligible(slot.provider, slot_model, registry=registry):
                 logger.warning(
-                    "Skipping blocked LLM model override: %s/%s", slot.provider, slot_model
+                    "Skipping registry-ineligible LLM model override: %s/%s", slot.provider, slot_model
                 )
                 slot_model = slot.model
-        if is_model_blocked(slot.provider, slot_model, registry=registry):
-            logger.warning("Skipping blocked LLM model: %s/%s", slot.provider, slot_model)
+        if not _is_model_eligible(slot.provider, slot_model, registry=registry):
+            logger.warning("Skipping registry-ineligible LLM model: %s/%s", slot.provider, slot_model)
             continue
         client_info = _build_for(slot.provider, slot_model, selected_timeout, selected_retries)
         if client_info is not None:

--- a/llm/client.py
+++ b/llm/client.py
@@ -145,7 +145,9 @@ def _load_slot_config() -> list[SlotDefinition]:
         if not provider or not model:
             continue
         if not _is_model_eligible(provider, model, registry=registry):
-            logger.warning("Skipping registry-ineligible LLM model in slot config: %s/%s", provider, model)
+            logger.warning(
+                "Skipping registry-ineligible LLM model in slot config: %s/%s", provider, model
+            )
             continue
         name = str(entry.get("name") or f"slot{index}").strip() or f"slot{index}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
@@ -173,7 +175,9 @@ def _apply_slot_env_overrides(slots: list[SlotDefinition]) -> list[SlotDefinitio
         if not _is_model_eligible(provider, model, registry=registry):
             logger.warning("Skipping registry-ineligible LLM slot override: %s/%s", provider, model)
             override_requested = provider_override is not None or model_override is not None
-            if override_requested and _is_model_eligible(slot.provider, slot.model, registry=registry):
+            if override_requested and _is_model_eligible(
+                slot.provider, slot.model, registry=registry
+            ):
                 updated.append(slot)
             continue
         updated.append(
@@ -273,10 +277,10 @@ def build_chat_client(
         if not selected_model:
             defaults = _default_slots()
             selected_model = defaults[0].model if defaults else ""
-        if not selected_model or not _is_model_eligible(
-            selected_provider, selected_model
-        ):
-            logger.warning("Refusing registry-ineligible LLM model: %s/%s", selected_provider, selected_model)
+        if not selected_model or not _is_model_eligible(selected_provider, selected_model):
+            logger.warning(
+                "Refusing registry-ineligible LLM model: %s/%s", selected_provider, selected_model
+            )
             return None
         return _build_for(selected_provider, selected_model, selected_timeout, selected_retries)
 
@@ -288,11 +292,15 @@ def build_chat_client(
             slot_model = (model or os.environ.get(ENV_MODEL) or slot.model).strip()
             if not _is_model_eligible(slot.provider, slot_model, registry=registry):
                 logger.warning(
-                    "Skipping registry-ineligible LLM model override: %s/%s", slot.provider, slot_model
+                    "Skipping registry-ineligible LLM model override: %s/%s",
+                    slot.provider,
+                    slot_model,
                 )
                 slot_model = slot.model
         if not _is_model_eligible(slot.provider, slot_model, registry=registry):
-            logger.warning("Skipping registry-ineligible LLM model: %s/%s", slot.provider, slot_model)
+            logger.warning(
+                "Skipping registry-ineligible LLM model: %s/%s", slot.provider, slot_model
+            )
             continue
         client_info = _build_for(slot.provider, slot_model, selected_timeout, selected_retries)
         if client_info is not None:

--- a/llm/client.py
+++ b/llm/client.py
@@ -274,10 +274,15 @@ def build_chat_client(
 
     if selected_provider is not None:
         selected_model = (model or os.environ.get(ENV_MODEL) or "").strip()
+        registry = load_model_registry()
         if not selected_model:
-            defaults = _default_slots()
-            selected_model = defaults[0].model if defaults else ""
-        if not selected_model or not _is_model_eligible(selected_provider, selected_model):
+            selected_model = next(
+                (slot.model for slot in _default_slots() if slot.provider == selected_provider),
+                "",
+            )
+        if not selected_model or not _is_model_eligible(
+            selected_provider, selected_model, registry=registry
+        ):
             logger.warning(
                 "Refusing registry-ineligible LLM model: %s/%s", selected_provider, selected_model
             )

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -36,20 +36,15 @@ def test_build_chat_client_info_prefers_llm_client_module(monkeypatch):
     assert chat_api_module._build_chat_client_info() is marker
 
 
-def test_build_chat_client_info_falls_back_when_llm_client_module_missing(monkeypatch):
-    marker = object()
-
+def test_build_chat_client_info_fails_closed_when_llm_client_module_missing(monkeypatch):
     def _missing_llm_client(_name: str):
         exc = ModuleNotFoundError("No module named 'llm.client'")
         exc.name = "llm.client"
         raise exc
 
-    import tools.langchain_client as langchain_client
-
     monkeypatch.setattr(chat_api_module.importlib, "import_module", _missing_llm_client)
-    monkeypatch.setattr(langchain_client, "build_chat_client", lambda: marker)
 
-    assert chat_api_module._build_chat_client_info() is marker
+    assert chat_api_module._build_chat_client_info() is None
 
 
 def test_build_chat_client_info_surfaces_llm_client_builder_errors(monkeypatch):

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -40,6 +40,31 @@ def _write_blocked_model_registry(tmp_path) -> str:
     return str(registry_path)
 
 
+def _write_lifecycle_registry(tmp_path) -> str:
+    registry_path = tmp_path / "model_registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "model_id": "gpt-5.5",
+                        "provider": "openai",
+                        "lifecycle": "compatibility",
+                    },
+                    {
+                        "model_id": "gpt-5.4",
+                        "provider": "openai",
+                        "lifecycle": "current",
+                    },
+                ],
+                "selections": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(registry_path)
+
+
 class _FakeClient:
     pass
 
@@ -65,7 +90,7 @@ def test_build_chat_client_falls_back_to_anthropic(monkeypatch):
 
     assert client_info is not None
     assert client_info.provider == "anthropic"
-    assert client_info.model == "claude-sonnet-4-6"
+    assert client_info.model == "claude-opus-4-6"
 
 
 def test_build_chat_client_returns_none_when_no_keys(monkeypatch):
@@ -78,7 +103,7 @@ def test_build_chat_client_returns_none_when_no_keys(monkeypatch):
 def test_build_chat_client_honors_env_overrides(monkeypatch):
     monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
     monkeypatch.setenv("LANGCHAIN_PROVIDER", "openai")
-    monkeypatch.setenv("LANGCHAIN_MODEL", "o3-mini")
+    monkeypatch.setenv("LANGCHAIN_MODEL", "gpt-5.6-sol")
     captured = {}
 
     def _fake_create_llm(config):
@@ -90,33 +115,36 @@ def test_build_chat_client_honors_env_overrides(monkeypatch):
     client_info = llm_client.build_chat_client()
 
     assert client_info is not None
-    assert client_info.model == "o3-mini"
+    assert client_info.model == "gpt-5.6-sol"
     assert captured["config"].client_kwargs["max_retries"] == llm_client.DEFAULT_MAX_RETRIES
-    assert "temperature" not in captured["config"].client_kwargs
+    assert captured["config"].client_kwargs["temperature"] == 0.1
 
 
-def test_slot_config_loading_from_json_file(monkeypatch, tmp_path):
+def test_non_current_lifecycle_model_is_not_served(monkeypatch, tmp_path):
     config_path = tmp_path / "llm_slots.json"
     config_path.write_text(
         json.dumps(
             {
                 "slots": [
-                    {"name": "slot1", "provider": "anthropic", "model": "claude-test"},
-                    {"name": "slot2", "provider": "openai", "model": "gpt-test"},
+                    {"name": "slot1", "provider": "openai", "model": "gpt-5.5"},
                 ]
             }
         )
     )
     monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
-    monkeypatch.setenv("MANAGER_DB_ANTHROPIC_API_KEY", "anthropic-key")
-    monkeypatch.delenv("MANAGER_DB_OPENAI_API_KEY", raising=False)
-    monkeypatch.setattr(llm_client, "create_llm", lambda config: _FakeClient())
+    monkeypatch.setenv(ENV_MODEL_REGISTRY_CONFIG, _write_lifecycle_registry(tmp_path))
+    monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
+
+    def _fake_create_llm(config):
+        if config.model_name == "gpt-5.5":
+            raise AssertionError("non-current model reached create_llm")
+        return _FakeClient()
+
+    monkeypatch.setattr(llm_client, "create_llm", _fake_create_llm)
 
     client_info = llm_client.build_chat_client()
 
-    assert client_info is not None
-    assert client_info.provider == "anthropic"
-    assert client_info.model == "claude-test"
+    assert client_info is None
 
 
 def test_blocked_slot_model_is_not_selected(monkeypatch, tmp_path):
@@ -187,7 +215,7 @@ def test_blocked_slot_env_model_falls_back_to_slot_model(monkeypatch, tmp_path):
     assert captured == ["gpt-5.4"]
 
 
-def test_invalid_slot_config_slots_shape_falls_back_to_defaults(monkeypatch, tmp_path):
+def test_invalid_slot_config_slots_shape_fails_closed(monkeypatch, tmp_path):
     config_path = tmp_path / "llm_slots.json"
     config_path.write_text(json.dumps({"slots": {"name": "slot1"}}))
     monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
@@ -197,12 +225,10 @@ def test_invalid_slot_config_slots_shape_falls_back_to_defaults(monkeypatch, tmp
 
     client_info = llm_client.build_chat_client()
 
-    assert client_info is not None
-    assert client_info.provider == "openai"
-    assert client_info.model == "gpt-5.4"
+    assert client_info is None
 
 
-def test_invalid_slot_config_entry_falls_back_to_defaults(monkeypatch, tmp_path):
+def test_invalid_slot_config_entry_fails_closed(monkeypatch, tmp_path):
     config_path = tmp_path / "llm_slots.json"
     config_path.write_text(json.dumps({"slots": [None]}))
     monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
@@ -212,9 +238,7 @@ def test_invalid_slot_config_entry_falls_back_to_defaults(monkeypatch, tmp_path)
 
     client_info = llm_client.build_chat_client()
 
-    assert client_info is not None
-    assert client_info.provider == "openai"
-    assert client_info.model == "gpt-5.4"
+    assert client_info is None
 
 
 def test_blank_slot_env_model_falls_back_to_slot_model(monkeypatch, tmp_path):

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -120,6 +120,36 @@ def test_build_chat_client_honors_env_overrides(monkeypatch):
     assert captured["config"].client_kwargs["temperature"] == 0.1
 
 
+def test_explicit_provider_uses_its_matching_default_model(monkeypatch):
+    registry = object()
+    monkeypatch.setattr(
+        llm_client,
+        "_default_slots",
+        lambda: [
+            llm_client.SlotDefinition("openai", "openai", "gpt-5.4"),
+            llm_client.SlotDefinition("anthropic", "anthropic", "claude-opus-4-6"),
+        ],
+    )
+    monkeypatch.setattr(llm_client, "load_model_registry", lambda: registry)
+    monkeypatch.setenv("MANAGER_DB_ANTHROPIC_API_KEY", "anthropic-key")
+    monkeypatch.delenv("MANAGER_DB_OPENAI_API_KEY", raising=False)
+    captured = {}
+
+    def _eligible(provider, model, *, registry=None):
+        captured["registry"] = registry
+        return provider == "anthropic" and model == "claude-opus-4-6"
+
+    monkeypatch.setattr(llm_client, "_is_model_eligible", _eligible)
+    monkeypatch.setattr(llm_client, "create_llm", lambda config: _FakeClient())
+
+    client_info = llm_client.build_chat_client(provider="anthropic")
+
+    assert client_info is not None
+    assert client_info.provider == "anthropic"
+    assert client_info.model == "claude-opus-4-6"
+    assert captured["registry"] is registry
+
+
 def test_non_current_lifecycle_model_is_not_served(monkeypatch, tmp_path):
     config_path = tmp_path / "llm_slots.json"
     config_path.write_text(


### PR DESCRIPTION
Closes #1489

## Summary
- enforce current, unblocked registry eligibility for every local chat-client configuration path
- derive defaults from reviewed registry selections and fail closed for invalid explicit slot configs
- remove the unreachable alternate chat-client fallback

## Validation
- python3.12 -m pytest -o addopts="" tests/test_llm_client.py tests/test_chat_api.py
- python3.12 -m ruff check llm/client.py api/chat.py tests/test_llm_client.py tests/test_chat_api.py
- deliberate lifecycle-gate break made gpt-5.5 reach create_llm; restored gate passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat providers are now selected only from currently eligible models registered as “current.”
  * Requests now fail clearly with no provider/model configured, rather than falling back to an unavailable provider.
  * Invalid, unreadable, or malformed slot configurations no longer silently fall back to default models.
  * Models that are registry-ineligible (including non-current lifecycle entries) are skipped and won’t be served.
  * Environment-based model overrides now respect the same eligibility rules.

* **Tests**
  * Updated coverage to reflect the new fail-closed behaviors and revised model expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->