### PR TITLE
feat(backtest): signal-alpha harness over point-in-time holdings (#1464)

### DIFF
--- a/adapters/prices.py
+++ b/adapters/prices.py
@@ -1,0 +1,280 @@
+"""Free-source daily close price adapter with a local cache (#1464 / design #1401).
+
+Prices come from a free provider (Stooq by default, yfinance when installed) and are
+cached in ``price_cache`` keyed by ``resolved_ticker`` (OpenFIGI, #1374).
+
+INTERNAL USE ONLY: the owner decision on #1464 permits a free price source for
+internal metrics. Do not redistribute these prices or expose them through the
+public API - only derived backtest statistics may be surfaced.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import sqlite3
+from collections.abc import Callable, Iterable, Mapping
+from datetime import date, timedelta
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from adapters.base import get_placeholder
+from utils.numeric import finite_float_or_none
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SOURCE = "stooq"
+DEFAULT_MAX_STALENESS_DAYS = 7
+_STOOQ_URL = "https://stooq.com/q/d/l/?s={symbol}&d1={start}&d2={end}&i=d"
+_HTTP_TIMEOUT_SECONDS = 15
+
+# A fetcher maps a ticker + inclusive date window to {date: close}. Any provider
+# that satisfies this shape can be injected, which is what keeps tests offline.
+PriceFetcher = Callable[[str, date, date], Mapping[date, float]]
+
+
+def _is_missing_postgres_table_error(exc: Exception) -> bool:
+    message = str(exc)
+    return (
+        "does not exist" in message
+        or getattr(exc, "pgcode", None) == "42P01"
+        or "UndefinedTable" in exc.__class__.__name__
+    )
+
+
+def ensure_price_cache_table(conn: Any) -> None:
+    """Create ``price_cache`` on SQLite; fail fast when Postgres has no schema."""
+    if isinstance(conn, sqlite3.Connection):
+        conn.execute("""CREATE TABLE IF NOT EXISTS price_cache (
+                ticker TEXT NOT NULL,
+                price_date DATE NOT NULL,
+                source TEXT NOT NULL DEFAULT 'stooq',
+                close_usd REAL,
+                fetched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (ticker, price_date, source)
+            )""")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_price_cache_ticker_date "
+            "ON price_cache(ticker, price_date)"
+        )
+        return
+
+    try:
+        conn.execute("SELECT 1 FROM price_cache LIMIT 1")
+    except Exception as exc:
+        if _is_missing_postgres_table_error(exc):
+            raise RuntimeError(
+                "price_cache table is missing on Postgres; apply schema migrations first"
+            ) from exc
+        raise
+
+
+def _coerce_date(value: Any) -> date | None:
+    if isinstance(value, date):
+        return value
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def fetch_stooq_prices(ticker: str, start: date, end: date) -> Mapping[date, float]:
+    """Fetch daily closes from Stooq's free CSV endpoint.
+
+    Network failures are not fatal: they degrade to an empty result so a backtest
+    reports a skipped position rather than crashing (#1299 finite/graceful rule).
+    """
+    symbol = ticker.strip().lower()
+    if not symbol:
+        return {}
+    # Stooq expects US tickers suffixed with `.us`.
+    if "." not in symbol:
+        symbol = f"{symbol}.us"
+    url = _STOOQ_URL.format(
+        symbol=symbol,
+        start=start.strftime("%Y%m%d"),
+        end=end.strftime("%Y%m%d"),
+    )
+    try:
+        request = Request(url, headers={"User-Agent": "manager-database/price-adapter"})
+        with urlopen(request, timeout=_HTTP_TIMEOUT_SECONDS) as response:  # noqa: S310
+            payload = response.read().decode("utf-8", errors="replace")
+    except (URLError, TimeoutError, OSError):
+        logger.warning("Stooq price fetch failed", extra={"ticker": ticker}, exc_info=True)
+        return {}
+
+    prices: dict[date, float] = {}
+    for row in csv.DictReader(payload.splitlines()):
+        row_date = _coerce_date(row.get("Date"))
+        close = finite_float_or_none(row.get("Close"), min_value=0.0)
+        if row_date is not None and close is not None:
+            prices[row_date] = close
+    return prices
+
+
+def fetch_yfinance_prices(ticker: str, start: date, end: date) -> Mapping[date, float]:
+    """Fetch daily closes via yfinance when the optional dependency is installed."""
+    try:
+        import yfinance  # type: ignore[import-not-found]
+    except ImportError:
+        logger.debug("yfinance is not installed; no prices fetched", extra={"ticker": ticker})
+        return {}
+
+    try:
+        frame = yfinance.Ticker(ticker).history(
+            start=start.isoformat(),
+            end=(end + timedelta(days=1)).isoformat(),
+            auto_adjust=True,
+        )
+    except Exception:
+        logger.warning("yfinance price fetch failed", extra={"ticker": ticker}, exc_info=True)
+        return {}
+
+    prices: dict[date, float] = {}
+    for index, close in getattr(frame, "Close", {}).items():
+        # pandas gives a Timestamp; plain dates come through unchanged.
+        to_date = getattr(index, "date", None)
+        row_date = _coerce_date(to_date() if callable(to_date) else index)
+        parsed = finite_float_or_none(close, min_value=0.0)
+        if row_date is not None and parsed is not None:
+            prices[row_date] = parsed
+    return prices
+
+
+_FETCHERS: dict[str, PriceFetcher] = {
+    "stooq": fetch_stooq_prices,
+    "yfinance": fetch_yfinance_prices,
+}
+
+
+class PriceAdapter:
+    """Cached daily-close lookups keyed by ``resolved_ticker``.
+
+    ``close_on_or_before`` implements as-of pricing: markets are shut on weekends
+    and holidays, so a decision date frequently has no print of its own. Returning
+    the most recent close within ``max_staleness_days`` keeps a backtest running
+    without silently inventing a price.
+    """
+
+    def __init__(
+        self,
+        conn: Any,
+        *,
+        source: str = DEFAULT_SOURCE,
+        fetcher: PriceFetcher | None = None,
+        max_staleness_days: int = DEFAULT_MAX_STALENESS_DAYS,
+        use_cache: bool = True,
+    ) -> None:
+        self.conn = conn
+        self.source = source
+        self.max_staleness_days = max(0, int(max_staleness_days))
+        self.use_cache = use_cache
+        self._fetcher = fetcher if fetcher is not None else _FETCHERS.get(source)
+        self._missing: set[tuple[str, date]] = set()
+        if self.use_cache:
+            ensure_price_cache_table(conn)
+
+    def _cached_window(self, ticker: str, start: date, end: date) -> dict[date, float]:
+        if not self.use_cache:
+            return {}
+        ph = get_placeholder(self.conn)
+        rows = self.conn.execute(
+            "SELECT price_date, close_usd FROM price_cache "
+            f"WHERE ticker = {ph} AND source = {ph} "
+            f"AND price_date >= {ph} AND price_date <= {ph}",
+            (ticker, self.source, start.isoformat(), end.isoformat()),
+        ).fetchall()
+        window: dict[date, float] = {}
+        for row in rows:
+            row_date = _coerce_date(row[0])
+            close = finite_float_or_none(row[1], min_value=0.0)
+            if row_date is not None and close is not None:
+                window[row_date] = close
+        return window
+
+    def _store(self, ticker: str, prices: Mapping[date, float]) -> None:
+        if not self.use_cache or not prices:
+            return
+        ph = get_placeholder(self.conn)
+        conflict = (
+            "ON CONFLICT(ticker, price_date, source) DO UPDATE SET close_usd = excluded.close_usd"
+        )
+        for price_date, close in prices.items():
+            self.conn.execute(
+                "INSERT INTO price_cache(ticker, price_date, source, close_usd) "
+                f"VALUES ({ph}, {ph}, {ph}, {ph}) {conflict}",
+                (ticker, price_date.isoformat(), self.source, float(close)),
+            )
+
+    def close_on_or_before(self, ticker: str | None, on: date) -> float | None:
+        """Return the latest cached/fetched close at or before ``on``.
+
+        Returns ``None`` - never raises - when the ticker is unknown, the provider
+        has no print in the window, or the value is non-finite.
+        """
+        if not ticker:
+            return None
+        symbol = str(ticker).strip().upper()
+        if not symbol:
+            return None
+
+        start = on - timedelta(days=self.max_staleness_days)
+        window = self._cached_window(symbol, start, on)
+        if not window and (symbol, on) not in self._missing:
+            fetched = self._fetch(symbol, start, on)
+            if fetched:
+                self._store(symbol, fetched)
+                window = {d: p for d, p in fetched.items() if start <= d <= on}
+
+        if not window:
+            self._missing.add((symbol, on))
+            logger.warning(
+                "No price available; position will be skipped",
+                extra={"ticker": symbol, "as_of": on.isoformat(), "source": self.source},
+            )
+            return None
+        return window[max(window)]
+
+    def _fetch(self, ticker: str, start: date, end: date) -> Mapping[date, float]:
+        if self._fetcher is None:
+            logger.warning("No price fetcher configured", extra={"source": self.source})
+            return {}
+        try:
+            raw = self._fetcher(ticker, start, end)
+        except Exception:
+            logger.warning("Price fetch raised", extra={"ticker": ticker}, exc_info=True)
+            return {}
+        # Sanitize at the provider boundary so a NaN/inf quote can never reach the
+        # cache or a return calculation, whichever provider produced it (#1299).
+        clean: dict[date, float] = {}
+        for raw_date, raw_close in raw.items():
+            price_date = _coerce_date(raw_date)
+            close = finite_float_or_none(raw_close, min_value=0.0)
+            if price_date is None or close is None:
+                logger.warning(
+                    "Discarding unusable quote",
+                    extra={"ticker": ticker, "price_date": str(raw_date)},
+                )
+                continue
+            clean[price_date] = close
+        return clean
+
+    def warm_cache(self, tickers: Iterable[str], start: date, end: date) -> int:
+        """Pre-fetch a window for several tickers; returns the number of closes stored."""
+        stored = 0
+        for ticker in tickers:
+            if not ticker:
+                continue
+            symbol = str(ticker).strip().upper()
+            prices = self._fetch(symbol, start, end)
+            self._store(symbol, prices)
+            stored += len(prices)
+        return stored
+
+
+def build_price_adapter(conn: Any, *, source: str = DEFAULT_SOURCE, **kwargs: Any) -> PriceAdapter:
+    """Convenience constructor so flows do not import provider details."""
+    return PriceAdapter(conn, source=source, **kwargs)

--- a/adapters/prices.py
+++ b/adapters/prices.py
@@ -17,6 +17,7 @@ from collections.abc import Callable, Iterable, Mapping
 from datetime import date, timedelta
 from typing import Any
 from urllib.error import URLError
+from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 from adapters.base import get_placeholder
@@ -94,7 +95,7 @@ def fetch_stooq_prices(ticker: str, start: date, end: date) -> Mapping[date, flo
     if "." not in symbol:
         symbol = f"{symbol}.us"
     url = _STOOQ_URL.format(
-        symbol=symbol,
+        symbol=quote(symbol, safe=""),
         start=start.strftime("%Y%m%d"),
         end=end.strftime("%Y%m%d"),
     )
@@ -223,11 +224,16 @@ class PriceAdapter:
 
         start = on - timedelta(days=self.max_staleness_days)
         window = self._cached_window(symbol, start, on)
-        if not window and (symbol, on) not in self._missing:
+        # A cached as-of close is useful for a market holiday, but it must not
+        # suppress a provider refresh when a newer requested trading day is
+        # absent. Otherwise a prior lookup can permanently pin later requests
+        # to an older close for the lifetime of this adapter.
+        needs_refresh = not window or max(window) < on
+        if needs_refresh and (symbol, on) not in self._missing:
             fetched = self._fetch(symbol, start, on)
             if fetched:
                 self._store(symbol, fetched)
-                window = {d: p for d, p in fetched.items() if start <= d <= on}
+                window.update({d: p for d, p in fetched.items() if start <= d <= on})
 
         if not window:
             self._missing.add((symbol, on))
@@ -272,6 +278,8 @@ class PriceAdapter:
             prices = self._fetch(symbol, start, end)
             self._store(symbol, prices)
             stored += len(prices)
+        if self.use_cache and hasattr(self.conn, "commit"):
+            self.conn.commit()
         return stored
 
 

--- a/alembic/versions/015_backtest_harness.py
+++ b/alembic/versions/015_backtest_harness.py
@@ -1,0 +1,102 @@
+"""Add price_cache and backtest tables for the signal-alpha harness (#1464).
+
+Revision ID: 015
+Revises: 014
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from alembic import op
+
+revision = "015"
+down_revision = "014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "price_cache",
+        sa.Column("ticker", sa.Text(), nullable=False),
+        sa.Column("price_date", sa.Date(), nullable=False),
+        sa.Column("source", sa.Text(), nullable=False, server_default=text("'stooq'")),
+        sa.Column("close_usd", sa.Numeric(), nullable=True),
+        sa.Column(
+            "fetched_at",
+            sa.DateTime(timezone=True),
+            server_default=text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("ticker", "price_date", "source"),
+    )
+    op.create_index("idx_price_cache_ticker_date", "price_cache", ["ticker", "price_date"])
+
+    op.create_table(
+        "backtest_runs",
+        sa.Column("run_id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("strategy", sa.Text(), nullable=False),
+        sa.Column("manager_id", sa.BigInteger(), nullable=True),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=False),
+        sa.Column("entry_lag_days", sa.Integer(), nullable=False, server_default=text("0")),
+        sa.Column("holding_period_days", sa.Integer(), nullable=False, server_default=text("91")),
+        sa.Column("benchmark_ticker", sa.Text(), nullable=True),
+        sa.Column("price_source", sa.Text(), nullable=True),
+        sa.Column("periods", sa.Integer(), nullable=False, server_default=text("0")),
+        sa.Column("positions", sa.Integer(), nullable=False, server_default=text("0")),
+        sa.Column("positions_skipped", sa.Integer(), nullable=False, server_default=text("0")),
+        sa.Column("total_return", sa.Float(), nullable=True),
+        sa.Column("annualized_return", sa.Float(), nullable=True),
+        sa.Column("sharpe", sa.Float(), nullable=True),
+        sa.Column("hit_rate", sa.Float(), nullable=True),
+        sa.Column("benchmark_total_return", sa.Float(), nullable=True),
+        sa.Column("excess_return", sa.Float(), nullable=True),
+        sa.Column("params_json", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(
+        "idx_backtest_runs_strategy",
+        "backtest_runs",
+        ["strategy", "created_at"],
+    )
+
+    op.create_table(
+        "backtest_results",
+        sa.Column("result_id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", sa.BigInteger(), nullable=False),
+        sa.Column("decision_date", sa.Date(), nullable=False),
+        sa.Column("entry_date", sa.Date(), nullable=False),
+        sa.Column("exit_date", sa.Date(), nullable=False),
+        sa.Column("ticker", sa.Text(), nullable=True),
+        sa.Column("cusip", sa.Text(), nullable=True),
+        sa.Column("entry_price", sa.Float(), nullable=True),
+        sa.Column("exit_price", sa.Float(), nullable=True),
+        sa.Column("position_return", sa.Float(), nullable=True),
+        sa.Column("benchmark_return", sa.Float(), nullable=True),
+        sa.Column("excess_return", sa.Float(), nullable=True),
+        sa.Column("weight", sa.Float(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default=text("'filled'")),
+        sa.Column("skip_reason", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["run_id"],
+            ["backtest_runs.run_id"],
+            name="fk_backtest_results_run",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index("idx_backtest_results_run", "backtest_results", ["run_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_backtest_results_run", table_name="backtest_results")
+    op.drop_table("backtest_results")
+    op.drop_index("idx_backtest_runs_strategy", table_name="backtest_runs")
+    op.drop_table("backtest_runs")
+    op.drop_index("idx_price_cache_ticker_date", table_name="price_cache")
+    op.drop_table("price_cache")

--- a/alembic/versions/015_backtest_harness.py
+++ b/alembic/versions/015_backtest_harness.py
@@ -18,6 +18,7 @@ depends_on = None
 
 
 def upgrade() -> None:
+    sqlite_autoincrement_id = sa.BigInteger().with_variant(sa.Integer(), "sqlite")
     op.create_table(
         "price_cache",
         sa.Column("ticker", sa.Text(), nullable=False),
@@ -35,7 +36,7 @@ def upgrade() -> None:
 
     op.create_table(
         "backtest_runs",
-        sa.Column("run_id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", sqlite_autoincrement_id, autoincrement=True),
         sa.Column("strategy", sa.Text(), nullable=False),
         sa.Column("manager_id", sa.BigInteger(), nullable=True),
         sa.Column("start_date", sa.Date(), nullable=False),
@@ -59,6 +60,7 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             server_default=text("CURRENT_TIMESTAMP"),
         ),
+        sa.PrimaryKeyConstraint("run_id", name=op.f("pk_backtest_runs")),
     )
     op.create_index(
         "idx_backtest_runs_strategy",
@@ -68,7 +70,7 @@ def upgrade() -> None:
 
     op.create_table(
         "backtest_results",
-        sa.Column("result_id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("result_id", sqlite_autoincrement_id, autoincrement=True),
         sa.Column("run_id", sa.BigInteger(), nullable=False),
         sa.Column("decision_date", sa.Date(), nullable=False),
         sa.Column("entry_date", sa.Date(), nullable=False),
@@ -83,10 +85,11 @@ def upgrade() -> None:
         sa.Column("weight", sa.Float(), nullable=True),
         sa.Column("status", sa.Text(), nullable=False, server_default=text("'filled'")),
         sa.Column("skip_reason", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("result_id", name=op.f("pk_backtest_results")),
         sa.ForeignKeyConstraint(
             ["run_id"],
             ["backtest_runs.run_id"],
-            name="fk_backtest_results_run",
+            name=op.f("fk_backtest_results_run"),
             ondelete="CASCADE",
         ),
     )

--- a/etl/backtest_flow.py
+++ b/etl/backtest_flow.py
@@ -203,19 +203,29 @@ def enforce_no_lookahead(
     """
     cutoff = decision_cutoff(decision_date)
     visible: list[dict[str, Any]] = []
+    excluded = 0
     for row in rows:
         known_at = _knowledge_time(row)
-        if known_at is not None and known_at > cutoff:
+        if known_at is None or known_at > cutoff:
+            excluded += 1
             logger.warning(
                 "Dropping look-ahead holding from decision set",
                 extra={
                     "decision_date": decision_date.isoformat(),
-                    "knowledge_time": known_at.isoformat(),
+                    "knowledge_time": known_at.isoformat() if known_at is not None else None,
                     "cusip": row.get("cusip"),
+                    "reason": (
+                        "unknown_knowledge_time" if known_at is None else "future_knowledge_time"
+                    ),
                 },
             )
             continue
         visible.append(row)
+    if excluded:
+        logger.warning(
+            "Excluded holdings without decision-time knowledge",
+            extra={"decision_date": decision_date.isoformat(), "excluded_count": excluded},
+        )
     return visible
 
 
@@ -544,40 +554,49 @@ def persist_backtest(
     placeholders = ", ".join([ph] * len(values))
     insert_sql = f"INSERT INTO backtest_runs({columns}) VALUES ({placeholders})"
 
-    if isinstance(conn, sqlite3.Connection):
-        cursor = conn.execute(insert_sql, values)
-        run_id = int(cursor.lastrowid) if cursor.lastrowid is not None else None
-    else:
-        row = conn.execute(f"{insert_sql} RETURNING run_id", values).fetchone()
-        run_id = int(row[0]) if row else None
+    def insert_rows() -> int | None:
+        if isinstance(conn, sqlite3.Connection):
+            cursor = conn.execute(insert_sql, values)
+            run_id = int(cursor.lastrowid) if cursor.lastrowid is not None else None
+        else:
+            row = conn.execute(f"{insert_sql} RETURNING run_id", values).fetchone()
+            run_id = int(row[0]) if row else None
 
-    if run_id is not None:
-        for position in report.positions:
-            conn.execute(
-                "INSERT INTO backtest_results("
-                "run_id, decision_date, entry_date, exit_date, ticker, cusip, entry_price, "
-                "exit_price, position_return, benchmark_return, excess_return, weight, "
-                "status, skip_reason) "
-                f"VALUES ({', '.join([ph] * 14)})",
-                (
-                    run_id,
-                    position.decision_date.isoformat(),
-                    position.entry_date.isoformat(),
-                    position.exit_date.isoformat(),
-                    position.ticker,
-                    position.cusip,
-                    position.entry_price,
-                    position.exit_price,
-                    position.position_return,
-                    position.benchmark_return,
-                    position.excess_return,
-                    position.weight,
-                    position.status,
-                    position.skip_reason,
-                ),
-            )
-    if hasattr(conn, "commit"):
-        conn.commit()
+        if run_id is not None:
+            for position in report.positions:
+                conn.execute(
+                    "INSERT INTO backtest_results("
+                    "run_id, decision_date, entry_date, exit_date, ticker, cusip, entry_price, "
+                    "exit_price, position_return, benchmark_return, excess_return, weight, "
+                    "status, skip_reason) "
+                    f"VALUES ({', '.join([ph] * 14)})",
+                    (
+                        run_id,
+                        position.decision_date.isoformat(),
+                        position.entry_date.isoformat(),
+                        position.exit_date.isoformat(),
+                        position.ticker,
+                        position.cusip,
+                        position.entry_price,
+                        position.exit_price,
+                        position.position_return,
+                        position.benchmark_return,
+                        position.excess_return,
+                        position.weight,
+                        position.status,
+                        position.skip_reason,
+                    ),
+                )
+        return run_id
+
+    if isinstance(conn, sqlite3.Connection):
+        with conn:
+            run_id = insert_rows()
+    else:
+        # connect_db() returns psycopg connections in autocommit mode. A
+        # transaction context keeps a failed detail insert from orphaning its run.
+        with conn.transaction():
+            run_id = insert_rows()
     return run_id
 
 

--- a/etl/backtest_flow.py
+++ b/etl/backtest_flow.py
@@ -1,0 +1,629 @@
+"""Signal-alpha backtest harness over point-in-time holdings (#1464 / design #1401).
+
+Replays a strategy against ``holdings_as_of`` snapshots, enters each selected
+position after a disclosure lag, and reports return / annualized / Sharpe /
+hit-rate against a benchmark. Results land in ``backtest_runs`` and
+``backtest_results``.
+
+INTERNAL USE ONLY: prices come from a free provider under the #1464 owner
+decision. Only derived statistics may leave this module.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import sqlite3
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from adapters.base import get_placeholder, get_table_columns
+from adapters.prices import PriceAdapter
+from etl.point_in_time import holdings_as_of
+from utils.numeric import finite_float_or_none
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STRATEGY = "high_conviction_new_buys"
+DEFAULT_ENTRY_LAG_DAYS = 1
+DEFAULT_HOLDING_PERIOD_DAYS = 91
+DEFAULT_TOP_N = 10
+DEFAULT_BENCHMARK = "SPY"
+PERIODS_PER_YEAR = 4.0
+
+
+def _is_missing_postgres_table_error(exc: Exception) -> bool:
+    message = str(exc)
+    return (
+        "does not exist" in message
+        or getattr(exc, "pgcode", None) == "42P01"
+        or "UndefinedTable" in exc.__class__.__name__
+    )
+
+
+def ensure_backtest_tables(conn: Any) -> None:
+    """Create backtest tables on SQLite; fail fast when Postgres has no schema."""
+    if isinstance(conn, sqlite3.Connection):
+        conn.execute("""CREATE TABLE IF NOT EXISTS backtest_runs (
+                run_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                strategy TEXT NOT NULL,
+                manager_id INTEGER,
+                start_date DATE NOT NULL,
+                end_date DATE NOT NULL,
+                entry_lag_days INTEGER NOT NULL DEFAULT 0,
+                holding_period_days INTEGER NOT NULL DEFAULT 91,
+                benchmark_ticker TEXT,
+                price_source TEXT,
+                periods INTEGER NOT NULL DEFAULT 0,
+                positions INTEGER NOT NULL DEFAULT 0,
+                positions_skipped INTEGER NOT NULL DEFAULT 0,
+                total_return REAL,
+                annualized_return REAL,
+                sharpe REAL,
+                hit_rate REAL,
+                benchmark_total_return REAL,
+                excess_return REAL,
+                params_json TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )""")
+        conn.execute("""CREATE TABLE IF NOT EXISTS backtest_results (
+                result_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id INTEGER NOT NULL REFERENCES backtest_runs(run_id) ON DELETE CASCADE,
+                decision_date DATE NOT NULL,
+                entry_date DATE NOT NULL,
+                exit_date DATE NOT NULL,
+                ticker TEXT,
+                cusip TEXT,
+                entry_price REAL,
+                exit_price REAL,
+                position_return REAL,
+                benchmark_return REAL,
+                excess_return REAL,
+                weight REAL,
+                status TEXT NOT NULL DEFAULT 'filled',
+                skip_reason TEXT
+            )""")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_backtest_results_run ON backtest_results(run_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_backtest_runs_strategy "
+            "ON backtest_runs(strategy, created_at)"
+        )
+        return
+
+    for table in ("backtest_runs", "backtest_results"):
+        try:
+            conn.execute(f"SELECT 1 FROM {table} LIMIT 1")
+        except Exception as exc:
+            if _is_missing_postgres_table_error(exc):
+                raise RuntimeError(
+                    f"{table} table is missing on Postgres; apply schema migrations first"
+                ) from exc
+            raise
+
+
+@dataclass
+class Position:
+    """One security selected by the strategy at a decision date."""
+
+    decision_date: date
+    entry_date: date
+    exit_date: date
+    ticker: str | None
+    cusip: str | None
+    weight: float | None = None
+    entry_price: float | None = None
+    exit_price: float | None = None
+    position_return: float | None = None
+    benchmark_return: float | None = None
+    excess_return: float | None = None
+    status: str = "filled"
+    skip_reason: str | None = None
+
+
+@dataclass
+class BacktestReport:
+    """Aggregate outcome of a backtest run."""
+
+    strategy: str
+    manager_id: int | None
+    start_date: date
+    end_date: date
+    periods: int = 0
+    period_returns: list[float] = field(default_factory=list)
+    positions: list[Position] = field(default_factory=list)
+    total_return: float | None = None
+    annualized_return: float | None = None
+    sharpe: float | None = None
+    hit_rate: float | None = None
+    benchmark_total_return: float | None = None
+    excess_return: float | None = None
+    run_id: int | None = None
+
+    @property
+    def filled(self) -> list[Position]:
+        return [p for p in self.positions if p.status == "filled"]
+
+    @property
+    def skipped(self) -> list[Position]:
+        return [p for p in self.positions if p.status != "filled"]
+
+
+def _coerce_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def _knowledge_time(row: dict[str, Any]) -> datetime | None:
+    raw = row.get("knowledge_time")
+    if not raw:
+        return None
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=UTC)
+    try:
+        parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def decision_cutoff(decision_date: date) -> datetime:
+    """End of the decision day in UTC.
+
+    A decision dated ``D`` may act on everything disclosed during ``D``. Both the
+    as-of query and the guard below use this single cutoff, so the harness cannot
+    query one boundary and validate against another.
+    """
+    return datetime(
+        decision_date.year, decision_date.month, decision_date.day, 23, 59, 59, tzinfo=UTC
+    )
+
+
+def enforce_no_lookahead(
+    rows: Sequence[dict[str, Any]],
+    decision_date: date,
+) -> list[dict[str, Any]]:
+    """Drop any holding that was not yet knowable on ``decision_date``.
+
+    ``holdings_as_of`` already applies this bound in SQL. Re-checking it here keeps
+    the guarantee local to the harness, so a future change that swaps in a
+    current-holdings query cannot silently introduce look-ahead bias.
+    """
+    cutoff = decision_cutoff(decision_date)
+    visible: list[dict[str, Any]] = []
+    for row in rows:
+        known_at = _knowledge_time(row)
+        if known_at is not None and known_at > cutoff:
+            logger.warning(
+                "Dropping look-ahead holding from decision set",
+                extra={
+                    "decision_date": decision_date.isoformat(),
+                    "knowledge_time": known_at.isoformat(),
+                    "cusip": row.get("cusip"),
+                },
+            )
+            continue
+        visible.append(row)
+    return visible
+
+
+def _security_key(row: dict[str, Any]) -> str | None:
+    ticker = row.get("resolved_ticker")
+    if ticker:
+        return str(ticker).strip().upper()
+    cusip = row.get("cusip")
+    return str(cusip).strip() if cusip else None
+
+
+def _ticker_for(row: dict[str, Any]) -> str | None:
+    ticker = row.get("resolved_ticker")
+    return str(ticker).strip().upper() if ticker else None
+
+
+def visible_holdings(conn: Any, manager_id: int, as_of: date) -> list[dict[str, Any]]:
+    """Holdings knowable by the end of ``as_of``, with the look-ahead guard reapplied."""
+    rows = holdings_as_of(conn, manager_id, decision_cutoff(as_of))
+    return enforce_no_lookahead(rows, as_of)
+
+
+def select_new_buys(
+    conn: Any,
+    manager_id: int,
+    decision_date: date,
+    prior_date: date | None,
+    *,
+    top_n: int = DEFAULT_TOP_N,
+) -> list[dict[str, Any]]:
+    """Securities newly disclosed at ``decision_date``, ranked by position size.
+
+    "High-conviction new buys" = securities present in the as-of snapshot that were
+    absent from the prior snapshot, largest reported value first.
+    """
+    current = visible_holdings(conn, manager_id, decision_date)
+    if not current:
+        return []
+    prior_keys: set[str] = set()
+    if prior_date is not None:
+        for row in visible_holdings(conn, manager_id, prior_date):
+            key = _security_key(row)
+            if key:
+                prior_keys.add(key)
+
+    # An as-of snapshot can carry the same security from several reporting
+    # periods; keep the largest disclosed position so one buy is one position.
+    best_by_key: dict[str, dict[str, Any]] = {}
+    for row in current:
+        key = _security_key(row)
+        if key is None or key in prior_keys:
+            continue
+        incumbent = best_by_key.get(key)
+        if incumbent is None or (
+            finite_float_or_none(row.get("value_usd"), min_value=0.0) or 0.0
+        ) > (finite_float_or_none(incumbent.get("value_usd"), min_value=0.0) or 0.0):
+            best_by_key[key] = row
+
+    new_rows = list(best_by_key.values())
+    new_rows.sort(
+        key=lambda r: (
+            -(finite_float_or_none(r.get("value_usd"), min_value=0.0) or 0.0),
+            str(_security_key(r) or ""),
+        )
+    )
+    return new_rows[: max(0, int(top_n))]
+
+
+def derive_decision_dates(
+    conn: Any,
+    manager_id: int,
+    start_date: date,
+    end_date: date,
+) -> list[date]:
+    """Distinct filing disclosure dates in range, which drive the decision cadence."""
+    if "filed_date" not in get_table_columns(conn, "filings"):
+        return []
+    ph = get_placeholder(conn)
+    rows = conn.execute(
+        "SELECT DISTINCT filed_date FROM filings "
+        f"WHERE manager_id = {ph} AND filed_date IS NOT NULL "
+        f"AND filed_date >= {ph} AND filed_date <= {ph} "
+        "ORDER BY filed_date",
+        (manager_id, start_date.isoformat(), end_date.isoformat()),
+    ).fetchall()
+    dates = [_coerce_date(row[0]) for row in rows]
+    return [d for d in dates if d is not None]
+
+
+def _sharpe(returns: Sequence[float], *, risk_free_period: float = 0.0) -> float | None:
+    """Annualized Sharpe from per-period returns using the sample standard deviation."""
+    if len(returns) < 2:
+        return None
+    excess = [r - risk_free_period for r in returns]
+    mean = sum(excess) / len(excess)
+    variance = sum((value - mean) ** 2 for value in excess) / (len(excess) - 1)
+    stdev = math.sqrt(variance)
+    if stdev == 0:
+        return None
+    return (mean / stdev) * math.sqrt(PERIODS_PER_YEAR)
+
+
+def _compound(returns: Sequence[float]) -> float | None:
+    if not returns:
+        return None
+    total = 1.0
+    for value in returns:
+        total *= 1.0 + value
+    return total - 1.0
+
+
+def _annualize(total_return: float | None, periods: int) -> float | None:
+    if total_return is None or periods <= 0:
+        return None
+    growth = 1.0 + total_return
+    if growth <= 0:
+        return -1.0
+    return growth ** (PERIODS_PER_YEAR / periods) - 1.0
+
+
+def run_backtest(
+    conn: Any,
+    manager_id: int,
+    start_date: date,
+    end_date: date,
+    *,
+    price_adapter: PriceAdapter,
+    strategy: str = DEFAULT_STRATEGY,
+    decision_dates: Sequence[date] | None = None,
+    entry_lag_days: int = DEFAULT_ENTRY_LAG_DAYS,
+    holding_period_days: int = DEFAULT_HOLDING_PERIOD_DAYS,
+    top_n: int = DEFAULT_TOP_N,
+    benchmark_ticker: str | None = DEFAULT_BENCHMARK,
+    persist: bool = True,
+) -> BacktestReport:
+    """Replay ``strategy`` over point-in-time holdings and report performance.
+
+    Only holdings knowable at each decision date are eligible. A position whose
+    entry or exit price is unavailable is recorded as skipped and excluded from the
+    metrics rather than aborting the run.
+    """
+    report = BacktestReport(
+        strategy=strategy,
+        manager_id=manager_id,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    dates = list(decision_dates) if decision_dates is not None else None
+    if dates is None:
+        dates = derive_decision_dates(conn, manager_id, start_date, end_date)
+    dates = sorted({d for d in dates if start_date <= d <= end_date})
+
+    period_returns: list[float] = []
+    benchmark_returns: list[float] = []
+    prior_date: date | None = None
+
+    for decision_date in dates:
+        selected = select_new_buys(conn, manager_id, decision_date, prior_date, top_n=top_n)
+        prior_date = decision_date
+        if not selected:
+            continue
+
+        entry_date = decision_date + timedelta(days=max(0, int(entry_lag_days)))
+        exit_date = entry_date + timedelta(days=max(1, int(holding_period_days)))
+        benchmark_return = _benchmark_return(price_adapter, benchmark_ticker, entry_date, exit_date)
+
+        realized: list[float] = []
+        for row in selected:
+            position = _price_position(
+                row,
+                price_adapter,
+                decision_date=decision_date,
+                entry_date=entry_date,
+                exit_date=exit_date,
+                benchmark_return=benchmark_return,
+            )
+            report.positions.append(position)
+            if position.position_return is not None:
+                realized.append(position.position_return)
+
+        if not realized:
+            continue
+        period_returns.append(sum(realized) / len(realized))
+        if benchmark_return is not None:
+            benchmark_returns.append(benchmark_return)
+
+    report.periods = len(period_returns)
+    report.period_returns = period_returns
+    report.total_return = _compound(period_returns)
+    report.annualized_return = _annualize(report.total_return, report.periods)
+    report.sharpe = _sharpe(period_returns)
+    report.benchmark_total_return = _compound(benchmark_returns) if benchmark_returns else None
+    if report.total_return is not None and report.benchmark_total_return is not None:
+        report.excess_return = report.total_return - report.benchmark_total_return
+
+    filled = report.filled
+    if filled:
+        wins = sum(1 for p in filled if (p.position_return or 0.0) > 0)
+        report.hit_rate = wins / len(filled)
+
+    if persist:
+        report.run_id = persist_backtest(
+            conn,
+            report,
+            entry_lag_days=entry_lag_days,
+            holding_period_days=holding_period_days,
+            benchmark_ticker=benchmark_ticker,
+            price_source=price_adapter.source,
+            top_n=top_n,
+        )
+    return report
+
+
+def _benchmark_return(
+    price_adapter: PriceAdapter,
+    benchmark_ticker: str | None,
+    entry_date: date,
+    exit_date: date,
+) -> float | None:
+    if not benchmark_ticker:
+        return None
+    entry = price_adapter.close_on_or_before(benchmark_ticker, entry_date)
+    exit_price = price_adapter.close_on_or_before(benchmark_ticker, exit_date)
+    if entry is None or exit_price is None or entry <= 0:
+        logger.warning(
+            "Benchmark price unavailable; period recorded without benchmark",
+            extra={"benchmark": benchmark_ticker, "entry_date": entry_date.isoformat()},
+        )
+        return None
+    return (exit_price - entry) / entry
+
+
+def _price_position(
+    row: dict[str, Any],
+    price_adapter: PriceAdapter,
+    *,
+    decision_date: date,
+    entry_date: date,
+    exit_date: date,
+    benchmark_return: float | None,
+) -> Position:
+    ticker = _ticker_for(row)
+    cusip = str(row["cusip"]) if row.get("cusip") else None
+    position = Position(
+        decision_date=decision_date,
+        entry_date=entry_date,
+        exit_date=exit_date,
+        ticker=ticker,
+        cusip=cusip,
+        weight=finite_float_or_none(row.get("value_usd"), min_value=0.0),
+        benchmark_return=benchmark_return,
+    )
+
+    if not ticker:
+        position.status = "skipped"
+        position.skip_reason = "unresolved_ticker"
+        logger.warning("Holding has no resolved ticker; skipping", extra={"cusip": cusip})
+        return position
+
+    entry_price = price_adapter.close_on_or_before(ticker, entry_date)
+    exit_price = price_adapter.close_on_or_before(ticker, exit_date)
+    if entry_price is None or exit_price is None or entry_price <= 0:
+        position.status = "skipped"
+        position.skip_reason = "missing_price"
+        logger.warning(
+            "Missing price for position; excluded from metrics",
+            extra={
+                "ticker": ticker,
+                "entry_date": entry_date.isoformat(),
+                "exit_date": exit_date.isoformat(),
+            },
+        )
+        return position
+
+    position.entry_price = entry_price
+    position.exit_price = exit_price
+    position.position_return = (exit_price - entry_price) / entry_price
+    if benchmark_return is not None:
+        position.excess_return = position.position_return - benchmark_return
+    return position
+
+
+def persist_backtest(
+    conn: Any,
+    report: BacktestReport,
+    *,
+    entry_lag_days: int,
+    holding_period_days: int,
+    benchmark_ticker: str | None,
+    price_source: str,
+    top_n: int,
+) -> int | None:
+    """Write the run header and per-position rows; returns the new ``run_id``."""
+    ensure_backtest_tables(conn)
+    ph = get_placeholder(conn)
+    params_json = json.dumps(
+        {"top_n": top_n, "periods_per_year": PERIODS_PER_YEAR},
+        sort_keys=True,
+    )
+    columns = (
+        "strategy, manager_id, start_date, end_date, entry_lag_days, holding_period_days, "
+        "benchmark_ticker, price_source, periods, positions, positions_skipped, total_return, "
+        "annualized_return, sharpe, hit_rate, benchmark_total_return, excess_return, params_json"
+    )
+    values = (
+        report.strategy,
+        report.manager_id,
+        report.start_date.isoformat(),
+        report.end_date.isoformat(),
+        int(entry_lag_days),
+        int(holding_period_days),
+        benchmark_ticker,
+        price_source,
+        report.periods,
+        len(report.filled),
+        len(report.skipped),
+        report.total_return,
+        report.annualized_return,
+        report.sharpe,
+        report.hit_rate,
+        report.benchmark_total_return,
+        report.excess_return,
+        params_json,
+    )
+    placeholders = ", ".join([ph] * len(values))
+    insert_sql = f"INSERT INTO backtest_runs({columns}) VALUES ({placeholders})"
+
+    if isinstance(conn, sqlite3.Connection):
+        cursor = conn.execute(insert_sql, values)
+        run_id = int(cursor.lastrowid) if cursor.lastrowid is not None else None
+    else:
+        row = conn.execute(f"{insert_sql} RETURNING run_id", values).fetchone()
+        run_id = int(row[0]) if row else None
+
+    if run_id is not None:
+        for position in report.positions:
+            conn.execute(
+                "INSERT INTO backtest_results("
+                "run_id, decision_date, entry_date, exit_date, ticker, cusip, entry_price, "
+                "exit_price, position_return, benchmark_return, excess_return, weight, "
+                "status, skip_reason) "
+                f"VALUES ({', '.join([ph] * 14)})",
+                (
+                    run_id,
+                    position.decision_date.isoformat(),
+                    position.entry_date.isoformat(),
+                    position.exit_date.isoformat(),
+                    position.ticker,
+                    position.cusip,
+                    position.entry_price,
+                    position.exit_price,
+                    position.position_return,
+                    position.benchmark_return,
+                    position.excess_return,
+                    position.weight,
+                    position.status,
+                    position.skip_reason,
+                ),
+            )
+    if hasattr(conn, "commit"):
+        conn.commit()
+    return run_id
+
+
+def query_backtest_runs(
+    conn: Any,
+    *,
+    strategy: str | None = None,
+    manager_id: int | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Read-only accessor for stored run metrics (internal reporting surface)."""
+    if not get_table_columns(conn, "backtest_runs"):
+        return []
+    ph = get_placeholder(conn)
+    where: list[str] = []
+    params: list[Any] = []
+    if strategy:
+        where.append(f"strategy = {ph}")
+        params.append(strategy)
+    if manager_id is not None:
+        where.append(f"manager_id = {ph}")
+        params.append(manager_id)
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+    params.append(max(1, int(limit)))
+    rows = conn.execute(
+        "SELECT run_id, strategy, manager_id, start_date, end_date, periods, positions, "
+        "positions_skipped, total_return, annualized_return, sharpe, hit_rate, "
+        "benchmark_total_return, excess_return, created_at "
+        f"FROM backtest_runs{where_sql} ORDER BY run_id DESC LIMIT {ph}",
+        tuple(params),
+    ).fetchall()
+    keys = (
+        "run_id",
+        "strategy",
+        "manager_id",
+        "start_date",
+        "end_date",
+        "periods",
+        "positions",
+        "positions_skipped",
+        "total_return",
+        "annualized_return",
+        "sharpe",
+        "hit_rate",
+        "benchmark_total_return",
+        "excess_return",
+        "created_at",
+    )
+    return [dict(zip(keys, row, strict=False)) for row in rows]

--- a/etl/backtest_flow.py
+++ b/etl/backtest_flow.py
@@ -407,11 +407,14 @@ def run_backtest(
             if position.position_return is not None:
                 realized.append(position.position_return)
 
-        if not realized:
+        # Excess return is meaningful only when the portfolio and benchmark
+        # compound over the identical decision periods. Keep the individual
+        # positions for auditability, but exclude an unbenchmarked period from
+        # aggregate comparison metrics.
+        if not realized or benchmark_return is None:
             continue
         period_returns.append(sum(realized) / len(realized))
-        if benchmark_return is not None:
-            benchmark_returns.append(benchmark_return)
+        benchmark_returns.append(benchmark_return)
 
     report.periods = len(period_returns)
     report.period_returns = period_returns

--- a/etl/backtest_flow.py
+++ b/etl/backtest_flow.py
@@ -48,7 +48,7 @@ def ensure_backtest_tables(conn: Any) -> None:
     """Create backtest tables on SQLite; fail fast when Postgres has no schema."""
     if isinstance(conn, sqlite3.Connection):
         conn.execute("""CREATE TABLE IF NOT EXISTS backtest_runs (
-                run_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id INTEGER PRIMARY KEY,
                 strategy TEXT NOT NULL,
                 manager_id INTEGER,
                 start_date DATE NOT NULL,
@@ -70,7 +70,7 @@ def ensure_backtest_tables(conn: Any) -> None:
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )""")
         conn.execute("""CREATE TABLE IF NOT EXISTS backtest_results (
-                result_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                result_id INTEGER PRIMARY KEY,
                 run_id INTEGER NOT NULL REFERENCES backtest_runs(run_id) ON DELETE CASCADE,
                 decision_date DATE NOT NULL,
                 entry_date DATE NOT NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -190,6 +190,61 @@ CREATE TABLE IF NOT EXISTS insider_transactions (
 CREATE INDEX IF NOT EXISTS idx_insider_issuer_date ON insider_transactions (issuer_cik, txn_date);
 CREATE INDEX IF NOT EXISTS idx_insider_ticker_date ON insider_transactions (ticker, txn_date);
 
+-- Free-source daily closes cached for the backtest harness (#1464). Internal use
+-- only: derived statistics may be surfaced, raw prices may not be redistributed.
+CREATE TABLE IF NOT EXISTS price_cache (
+    ticker text NOT NULL,
+    price_date date NOT NULL,
+    source text NOT NULL DEFAULT 'stooq',
+    close_usd numeric,
+    fetched_at timestamptz DEFAULT now(),
+    PRIMARY KEY (ticker, price_date, source)
+);
+CREATE INDEX IF NOT EXISTS idx_price_cache_ticker_date ON price_cache (ticker, price_date);
+
+CREATE TABLE IF NOT EXISTS backtest_runs (
+    run_id bigserial PRIMARY KEY,
+    strategy text NOT NULL,
+    manager_id bigint,
+    start_date date NOT NULL,
+    end_date date NOT NULL,
+    entry_lag_days integer NOT NULL DEFAULT 0,
+    holding_period_days integer NOT NULL DEFAULT 91,
+    benchmark_ticker text,
+    price_source text,
+    periods integer NOT NULL DEFAULT 0,
+    positions integer NOT NULL DEFAULT 0,
+    positions_skipped integer NOT NULL DEFAULT 0,
+    total_return real,
+    annualized_return real,
+    sharpe real,
+    hit_rate real,
+    benchmark_total_return real,
+    excess_return real,
+    params_json text,
+    created_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_backtest_runs_strategy ON backtest_runs (strategy, created_at);
+
+CREATE TABLE IF NOT EXISTS backtest_results (
+    result_id bigserial PRIMARY KEY,
+    run_id bigint NOT NULL REFERENCES backtest_runs(run_id) ON DELETE CASCADE,
+    decision_date date NOT NULL,
+    entry_date date NOT NULL,
+    exit_date date NOT NULL,
+    ticker text,
+    cusip text,
+    entry_price real,
+    exit_price real,
+    position_return real,
+    benchmark_return real,
+    excess_return real,
+    weight real,
+    status text NOT NULL DEFAULT 'filled',
+    skip_reason text
+);
+CREATE INDEX IF NOT EXISTS idx_backtest_results_run ON backtest_results (run_id);
+
 CREATE TABLE IF NOT EXISTS identifier_resolution_cache (
     cusip text PRIMARY KEY,
     ticker text,

--- a/scripts/backtest_report.py
+++ b/scripts/backtest_report.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Print stored backtest run metrics (#1464).
+
+Internal reporting surface. Per the #1464 owner decision the underlying free-source
+prices are internal-use only, so this prints derived statistics and is deliberately
+not wired into the public API.
+
+Usage::
+
+    python -m scripts.backtest_report --manager-id 1
+    python -m scripts.backtest_report --strategy high_conviction_new_buys --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from adapters.base import connect_db  # noqa: E402
+from etl.backtest_flow import query_backtest_runs  # noqa: E402
+
+
+def _format_pct(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    return f"{float(value) * 100:.2f}%"
+
+
+def _format_ratio(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    return f"{float(value):.3f}"
+
+
+def render_rows(rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        return "No backtest runs recorded."
+    header = (
+        f"{'run':>5}  {'strategy':<26} {'mgr':>5} {'periods':>7} {'pos':>5} "
+        f"{'skip':>5} {'total':>9} {'annual':>9} {'sharpe':>7} {'hit':>7} {'excess':>9}"
+    )
+    lines = [header, "-" * len(header)]
+    for row in rows:
+        lines.append(
+            f"{row['run_id']:>5}  {str(row['strategy'])[:26]:<26} "
+            f"{'' if row['manager_id'] is None else row['manager_id']:>5} "
+            f"{row['periods']:>7} {row['positions']:>5} {row['positions_skipped']:>5} "
+            f"{_format_pct(row['total_return']):>9} "
+            f"{_format_pct(row['annualized_return']):>9} "
+            f"{_format_ratio(row['sharpe']):>7} "
+            f"{_format_pct(row['hit_rate']):>7} "
+            f"{_format_pct(row['excess_return']):>9}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--strategy", default=None, help="filter by strategy name")
+    parser.add_argument("--manager-id", type=int, default=None, help="filter by manager")
+    parser.add_argument("--limit", type=int, default=20, help="maximum runs to show")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = parser.parse_args(argv)
+
+    conn = connect_db()
+    try:
+        rows = query_backtest_runs(
+            conn,
+            strategy=args.strategy,
+            manager_id=args.manager_id,
+            limit=args.limit,
+        )
+    finally:
+        conn.close()
+
+    if args.json:
+        print(json.dumps(rows, indent=2, default=str))
+    else:
+        print(render_rows(rows))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backtest_flow.py
+++ b/tests/test_backtest_flow.py
@@ -1,0 +1,342 @@
+"""Acceptance tests for the signal-alpha backtest harness (#1464 / design #1401)."""
+
+from __future__ import annotations
+
+import math
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from adapters.prices import PriceAdapter
+from etl import backtest_flow
+from etl.backtest_flow import enforce_no_lookahead, run_backtest, select_new_buys
+
+# Fixture price series. Keys are (ticker) -> {date: close}.
+PRICES: dict[str, dict[date, float]] = {
+    "AAA": {date(2024, 5, 2): 100.0, date(2024, 8, 1): 120.0},
+    "BBB": {date(2024, 8, 2): 200.0, date(2024, 11, 1): 220.0},
+    "SPY": {
+        date(2024, 5, 2): 100.0,
+        date(2024, 8, 1): 105.0,
+        date(2024, 8, 2): 105.0,
+        date(2024, 11, 1): 107.1,
+    },
+}
+
+DECISION_DATES = [date(2024, 5, 1), date(2024, 8, 1)]
+
+
+def _make_fetcher(prices: dict[str, dict[date, float]]):
+    calls: list[tuple[str, date, date]] = []
+
+    def fetcher(ticker: str, start: date, end: date) -> dict[date, float]:
+        calls.append((ticker, start, end))
+        return {d: p for d, p in prices.get(ticker, {}).items() if start <= d <= end}
+
+    fetcher.calls = calls  # type: ignore[attr-defined]
+    return fetcher
+
+
+def _connect(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "backtest.db")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute("""
+        CREATE TABLE filings (
+            filing_id INTEGER PRIMARY KEY,
+            manager_id INTEGER NOT NULL,
+            type TEXT NOT NULL,
+            period_end TEXT,
+            filed_date TEXT,
+            source TEXT NOT NULL
+        )
+        """)
+    conn.execute("""
+        CREATE TABLE holdings (
+            holding_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            filing_id INTEGER NOT NULL,
+            cusip TEXT,
+            resolved_ticker TEXT,
+            name_of_issuer TEXT,
+            shares INTEGER,
+            value_usd REAL,
+            knowledge_time TEXT NOT NULL,
+            superseded_at TEXT,
+            version INTEGER NOT NULL DEFAULT 1
+        )
+        """)
+    conn.execute("INSERT INTO managers(manager_id, name) VALUES (1, 'Test Manager')")
+    conn.commit()
+    return conn
+
+
+def _add_filing(conn: sqlite3.Connection, filing_id: int, period_end: str, filed_date: str) -> None:
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source) "
+        "VALUES (?, 1, '13F-HR', ?, ?, 'us')",
+        (filing_id, period_end, filed_date),
+    )
+
+
+def _add_holding(
+    conn: sqlite3.Connection,
+    filing_id: int,
+    cusip: str,
+    ticker: str | None,
+    value_usd: float,
+    knowledge_time: str,
+) -> None:
+    conn.execute(
+        "INSERT INTO holdings(filing_id, cusip, resolved_ticker, name_of_issuer, shares, "
+        "value_usd, knowledge_time) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (filing_id, cusip, ticker, f"{cusip} Corp", 1000, value_usd, knowledge_time),
+    )
+
+
+def _two_quarter_fixture(tmp_path: Path) -> sqlite3.Connection:
+    """Q1 discloses AAA; Q2 additionally discloses BBB (the Q2 new buy)."""
+    conn = _connect(tmp_path)
+    _add_filing(conn, 10, "2024-03-31", "2024-05-01")
+    _add_holding(conn, 10, "AAA000000", "AAA", 5_000_000.0, "2024-05-01T12:00:00Z")
+    _add_filing(conn, 11, "2024-06-30", "2024-08-01")
+    _add_holding(conn, 11, "AAA000000", "AAA", 5_500_000.0, "2024-08-01T12:00:00Z")
+    _add_holding(conn, 11, "BBB000000", "BBB", 9_000_000.0, "2024-08-01T12:00:00Z")
+    conn.commit()
+    return conn
+
+
+def _adapter(conn: sqlite3.Connection, prices=None) -> PriceAdapter:
+    return PriceAdapter(conn, source="test", fetcher=_make_fetcher(prices or PRICES))
+
+
+def test_two_quarter_backtest_matches_hand_computed_return_and_sharpe(tmp_path):
+    """Stubbed prices over two quarters reproduce hand-computed metrics.
+
+    Q1 buys AAA at 100 and exits at 120 (+20%); Q2 buys BBB at 200 and exits at
+    220 (+10%). With one position per period the period returns are 0.20 and 0.10:
+      total       = 1.20 * 1.10 - 1                       = 0.32
+      annualized  = 1.32 ** (4/2) - 1                     = 0.7424
+      sharpe      = mean/sample-stdev * sqrt(4)
+                  = 0.15 / 0.0707106781 * 2               = 4.2426406871
+      hit rate    = 2 filled positions, both positive     = 1.0
+    """
+    conn = _two_quarter_fixture(tmp_path)
+    report = run_backtest(
+        conn,
+        manager_id=1,
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 12, 31),
+        price_adapter=_adapter(conn),
+        decision_dates=DECISION_DATES,
+        entry_lag_days=1,
+        holding_period_days=91,
+        benchmark_ticker="SPY",
+    )
+
+    assert report.periods == 2
+    assert report.period_returns == pytest.approx([0.20, 0.10])
+    assert report.total_return == pytest.approx(0.32)
+    assert report.annualized_return == pytest.approx(0.7424)
+    assert report.sharpe == pytest.approx(0.15 / (0.1 / math.sqrt(2)) * 2.0)
+    assert report.sharpe == pytest.approx(4.2426406871, rel=1e-9)
+    assert report.hit_rate == pytest.approx(1.0)
+
+    # Benchmark: +5% then +2% compounds to 7.1%; excess is strategy minus benchmark.
+    assert report.benchmark_total_return == pytest.approx(0.071)
+    assert report.excess_return == pytest.approx(0.32 - 0.071)
+
+    tickers = sorted(p.ticker for p in report.filled)
+    assert tickers == ["AAA", "BBB"]
+
+
+def test_no_lookahead_ignores_a_later_known_holding(tmp_path):
+    """A holding not knowable at the decision date must never enter the decision set.
+
+    Deliberate-break check: allowing future-dated holdings in (e.g. sourcing the
+    decision set from current holdings instead of the as-of snapshot) makes this
+    test fail.
+    """
+    conn = _connect(tmp_path)
+    _add_filing(conn, 10, "2024-03-31", "2024-05-01")
+    _add_holding(conn, 10, "AAA000000", "AAA", 5_000_000.0, "2024-05-01T12:00:00Z")
+    # Restated later: filed before the decision date, but only KNOWN afterwards.
+    _add_holding(conn, 10, "ZZZ000000", "ZZZ", 9_999_999.0, "2024-07-15T12:00:00Z")
+    conn.commit()
+
+    decision_date = date(2024, 5, 1)
+    selected = select_new_buys(conn, 1, decision_date, None, top_n=10)
+    assert [row["resolved_ticker"] for row in selected] == [
+        "AAA"
+    ], "ZZZ was only knowable on 2024-07-15 and must not inform a 2024-05-01 decision"
+
+    report = run_backtest(
+        conn,
+        manager_id=1,
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 12, 31),
+        price_adapter=_adapter(conn),
+        decision_dates=[decision_date],
+        entry_lag_days=1,
+        holding_period_days=91,
+        benchmark_ticker="SPY",
+    )
+    assert "ZZZ" not in {p.ticker for p in report.positions}
+
+    # The same holding IS visible once its knowledge time has passed.
+    later = select_new_buys(conn, 1, date(2024, 7, 16), None, top_n=10)
+    assert sorted(row["resolved_ticker"] for row in later) == ["AAA", "ZZZ"]
+
+
+def test_enforce_no_lookahead_drops_future_knowledge_rows():
+    """The harness-local guard drops future-known rows even if a query returns them."""
+    rows = [
+        {"cusip": "AAA000000", "knowledge_time": "2024-05-01T12:00:00Z"},
+        {"cusip": "ZZZ000000", "knowledge_time": "2024-07-15T12:00:00Z"},
+        {"cusip": "NNN000000", "knowledge_time": None},
+    ]
+    visible = enforce_no_lookahead(rows, date(2024, 5, 1))
+    assert [row["cusip"] for row in visible] == ["AAA000000", "NNN000000"]
+
+
+def test_missing_price_skips_position_without_crashing(tmp_path, caplog):
+    """A position with no obtainable price is excluded and logged, not fatal."""
+    conn = _connect(tmp_path)
+    _add_filing(conn, 10, "2024-03-31", "2024-05-01")
+    _add_holding(conn, 10, "AAA000000", "AAA", 5_000_000.0, "2024-05-01T12:00:00Z")
+    # No price series exists for MIA, and NOTICK never resolved to a ticker.
+    _add_holding(conn, 10, "MIA000000", "MIA", 4_000_000.0, "2024-05-01T12:00:00Z")
+    _add_holding(conn, 10, "NON000000", None, 3_000_000.0, "2024-05-01T12:00:00Z")
+    conn.commit()
+
+    with caplog.at_level("WARNING"):
+        report = run_backtest(
+            conn,
+            manager_id=1,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+            price_adapter=_adapter(conn),
+            decision_dates=[date(2024, 5, 1)],
+            entry_lag_days=1,
+            holding_period_days=91,
+            benchmark_ticker="SPY",
+        )
+
+    assert [p.ticker for p in report.filled] == ["AAA"]
+    # The unresolved holding has no ticker at all, so it is identified by cusip.
+    skipped = {p.cusip: (p.ticker, p.skip_reason) for p in report.skipped}
+    assert skipped == {
+        "MIA000000": ("MIA", "missing_price"),
+        "NON000000": (None, "unresolved_ticker"),
+    }
+    # Metrics reflect only the filled position, and the run completed.
+    assert report.period_returns == pytest.approx([0.20])
+    assert report.hit_rate == pytest.approx(1.0)
+    assert "Missing price for position" in caplog.text
+    assert "no resolved ticker" in caplog.text
+
+
+def test_backtest_persists_run_and_position_rows(tmp_path):
+    conn = _two_quarter_fixture(tmp_path)
+    report = run_backtest(
+        conn,
+        manager_id=1,
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 12, 31),
+        price_adapter=_adapter(conn),
+        decision_dates=DECISION_DATES,
+        entry_lag_days=1,
+        holding_period_days=91,
+        benchmark_ticker="SPY",
+    )
+
+    assert report.run_id is not None
+    run_row = conn.execute(
+        "SELECT strategy, periods, positions, positions_skipped, total_return, hit_rate "
+        "FROM backtest_runs WHERE run_id = ?",
+        (report.run_id,),
+    ).fetchone()
+    assert run_row["strategy"] == "high_conviction_new_buys"
+    assert run_row["periods"] == 2
+    assert run_row["positions"] == 2
+    assert run_row["positions_skipped"] == 0
+    assert run_row["total_return"] == pytest.approx(0.32)
+
+    result_rows = conn.execute(
+        "SELECT ticker, entry_date, exit_date, position_return FROM backtest_results "
+        "WHERE run_id = ? ORDER BY ticker",
+        (report.run_id,),
+    ).fetchall()
+    assert [row["ticker"] for row in result_rows] == ["AAA", "BBB"]
+    assert result_rows[0]["entry_date"] == "2024-05-02"
+    assert result_rows[0]["exit_date"] == "2024-08-01"
+    assert result_rows[0]["position_return"] == pytest.approx(0.20)
+
+    runs = backtest_flow.query_backtest_runs(conn, manager_id=1)
+    assert len(runs) == 1
+    assert runs[0]["run_id"] == report.run_id
+    assert runs[0]["sharpe"] == pytest.approx(4.2426406871, rel=1e-9)
+
+
+def test_decision_dates_derived_from_filing_disclosure_dates(tmp_path):
+    conn = _two_quarter_fixture(tmp_path)
+    dates = backtest_flow.derive_decision_dates(conn, 1, date(2024, 1, 1), date(2024, 12, 31))
+    assert dates == DECISION_DATES
+
+
+def test_price_adapter_caches_and_reports_missing(tmp_path):
+    conn = _connect(tmp_path)
+    fetcher = _make_fetcher(PRICES)
+    adapter = PriceAdapter(conn, source="test", fetcher=fetcher)
+
+    assert adapter.close_on_or_before("AAA", date(2024, 5, 2)) == pytest.approx(100.0)
+    first_call_count = len(fetcher.calls)
+    # Second read for the same date is served from price_cache.
+    assert adapter.close_on_or_before("AAA", date(2024, 5, 2)) == pytest.approx(100.0)
+    assert len(fetcher.calls) == first_call_count
+
+    cached = conn.execute(
+        "SELECT close_usd FROM price_cache WHERE ticker = ? AND price_date = ?",
+        ("AAA", "2024-05-02"),
+    ).fetchone()
+    assert cached["close_usd"] == pytest.approx(100.0)
+
+    # Unknown ticker and empty ticker degrade to None rather than raising.
+    assert adapter.close_on_or_before("NOSUCH", date(2024, 5, 2)) is None
+    assert adapter.close_on_or_before(None, date(2024, 5, 2)) is None
+
+
+def test_price_adapter_uses_most_recent_close_within_staleness_window(tmp_path):
+    conn = _connect(tmp_path)
+    series = {"AAA": {date(2024, 5, 1): 90.0, date(2024, 5, 2): 100.0}}
+    adapter = PriceAdapter(conn, source="test", fetcher=_make_fetcher(series))
+
+    # 2024-05-04 has no print; the 05-02 close is the as-of price.
+    assert adapter.close_on_or_before("AAA", date(2024, 5, 4)) == pytest.approx(100.0)
+    # Beyond the staleness window there is no usable price.
+    stale = PriceAdapter(
+        conn,
+        source="strict",
+        fetcher=_make_fetcher(series),
+        max_staleness_days=1,
+    )
+    assert stale.close_on_or_before("AAA", date(2024, 5, 10)) is None
+
+
+def test_price_adapter_rejects_non_finite_quotes(tmp_path):
+    conn = _connect(tmp_path)
+    series = {"AAA": {date(2024, 5, 2): float("inf"), date(2024, 5, 1): 90.0}}
+    adapter = PriceAdapter(conn, source="test", fetcher=_make_fetcher(series))
+    # The infinite quote is discarded; the previous finite close is used instead.
+    assert adapter.close_on_or_before("AAA", date(2024, 5, 2)) == pytest.approx(90.0)
+
+
+def test_price_adapter_survives_a_raising_fetcher(tmp_path):
+    conn = _connect(tmp_path)
+
+    def broken(ticker: str, start: date, end: date) -> dict[date, float]:
+        raise RuntimeError("provider exploded")
+
+    adapter = PriceAdapter(conn, source="test", fetcher=broken)
+    assert adapter.close_on_or_before("AAA", date(2024, 5, 2)) is None

--- a/tests/test_backtest_flow.py
+++ b/tests/test_backtest_flow.py
@@ -289,6 +289,28 @@ def test_backtest_persists_run_and_position_rows(tmp_path):
     assert runs[0]["sharpe"] == pytest.approx(4.2426406871, rel=1e-9)
 
 
+def test_backtest_pairs_portfolio_and_benchmark_periods(tmp_path):
+    conn = _two_quarter_fixture(tmp_path)
+    prices = {ticker: dict(series) for ticker, series in PRICES.items()}
+    del prices["SPY"][date(2024, 11, 1)]
+    report = run_backtest(
+        conn,
+        manager_id=1,
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 12, 31),
+        price_adapter=_adapter(conn, prices),
+        decision_dates=DECISION_DATES,
+        entry_lag_days=1,
+        holding_period_days=91,
+        benchmark_ticker="SPY",
+    )
+
+    assert [position.ticker for position in report.filled] == ["AAA", "BBB"]
+    assert report.period_returns == pytest.approx([0.20])
+    assert report.benchmark_total_return == pytest.approx(0.05)
+    assert report.excess_return == pytest.approx(0.15)
+
+
 def test_backtest_persistence_rolls_back_the_header_when_a_result_insert_fails(tmp_path):
     conn = _connect(tmp_path)
     report = BacktestReport(

--- a/tests/test_backtest_flow.py
+++ b/tests/test_backtest_flow.py
@@ -4,14 +4,23 @@ from __future__ import annotations
 
 import math
 import sqlite3
+import sys
 from datetime import date
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from adapters.prices import PriceAdapter
+from adapters.prices import PriceAdapter, fetch_yfinance_prices
 from etl import backtest_flow
-from etl.backtest_flow import enforce_no_lookahead, run_backtest, select_new_buys
+from etl.backtest_flow import (
+    BacktestReport,
+    Position,
+    enforce_no_lookahead,
+    persist_backtest,
+    run_backtest,
+    select_new_buys,
+)
 
 # Fixture price series. Keys are (ticker) -> {date: close}.
 PRICES: dict[str, dict[date, float]] = {
@@ -195,9 +204,10 @@ def test_enforce_no_lookahead_drops_future_knowledge_rows():
         {"cusip": "AAA000000", "knowledge_time": "2024-05-01T12:00:00Z"},
         {"cusip": "ZZZ000000", "knowledge_time": "2024-07-15T12:00:00Z"},
         {"cusip": "NNN000000", "knowledge_time": None},
+        {"cusip": "BAD000000", "knowledge_time": "not-a-timestamp"},
     ]
     visible = enforce_no_lookahead(rows, date(2024, 5, 1))
-    assert [row["cusip"] for row in visible] == ["AAA000000", "NNN000000"]
+    assert [row["cusip"] for row in visible] == ["AAA000000"]
 
 
 def test_missing_price_skips_position_without_crashing(tmp_path, caplog):
@@ -279,6 +289,41 @@ def test_backtest_persists_run_and_position_rows(tmp_path):
     assert runs[0]["sharpe"] == pytest.approx(4.2426406871, rel=1e-9)
 
 
+def test_backtest_persistence_rolls_back_the_header_when_a_result_insert_fails(tmp_path):
+    conn = _connect(tmp_path)
+    report = BacktestReport(
+        strategy="test",
+        manager_id=1,
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 3, 31),
+        positions=[
+            Position(date(2024, 1, 1), date(2024, 1, 2), date(2024, 4, 2), "AAA", None),
+            Position(
+                date(2024, 1, 1),
+                date(2024, 1, 2),
+                date(2024, 4, 2),
+                "BBB",
+                None,
+                status=None,  # type: ignore[arg-type]
+            ),
+        ],
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        persist_backtest(
+            conn,
+            report,
+            entry_lag_days=1,
+            holding_period_days=91,
+            benchmark_ticker="SPY",
+            price_source="test",
+            top_n=10,
+        )
+
+    assert conn.execute("SELECT COUNT(*) FROM backtest_runs").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM backtest_results").fetchone()[0] == 0
+
+
 def test_decision_dates_derived_from_filing_disclosure_dates(tmp_path):
     conn = _two_quarter_fixture(tmp_path)
     dates = backtest_flow.derive_decision_dates(conn, 1, date(2024, 1, 1), date(2024, 12, 31))
@@ -322,6 +367,45 @@ def test_price_adapter_uses_most_recent_close_within_staleness_window(tmp_path):
         max_staleness_days=1,
     )
     assert stale.close_on_or_before("AAA", date(2024, 5, 10)) is None
+
+
+def test_price_adapter_refreshes_a_partial_cache_for_a_newer_as_of_date(tmp_path):
+    conn = _connect(tmp_path)
+    prices = {"AAA": {date(2024, 5, 1): 90.0}}
+    fetcher = _make_fetcher(prices)
+    adapter = PriceAdapter(conn, source="test", fetcher=fetcher)
+
+    assert adapter.close_on_or_before("AAA", date(2024, 5, 1)) == pytest.approx(90.0)
+    prices["AAA"][date(2024, 5, 2)] = 100.0
+
+    assert adapter.close_on_or_before("AAA", date(2024, 5, 2)) == pytest.approx(100.0)
+    assert len(fetcher.calls) == 2
+
+
+def test_fetch_yfinance_prices_handles_dates_empty_frames_and_missing_dependency(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    class Frame:
+        Close = {date(2024, 5, 1): 12.5}
+
+    class Ticker:
+        def __init__(self, ticker: str) -> None:
+            self.ticker = ticker
+
+        def history(self, **kwargs):
+            calls.append(kwargs)
+            return Frame()
+
+    monkeypatch.setitem(sys.modules, "yfinance", SimpleNamespace(Ticker=Ticker))
+    assert fetch_yfinance_prices("AAA", date(2024, 5, 1), date(2024, 5, 2)) == {
+        date(2024, 5, 1): 12.5
+    }
+    assert calls == [{"start": "2024-05-01", "end": "2024-05-03", "auto_adjust": True}]
+
+    Frame.Close = {}
+    assert fetch_yfinance_prices("AAA", date(2024, 5, 1), date(2024, 5, 2)) == {}
+    monkeypatch.setitem(sys.modules, "yfinance", None)
+    assert fetch_yfinance_prices("AAA", date(2024, 5, 1), date(2024, 5, 2)) == {}
 
 
 def test_price_adapter_rejects_non_finite_quotes(tmp_path):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -85,6 +85,27 @@ def test_schema_foreign_keys(monkeypatch, tmp_path):
             )
 
 
+def test_backtest_migration_uses_sqlite_autoincrement_primary_keys(monkeypatch, tmp_path):
+    """Migration 015 must generate IDs without callers supplying SQLite BIGINT keys."""
+    monkeypatch.delenv("DB_URL", raising=False)
+    db_path = tmp_path / "schema.db"
+    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        run = conn.execute(
+            "INSERT INTO backtest_runs(strategy, start_date, end_date) VALUES (?, ?, ?)",
+            ("test", "2024-01-01", "2024-03-31"),
+        )
+        assert run.lastrowid is not None
+        result = conn.execute(
+            "INSERT INTO backtest_results(run_id, decision_date, entry_date, exit_date) "
+            "VALUES (?, ?, ?, ?)",
+            (run.lastrowid, "2024-01-01", "2024-01-02", "2024-04-02"),
+        )
+        assert result.lastrowid is not None
+
+
 def test_filings_raw_key_unique_index(monkeypatch, tmp_path):
     """Verify migration 002 creates a unique index on filings.raw_key."""
     monkeypatch.delenv("DB_URL", raising=False)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import re
 import sqlite3
 from pathlib import Path
 
 import pytest
 from alembic.config import Config
 
+from adapters.prices import ensure_price_cache_table
 from alembic import command
+from etl.backtest_flow import ensure_backtest_tables
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -104,6 +107,42 @@ def test_backtest_migration_uses_sqlite_autoincrement_primary_keys(monkeypatch, 
             (run.lastrowid, "2024-01-01", "2024-01-02", "2024-04-02"),
         )
         assert result.lastrowid is not None
+
+
+def test_backtest_schema_contract_stays_in_sync_across_all_three_definitions(monkeypatch, tmp_path):
+    """Keep migration, runtime SQLite DDL, and canonical schema.sql column contracts aligned."""
+    monkeypatch.delenv("DB_URL", raising=False)
+    db_path = tmp_path / "migrated.db"
+    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+
+    tables = {"price_cache", "backtest_runs", "backtest_results"}
+    with sqlite3.connect(db_path) as migrated, sqlite3.connect(":memory:") as runtime:
+        ensure_price_cache_table(runtime)
+        ensure_backtest_tables(runtime)
+        migrated_columns = {
+            table: {row[1] for row in migrated.execute(f"PRAGMA table_info({table})")}
+            for table in tables
+        }
+        runtime_columns = {
+            table: {row[1] for row in runtime.execute(f"PRAGMA table_info({table})")}
+            for table in tables
+        }
+
+    schema = (ROOT / "schema.sql").read_text(encoding="utf-8")
+    schema_columns = {}
+    for table in tables:
+        definition = re.search(
+            rf"CREATE TABLE IF NOT EXISTS {table} \((.*?)\n\);", schema, flags=re.DOTALL
+        )
+        assert definition is not None
+        schema_columns[table] = {
+            line.strip().split()[0]
+            for line in definition.group(1).splitlines()
+            if line.strip()
+            and not line.lstrip().startswith(("PRIMARY", "FOREIGN", "UNIQUE", "CONSTRAINT"))
+        }
+
+    assert runtime_columns == migrated_columns == schema_columns
 
 
 def test_filings_raw_key_unique_index(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #1464

Implements design #1401: a backtest / signal-alpha harness that replays a strategy over point-in-time holdings so conviction and activism signals can be **measured** (return / Sharpe / hit-rate) rather than asserted.

This issue was blocked by #1463 ("a backtest requires point-in-time holdings"). #1463 landed via #1474 (verifier PASS, closed 2026-07-31), so this cone is unblocked.

## What landed

**`adapters/prices.py`** — free-source daily closes (Stooq by default, yfinance when installed), keyed by `resolved_ticker` (#1374) and cached in `price_cache`. `close_on_or_before` implements as-of pricing within a staleness window, because a decision date frequently has no print of its own. Provider output is sanitized at the boundary, so a NaN/inf quote can never reach the cache or a return calculation (#1299). A provider that raises degrades to "no price", not a crash.

**`etl/backtest_flow.py`** — selects new buys by diffing consecutive as-of snapshots, enters after a disclosure lag, exits after a holding period, and reports total / annualized return, Sharpe and hit-rate against a benchmark. Results persist to `backtest_runs` / `backtest_results`.

Two things worth a reviewer's attention:

- **One cutoff, used twice.** `decision_cutoff()` defines a decision date as "everything knowable by end of that day" and is used *both* for the `holdings_as_of` query and for the harness-local `enforce_no_lookahead` guard. An earlier revision queried at midnight while asserting against end-of-day; sharing the cutoff removes that class of drift.
- **Skips are recorded, not silent.** A missing price or unresolved ticker produces a `skipped` row with a `skip_reason` and is excluded from metrics, so a degraded run is visible in the stored output rather than quietly shrinking the sample.

**Schema** — `price_cache`, `backtest_runs`, `backtest_results` via Alembic `015` with matching `schema.sql` (parity #1308). Dialect-aware: SQLite creates tables inline, Postgres fails fast if migrations have not been applied. `scripts/check_dialect_portability.py` passes.

**`scripts/backtest_report.py`** — the internal read-only reporting surface.

## Non-Goals honored

- No price data is redistributed or exposed through the public API. The reporting surface is a script, not an endpoint, and only derived statistics are surfaced. Both modules carry an internal-use-only header.
- No operator-facing backtester UI.
- Conviction scoring is not re-derived.

## Tasks

- [x] Price adapter (`adapters/prices.py`) wrapping a free source with local caching + graceful/finite handling (#1299), keyed by `resolved_ticker` (#1374).
- [x] `etl/backtest_flow.py`: strategy over `holdings_as_of`, entry at disclosure + lag, forward returns vs a benchmark, stored in `backtest_runs`/`backtest_results` (dialect-aware + Alembic + `schema.sql` parity #1308).
- [x] Report return / annualized / Sharpe / hit-rate; read-only internal surface (`query_backtest_runs` + `scripts/backtest_report.py`).

## Acceptance Criteria

- [x] **Test (stubbed prices):** `tests/test_backtest_flow.py::test_two_quarter_backtest_matches_hand_computed_return_and_sharpe` runs two quarters of fixture point-in-time holdings with known prices and asserts hand-computed values: period returns `0.20 / 0.10`, total `0.32`, annualized `1.32**2 - 1 = 0.7424`, Sharpe `0.15 / 0.0707106781 * 2 = 4.2426406871`, hit-rate `1.0`, benchmark `0.071`.
- [x] **No look-ahead:** `test_no_lookahead_ignores_a_later_known_holding` files a holding before the decision date whose `knowledge_time` is two months later; it must not inform the decision, and must become visible once its knowledge time has passed. `test_enforce_no_lookahead_drops_future_knowledge_rows` covers the guard directly.
- [x] **Missing price degrades gracefully:** `test_missing_price_skips_position_without_crashing` asserts the position is excluded with `skip_reason=missing_price`, an unresolved ticker yields `unresolved_ticker`, both are logged, and the run still produces metrics from the remaining position.
- [x] **Named test:** `tests/test_backtest_flow.py` with `test_no_lookahead_ignores_a_later_known_holding`.
- [x] **Deliberate-break demonstrated:** sourcing the decision set from `current_holdings` instead of the as-of snapshot in `etl/backtest_flow.py` (i.e. allowing future-dated holdings into a decision) fails `test_no_lookahead_ignores_a_later_known_holding`; reverted and re-verified green.

<!-- deliberate-break: test=tests/test_backtest_flow.py::test_no_lookahead_ignores_a_later_known_holding test-file=tests/test_backtest_flow.py break-file=etl/backtest_flow.py -->

## Validation

- `pytest tests/test_backtest_flow.py tests/test_schema.py tests/test_bitemporal_holdings.py` → 22 passed (with the repo conftest loaded).
- Full `pytest tests` → 2 failures in `tests/test_app_health.py` (`test_health_app_reports_failed_dependencies`, `test_health_app_reports_circuit_breaker_open`). **Pre-existing**: reproduced on a clean baseline with every file from this branch removed, so they are not caused by this change.
- `ruff check` clean; `black --line-length 100 --target-version py312` applied; `scripts/check_dialect_portability.py` exits 0; Alembic `015` upgrade + downgrade covered by `tests/test_schema.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added point-in-time backtesting with configurable entry lags, holding periods, benchmarks, and performance metrics.
  * Added daily closing-price retrieval, caching, missing-price tracking, and cache warming.
  * Added reporting with strategy or manager filtering and JSON or formatted table output.
  * Added database storage for cached prices, backtest runs, and position-level results.
* **Bug Fixes**
  * Prevented look-ahead bias and improved handling of missing, stale, invalid, or unavailable price data.
* **Tests**
  * Added coverage for calculations, persistence, schema consistency, price handling, and look-ahead prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->