### PR TITLE
feat(activism): add campaign timeline materialization

### DIFF
--- a/alembic/versions/015_activism_campaigns.py
+++ b/alembic/versions/015_activism_campaigns.py
@@ -1,0 +1,59 @@
+"""Add materialized activism campaign summaries and timelines.
+
+Revision ID: 015
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "015"
+down_revision = "014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "activism_campaigns",
+        sa.Column("campaign_id", sa.BigInteger(), primary_key=True),
+        sa.Column("manager_id", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False),
+        sa.Column("target_identifier", sa.Text(), nullable=False),
+        sa.Column("target_company", sa.Text(), nullable=False),
+        sa.Column("first_filed", sa.Date(), nullable=False),
+        sa.Column("last_filed", sa.Date(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("peak_ownership_pct", sa.Numeric(8, 4)),
+        sa.Column("latest_ownership_pct", sa.Numeric(8, 4)),
+        sa.Column("filing_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("event_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("latest_event_type", sa.Text()),
+        sa.Column("source_forms", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("data_quality_flags", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("computed_at", sa.DateTime(), nullable=False, server_default=sa.func.current_timestamp()),
+        sa.UniqueConstraint("manager_id", "target_identifier", name="uq_activism_campaign_manager_target"),
+    )
+    op.create_index("idx_activism_campaigns_manager", "activism_campaigns", ["manager_id"])
+    op.create_index("idx_activism_campaigns_status", "activism_campaigns", ["status"])
+    op.create_table(
+        "activism_campaign_timeline",
+        sa.Column("timeline_id", sa.BigInteger(), primary_key=True),
+        sa.Column("campaign_id", sa.BigInteger(), sa.ForeignKey("activism_campaigns.campaign_id"), nullable=False),
+        sa.Column("filing_id", sa.BigInteger(), sa.ForeignKey("activism_filings.filing_id"), nullable=False),
+        sa.Column("event_id", sa.BigInteger(), sa.ForeignKey("activism_events.event_id")),
+        sa.Column("event_date", sa.Date(), nullable=False),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("form_type", sa.Text(), nullable=False),
+        sa.Column("ownership_pct", sa.Numeric(8, 4)),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("source_url", sa.Text()),
+        sa.UniqueConstraint("campaign_id", "filing_id", "event_id", name="uq_activism_campaign_timeline_source"),
+    )
+    op.create_index("idx_activism_campaign_timeline_campaign", "activism_campaign_timeline", ["campaign_id", "event_date"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_activism_campaign_timeline_campaign", table_name="activism_campaign_timeline")
+    op.drop_table("activism_campaign_timeline")
+    op.drop_index("idx_activism_campaigns_status", table_name="activism_campaigns")
+    op.drop_index("idx_activism_campaigns_manager", table_name="activism_campaigns")
+    op.drop_table("activism_campaigns")

--- a/alembic/versions/015_activism_campaigns.py
+++ b/alembic/versions/015_activism_campaigns.py
@@ -3,8 +3,9 @@
 Revision ID: 015
 """
 
-from alembic import op
 import sqlalchemy as sa
+
+from alembic import op
 
 revision = "015"
 down_revision = "014"
@@ -16,7 +17,9 @@ def upgrade() -> None:
     op.create_table(
         "activism_campaigns",
         sa.Column("campaign_id", sa.BigInteger(), primary_key=True),
-        sa.Column("manager_id", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False),
+        sa.Column(
+            "manager_id", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False
+        ),
         sa.Column("target_identifier", sa.Text(), nullable=False),
         sa.Column("target_company", sa.Text(), nullable=False),
         sa.Column("first_filed", sa.Date(), nullable=False),
@@ -29,16 +32,30 @@ def upgrade() -> None:
         sa.Column("latest_event_type", sa.Text()),
         sa.Column("source_forms", sa.Text(), nullable=False, server_default="[]"),
         sa.Column("data_quality_flags", sa.Text(), nullable=False, server_default="[]"),
-        sa.Column("computed_at", sa.DateTime(), nullable=False, server_default=sa.func.current_timestamp()),
-        sa.UniqueConstraint("manager_id", "target_identifier", name="uq_activism_campaign_manager_target"),
+        sa.Column(
+            "computed_at", sa.DateTime(), nullable=False, server_default=sa.func.current_timestamp()
+        ),
+        sa.UniqueConstraint(
+            "manager_id", "target_identifier", name="uq_activism_campaign_manager_target"
+        ),
     )
     op.create_index("idx_activism_campaigns_manager", "activism_campaigns", ["manager_id"])
     op.create_index("idx_activism_campaigns_status", "activism_campaigns", ["status"])
     op.create_table(
         "activism_campaign_timeline",
         sa.Column("timeline_id", sa.BigInteger(), primary_key=True),
-        sa.Column("campaign_id", sa.BigInteger(), sa.ForeignKey("activism_campaigns.campaign_id"), nullable=False),
-        sa.Column("filing_id", sa.BigInteger(), sa.ForeignKey("activism_filings.filing_id"), nullable=False),
+        sa.Column(
+            "campaign_id",
+            sa.BigInteger(),
+            sa.ForeignKey("activism_campaigns.campaign_id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "filing_id",
+            sa.BigInteger(),
+            sa.ForeignKey("activism_filings.filing_id"),
+            nullable=False,
+        ),
         sa.Column("event_id", sa.BigInteger(), sa.ForeignKey("activism_events.event_id")),
         sa.Column("event_date", sa.Date(), nullable=False),
         sa.Column("event_type", sa.Text(), nullable=False),
@@ -46,13 +63,21 @@ def upgrade() -> None:
         sa.Column("ownership_pct", sa.Numeric(8, 4)),
         sa.Column("summary", sa.Text(), nullable=False),
         sa.Column("source_url", sa.Text()),
-        sa.UniqueConstraint("campaign_id", "filing_id", "event_id", name="uq_activism_campaign_timeline_source"),
+        sa.UniqueConstraint(
+            "campaign_id", "filing_id", "event_id", name="uq_activism_campaign_timeline_source"
+        ),
     )
-    op.create_index("idx_activism_campaign_timeline_campaign", "activism_campaign_timeline", ["campaign_id", "event_date"])
+    op.create_index(
+        "idx_activism_campaign_timeline_campaign",
+        "activism_campaign_timeline",
+        ["campaign_id", "event_date"],
+    )
 
 
 def downgrade() -> None:
-    op.drop_index("idx_activism_campaign_timeline_campaign", table_name="activism_campaign_timeline")
+    op.drop_index(
+        "idx_activism_campaign_timeline_campaign", table_name="activism_campaign_timeline"
+    )
     op.drop_table("activism_campaign_timeline")
     op.drop_index("idx_activism_campaigns_status", table_name="activism_campaigns")
     op.drop_index("idx_activism_campaigns_manager", table_name="activism_campaigns")

--- a/alembic/versions/016_activism_campaigns.py
+++ b/alembic/versions/016_activism_campaigns.py
@@ -1,22 +1,24 @@
 """Add materialized activism campaign summaries and timelines.
 
-Revision ID: 015
+Revision ID: 016
+Revises: 015
 """
 
 import sqlalchemy as sa
 
 from alembic import op
 
-revision = "015"
-down_revision = "014"
+revision = "016"
+down_revision = "015"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
+    sqlite_autoincrement_id = sa.BigInteger().with_variant(sa.Integer(), "sqlite")
     op.create_table(
         "activism_campaigns",
-        sa.Column("campaign_id", sa.BigInteger(), primary_key=True),
+        sa.Column("campaign_id", sqlite_autoincrement_id, primary_key=True, autoincrement=True),
         sa.Column(
             "manager_id", sa.BigInteger(), sa.ForeignKey("managers.manager_id"), nullable=False
         ),
@@ -33,17 +35,24 @@ def upgrade() -> None:
         sa.Column("source_forms", sa.Text(), nullable=False, server_default="[]"),
         sa.Column("data_quality_flags", sa.Text(), nullable=False, server_default="[]"),
         sa.Column(
-            "computed_at", sa.DateTime(), nullable=False, server_default=sa.func.current_timestamp()
+            "computed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.current_timestamp(),
         ),
         sa.UniqueConstraint(
             "manager_id", "target_identifier", name="uq_activism_campaign_manager_target"
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'monitoring', 'closed', 'unknown')",
+            name="ck_activism_campaigns_status",
         ),
     )
     op.create_index("idx_activism_campaigns_manager", "activism_campaigns", ["manager_id"])
     op.create_index("idx_activism_campaigns_status", "activism_campaigns", ["status"])
     op.create_table(
         "activism_campaign_timeline",
-        sa.Column("timeline_id", sa.BigInteger(), primary_key=True),
+        sa.Column("timeline_id", sqlite_autoincrement_id, primary_key=True, autoincrement=True),
         sa.Column(
             "campaign_id",
             sa.BigInteger(),
@@ -72,9 +81,22 @@ def upgrade() -> None:
         "activism_campaign_timeline",
         ["campaign_id", "event_date"],
     )
+    # SQLite and PostgreSQL both treat NULLs as distinct in a UNIQUE constraint, so the
+    # composite key above cannot stop duplicate filing-only rows.
+    op.create_index(
+        "uq_activism_campaign_timeline_filing_only",
+        "activism_campaign_timeline",
+        ["campaign_id", "filing_id"],
+        unique=True,
+        sqlite_where=sa.text("event_id IS NULL"),
+        postgresql_where=sa.text("event_id IS NULL"),
+    )
 
 
 def downgrade() -> None:
+    op.drop_index(
+        "uq_activism_campaign_timeline_filing_only", table_name="activism_campaign_timeline"
+    )
     op.drop_index(
         "idx_activism_campaign_timeline_campaign", table_name="activism_campaign_timeline"
     )

--- a/api/activism.py
+++ b/api/activism.py
@@ -60,6 +60,34 @@ class ActiveCampaignResponse(BaseModel):
     latest_event_type: str | None
 
 
+class ActivismCampaignResponse(BaseModel):
+    campaign_id: int
+    manager_id: int
+    manager_name: str | None
+    target_identifier: str
+    target_company: str
+    first_filed: date
+    last_filed: date
+    status: str
+    peak_ownership_pct: float | None
+    latest_ownership_pct: float | None
+    filing_count: int
+    event_count: int
+    latest_event_type: str | None
+    data_quality_flags: list[str] = Field(default_factory=list)
+
+
+class ActivismCampaignTimelineResponse(BaseModel):
+    filing_id: int
+    event_id: int | None
+    event_date: date
+    event_type: str
+    form_type: str
+    ownership_pct: float | None
+    summary: str
+    source_url: str | None
+
+
 def _to_float(value: Any) -> float | None:
     if value is None:
         return None
@@ -93,6 +121,18 @@ def _to_datetime(value: Any) -> datetime:
     if text.endswith("Z"):
         text = f"{text[:-1]}+00:00"
     return datetime.fromisoformat(text)
+
+
+def _json_strings(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if value in (None, ""):
+        return []
+    try:
+        parsed = __import__("json").loads(str(value))
+    except (TypeError, ValueError):
+        return []
+    return [str(item) for item in parsed] if isinstance(parsed, list) else []
 
 
 # Keep the SQL-building logic in one place so API and Streamlit views stay aligned.
@@ -327,6 +367,98 @@ def query_active_campaigns(
     ]
 
 
+def query_activism_campaigns(
+    conn: Any,
+    *,
+    campaign_id: int | None = None,
+    manager_id: int | None = None,
+    target_identifier: str | None = None,
+    status: str | None = None,
+    filed_from: date | None = None,
+    filed_to: date | None = None,
+    limit: int = 25,
+) -> list[ActivismCampaignResponse]:
+    if not table_exists(conn, "activism_campaigns"):
+        return []
+    ph = get_placeholder(conn)
+    filters: list[str] = []
+    params: list[Any] = []
+    if campaign_id is not None:
+        filters.append(f"ac.campaign_id = {ph}")
+        params.append(campaign_id)
+    if manager_id is not None:
+        filters.append(f"ac.manager_id = {ph}")
+        params.append(manager_id)
+    if target_identifier:
+        filters.append(f"upper(ac.target_identifier) = upper({ph})")
+        params.append(target_identifier)
+    if status:
+        filters.append(f"ac.status = {ph}")
+        params.append(status)
+    if filed_from is not None:
+        filters.append(f"ac.last_filed >= {ph}")
+        params.append(filed_from)
+    if filed_to is not None:
+        filters.append(f"ac.first_filed <= {ph}")
+        params.append(filed_to)
+    where = f"WHERE {' AND '.join(filters)}" if filters else ""
+    params.append(limit)
+    rows = conn.execute(
+        "SELECT ac.campaign_id, ac.manager_id, m.name, ac.target_identifier, ac.target_company, "
+        "ac.first_filed, ac.last_filed, ac.status, ac.peak_ownership_pct, ac.latest_ownership_pct, "
+        "ac.filing_count, ac.event_count, ac.latest_event_type, ac.data_quality_flags "
+        "FROM activism_campaigns ac LEFT JOIN managers m ON m.manager_id = ac.manager_id "
+        f"{where} ORDER BY ac.last_filed DESC, ac.campaign_id DESC LIMIT {ph}",
+        tuple(params),
+    ).fetchall()
+    return [
+        ActivismCampaignResponse(
+            campaign_id=int(row[0]),
+            manager_id=int(row[1]),
+            manager_name=str(row[2]) if row[2] is not None else None,
+            target_identifier=str(row[3]),
+            target_company=str(row[4]),
+            first_filed=_to_date(row[5]),
+            last_filed=_to_date(row[6]),
+            status=str(row[7]),
+            peak_ownership_pct=_to_float(row[8]),
+            latest_ownership_pct=_to_float(row[9]),
+            filing_count=int(row[10]),
+            event_count=int(row[11]),
+            latest_event_type=str(row[12]) if row[12] is not None else None,
+            data_quality_flags=_json_strings(row[13]),
+        )
+        for row in rows
+    ]
+
+
+def query_activism_campaign_timeline(
+    conn: Any, campaign_id: int
+) -> list[ActivismCampaignTimelineResponse]:
+    if not table_exists(conn, "activism_campaign_timeline"):
+        return []
+    ph = get_placeholder(conn)
+    rows = conn.execute(
+        "SELECT filing_id, event_id, event_date, event_type, form_type, ownership_pct, summary, source_url "
+        "FROM activism_campaign_timeline WHERE campaign_id = " + ph + " "
+        "ORDER BY event_date ASC, form_type ASC, filing_id ASC, event_id ASC",
+        (campaign_id,),
+    ).fetchall()
+    return [
+        ActivismCampaignTimelineResponse(
+            filing_id=int(row[0]),
+            event_id=_to_int(row[1]),
+            event_date=_to_date(row[2]),
+            event_type=str(row[3]),
+            form_type=str(row[4]),
+            ownership_pct=_to_float(row[5]),
+            summary=str(row[6]),
+            source_url=str(row[7]) if row[7] is not None else None,
+        )
+        for row in rows
+    ]
+
+
 @router.get(
     "/api/activism/filings",
     response_model=list[ActivismFilingResponse],
@@ -404,5 +536,62 @@ async def active_campaigns(
     conn = connect_db()
     try:
         return query_active_campaigns(conn, min_ownership_pct=min_ownership_pct, limit=limit)
+    finally:
+        conn.close()
+
+
+@router.get(
+    "/api/activism/campaigns",
+    response_model=list[ActivismCampaignResponse],
+    summary="List materialized activism campaigns",
+)
+async def list_activism_campaigns(
+    manager_id: int | None = None,
+    target_identifier: str | None = None,
+    status: str | None = None,
+    filed_from: date | None = None,
+    filed_to: date | None = None,
+    limit: int = Query(25, ge=1, le=100),
+) -> list[ActivismCampaignResponse]:
+    conn = connect_db()
+    try:
+        return query_activism_campaigns(
+            conn,
+            manager_id=manager_id,
+            target_identifier=target_identifier,
+            status=status,
+            filed_from=filed_from,
+            filed_to=filed_to,
+            limit=limit,
+        )
+    finally:
+        conn.close()
+
+
+@router.get(
+    "/api/activism/campaigns/{campaign_id}",
+    response_model=ActivismCampaignResponse | None,
+    summary="Get an activism campaign",
+)
+async def get_activism_campaign(campaign_id: int) -> ActivismCampaignResponse | None:
+    conn = connect_db()
+    try:
+        campaigns = query_activism_campaigns(conn, campaign_id=campaign_id, limit=1)
+        return campaigns[0] if campaigns else None
+    finally:
+        conn.close()
+
+
+@router.get(
+    "/api/activism/campaigns/{campaign_id}/timeline",
+    response_model=list[ActivismCampaignTimelineResponse],
+    summary="Get a deterministic activism campaign timeline",
+)
+async def get_activism_campaign_timeline(
+    campaign_id: int,
+) -> list[ActivismCampaignTimelineResponse]:
+    conn = connect_db()
+    try:
+        return query_activism_campaign_timeline(conn, campaign_id)
     finally:
         conn.close()

--- a/api/activism.py
+++ b/api/activism.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from datetime import date, datetime
 from typing import Any
 
@@ -92,9 +93,11 @@ def _to_float(value: Any) -> float | None:
     if value is None:
         return None
     try:
-        return float(value)
+        number = float(value)
     except (TypeError, ValueError):
         return None
+    # SQLite REAL columns can hold Infinity/NaN, which Starlette cannot serialize.
+    return number if math.isfinite(number) else None
 
 
 def _to_int(value: Any) -> int | None:

--- a/etl/activism_campaign_flow.py
+++ b/etl/activism_campaign_flow.py
@@ -1,0 +1,328 @@
+"""Materialize deterministic activism campaigns from filing-level records."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+from adapters.base import get_placeholder, is_postgres, is_sqlite, table_exists
+
+
+@dataclass(frozen=True)
+class CampaignRunSummary:
+    filings_scanned: int = 0
+    campaigns_written: int = 0
+    timeline_rows_written: int = 0
+    skipped_filings: int = 0
+    skip_reasons: dict[str, int] | None = None
+
+
+def ensure_activism_campaign_tables(conn: Any) -> None:
+    """Create runtime tables for SQLite development databases.
+
+    Production schemas are owned by Alembic; these definitions keep the
+    ingestion/materialization path usable in a fresh local SQLite database.
+    """
+    if is_sqlite(conn):
+        conn.execute("""CREATE TABLE IF NOT EXISTS activism_campaigns (
+                campaign_id INTEGER PRIMARY KEY,
+                manager_id INTEGER NOT NULL,
+                target_identifier TEXT NOT NULL,
+                target_company TEXT NOT NULL,
+                first_filed TEXT NOT NULL,
+                last_filed TEXT NOT NULL,
+                status TEXT NOT NULL,
+                peak_ownership_pct REAL,
+                latest_ownership_pct REAL,
+                filing_count INTEGER NOT NULL DEFAULT 0,
+                event_count INTEGER NOT NULL DEFAULT 0,
+                latest_event_type TEXT,
+                source_forms TEXT NOT NULL DEFAULT '[]',
+                data_quality_flags TEXT NOT NULL DEFAULT '[]',
+                computed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(manager_id, target_identifier)
+            )""")
+        conn.execute("""CREATE TABLE IF NOT EXISTS activism_campaign_timeline (
+                timeline_id INTEGER PRIMARY KEY,
+                campaign_id INTEGER NOT NULL REFERENCES activism_campaigns(campaign_id),
+                filing_id INTEGER NOT NULL REFERENCES activism_filings(filing_id),
+                event_id INTEGER REFERENCES activism_events(event_id),
+                event_date TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                form_type TEXT NOT NULL,
+                ownership_pct REAL,
+                summary TEXT NOT NULL,
+                source_url TEXT,
+                UNIQUE(campaign_id, filing_id, event_id)
+            )""")
+    elif is_postgres(conn):
+        conn.execute("""CREATE TABLE IF NOT EXISTS activism_campaigns (
+                campaign_id BIGSERIAL PRIMARY KEY,
+                manager_id BIGINT NOT NULL REFERENCES managers(manager_id),
+                target_identifier TEXT NOT NULL,
+                target_company TEXT NOT NULL,
+                first_filed DATE NOT NULL,
+                last_filed DATE NOT NULL,
+                status TEXT NOT NULL,
+                peak_ownership_pct NUMERIC(8,4),
+                latest_ownership_pct NUMERIC(8,4),
+                filing_count INTEGER NOT NULL DEFAULT 0,
+                event_count INTEGER NOT NULL DEFAULT 0,
+                latest_event_type TEXT,
+                source_forms JSONB NOT NULL DEFAULT '[]'::jsonb,
+                data_quality_flags JSONB NOT NULL DEFAULT '[]'::jsonb,
+                computed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(manager_id, target_identifier)
+            )""")
+        conn.execute("""CREATE TABLE IF NOT EXISTS activism_campaign_timeline (
+                timeline_id BIGSERIAL PRIMARY KEY,
+                campaign_id BIGINT NOT NULL REFERENCES activism_campaigns(campaign_id),
+                filing_id BIGINT NOT NULL REFERENCES activism_filings(filing_id),
+                event_id BIGINT REFERENCES activism_events(event_id),
+                event_date DATE NOT NULL,
+                event_type TEXT NOT NULL,
+                form_type TEXT NOT NULL,
+                ownership_pct NUMERIC(8,4),
+                summary TEXT NOT NULL,
+                source_url TEXT,
+                UNIQUE NULLS NOT DISTINCT(campaign_id, filing_id, event_id)
+            )""")
+    else:
+        raise TypeError(f"Unsupported database connection type: {type(conn)!r}")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activism_campaigns_manager ON activism_campaigns(manager_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activism_campaigns_status ON activism_campaigns(status)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activism_campaign_timeline_campaign "
+        "ON activism_campaign_timeline(campaign_id, event_date)"
+    )
+
+
+def _target_identifier(cusip: Any, company: Any) -> tuple[str | None, list[str]]:
+    normalized_cusip = str(cusip or "").strip().upper()
+    if normalized_cusip:
+        return normalized_cusip, []
+    normalized_company = " ".join(str(company or "").upper().split())
+    if normalized_company:
+        return f"name:{normalized_company}", ["missing_cusip"]
+    return None, ["missing_target"]
+
+
+def _status(form_type: str, latest_ownership: float | None) -> str:
+    if latest_ownership is not None and latest_ownership <= 0:
+        return "closed"
+    if form_type.startswith("SC 13D"):
+        return "active"
+    if form_type.startswith("SC 13G"):
+        return "monitoring"
+    return "unknown"
+
+
+def _json(value: list[str]) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _timeline_summary(form_type: str, company: str, ownership: float | None) -> str:
+    ownership_text = f" at {ownership:g}% ownership" if ownership is not None else ""
+    return f"Filed {form_type} for {company}{ownership_text}."
+
+
+def _upsert_campaign(
+    conn: Any,
+    *,
+    manager_id: int,
+    target_identifier: str,
+    target_company: str,
+    first_filed: str,
+    last_filed: str,
+    status: str,
+    peak_ownership: float | None,
+    latest_ownership: float | None,
+    filing_count: int,
+    event_count: int,
+    latest_event_type: str | None,
+    forms: list[str],
+    flags: list[str],
+) -> int:
+    ph = get_placeholder(conn)
+    values = (
+        manager_id,
+        target_identifier,
+        target_company,
+        first_filed,
+        last_filed,
+        status,
+        peak_ownership,
+        latest_ownership,
+        filing_count,
+        event_count,
+        latest_event_type,
+        _json(forms),
+        _json(flags),
+    )
+    if is_sqlite(conn):
+        conn.execute(
+            "INSERT INTO activism_campaigns(manager_id, target_identifier, target_company, first_filed, "
+            "last_filed, status, peak_ownership_pct, latest_ownership_pct, filing_count, event_count, "
+            "latest_event_type, source_forms, data_quality_flags, computed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP) "
+            "ON CONFLICT(manager_id, target_identifier) DO UPDATE SET "
+            "target_company=excluded.target_company, first_filed=excluded.first_filed, "
+            "last_filed=excluded.last_filed, status=excluded.status, peak_ownership_pct=excluded.peak_ownership_pct, "
+            "latest_ownership_pct=excluded.latest_ownership_pct, filing_count=excluded.filing_count, "
+            "event_count=excluded.event_count, latest_event_type=excluded.latest_event_type, "
+            "source_forms=excluded.source_forms, data_quality_flags=excluded.data_quality_flags, "
+            "computed_at=CURRENT_TIMESTAMP",
+            values,
+        )
+        row = conn.execute(
+            "SELECT campaign_id FROM activism_campaigns WHERE manager_id = ? AND target_identifier = ?",
+            (manager_id, target_identifier),
+        ).fetchone()
+    else:
+        conn.execute(
+            "INSERT INTO activism_campaigns(manager_id, target_identifier, target_company, first_filed, "
+            "last_filed, status, peak_ownership_pct, latest_ownership_pct, filing_count, event_count, "
+            "latest_event_type, source_forms, data_quality_flags, computed_at) "
+            f"VALUES ({', '.join([ph] * 13)}, CURRENT_TIMESTAMP) "
+            "ON CONFLICT(manager_id, target_identifier) DO UPDATE SET "
+            "target_company=excluded.target_company, first_filed=excluded.first_filed, "
+            "last_filed=excluded.last_filed, status=excluded.status, peak_ownership_pct=excluded.peak_ownership_pct, "
+            "latest_ownership_pct=excluded.latest_ownership_pct, filing_count=excluded.filing_count, "
+            "event_count=excluded.event_count, latest_event_type=excluded.latest_event_type, "
+            "source_forms=excluded.source_forms, data_quality_flags=excluded.data_quality_flags, "
+            "computed_at=CURRENT_TIMESTAMP",
+            values,
+        )
+        row = conn.execute(
+            f"SELECT campaign_id FROM activism_campaigns WHERE manager_id = {ph} AND target_identifier = {ph}",
+            (manager_id, target_identifier),
+        ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def materialize_activism_campaigns(conn: Any, since: date | None = None) -> CampaignRunSummary:
+    """Build campaign summaries and deterministic filing timelines from source rows."""
+    if not table_exists(conn, "activism_filings"):
+        return CampaignRunSummary(skip_reasons={"missing_activism_filings_table": 1})
+    ensure_activism_campaign_tables(conn)
+    ph = get_placeholder(conn)
+    where = "WHERE af.filed_date >= " + ph if since else ""
+    rows = conn.execute(
+        "SELECT af.filing_id, af.manager_id, af.filing_type, af.subject_company, af.subject_cusip, "
+        "af.ownership_pct, af.filed_date, af.url FROM activism_filings af "
+        f"{where} ORDER BY af.manager_id, af.subject_cusip, af.subject_company, af.filed_date, af.filing_id",
+        (since,) if since else (),
+    ).fetchall()
+    events_by_filing: dict[int, list[tuple[Any, ...]]] = defaultdict(list)
+    if table_exists(conn, "activism_events"):
+        for event in conn.execute(
+            "SELECT event_id, filing_id, event_type, detected_at FROM activism_events ORDER BY detected_at, event_id"
+        ).fetchall():
+            events_by_filing[int(event[1])].append(event)
+
+    grouped: dict[tuple[int, str], list[tuple[Any, ...]]] = defaultdict(list)
+    skipped: dict[str, int] = defaultdict(int)
+    for row in rows:
+        identifier, flags = _target_identifier(row[4], row[3])
+        if identifier is None:
+            skipped[flags[0]] += 1
+            continue
+        grouped[(int(row[1]), identifier)].append(row)
+
+    timeline_count = 0
+    for (manager_id, identifier), filings in grouped.items():
+        first, latest = filings[0], filings[-1]
+        ownerships = [float(row[5]) for row in filings if row[5] is not None]
+        events = [event for row in filings for event in events_by_filing[int(row[0])]]
+        campaign_id = _upsert_campaign(
+            conn,
+            manager_id=manager_id,
+            target_identifier=identifier,
+            target_company=str(latest[3]),
+            first_filed=str(first[6]),
+            last_filed=str(latest[6]),
+            status=_status(str(latest[2]), float(latest[5]) if latest[5] is not None else None),
+            peak_ownership=max(ownerships) if ownerships else None,
+            latest_ownership=float(latest[5]) if latest[5] is not None else None,
+            filing_count=len(filings),
+            event_count=len(events),
+            latest_event_type=str(events[-1][2]) if events else None,
+            forms=sorted({str(row[2]) for row in filings}),
+            flags=_target_identifier(latest[4], latest[3])[1],
+        )
+        for filing in filings:
+            filing_id = int(filing[0])
+            event_rows = events_by_filing.get(filing_id) or [
+                (None, filing_id, "initial_filing", filing[6])
+            ]
+            for event_id, _event_filing_id, event_type, detected_at in event_rows:
+                event_date = (
+                    str(detected_at).split("T", 1)[0] if event_id is not None else str(filing[6])
+                )
+                if is_sqlite(conn):
+                    # SQLite UNIQUE constraints consider NULL values distinct, so a
+                    # filing-only timeline row (event_id NULL) needs an explicit
+                    # replacement to keep reruns append-safe.
+                    conn.execute(
+                        "DELETE FROM activism_campaign_timeline WHERE campaign_id = ? AND filing_id = ? "
+                        "AND event_id IS ?",
+                        (campaign_id, filing_id, event_id),
+                    )
+                    conn.execute(
+                        "INSERT INTO activism_campaign_timeline(campaign_id, filing_id, event_id, event_date, "
+                        "event_type, form_type, ownership_pct, summary, source_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                        "",
+                        (
+                            campaign_id,
+                            filing_id,
+                            event_id,
+                            event_date,
+                            event_type,
+                            filing[2],
+                            filing[5],
+                            _timeline_summary(
+                                str(filing[2]),
+                                str(filing[3]),
+                                float(filing[5]) if filing[5] is not None else None,
+                            ),
+                            filing[7],
+                        ),
+                    )
+                else:
+                    conn.execute(
+                        "DELETE FROM activism_campaign_timeline WHERE campaign_id = %s AND filing_id = %s "
+                        "AND event_id IS NOT DISTINCT FROM %s",
+                        (campaign_id, filing_id, event_id),
+                    )
+                    conn.execute(
+                        "INSERT INTO activism_campaign_timeline(campaign_id, filing_id, event_id, event_date, "
+                        "event_type, form_type, ownership_pct, summary, source_url) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+                        (
+                            campaign_id,
+                            filing_id,
+                            event_id,
+                            event_date,
+                            event_type,
+                            filing[2],
+                            filing[5],
+                            _timeline_summary(
+                                str(filing[2]),
+                                str(filing[3]),
+                                float(filing[5]) if filing[5] is not None else None,
+                            ),
+                            filing[7],
+                        ),
+                    )
+                timeline_count += 1
+    conn.commit()
+    return CampaignRunSummary(
+        len(rows), len(grouped), timeline_count, sum(skipped.values()), dict(skipped)
+    )

--- a/etl/activism_campaign_flow.py
+++ b/etl/activism_campaign_flow.py
@@ -43,7 +43,8 @@ def ensure_activism_campaign_tables(conn: Any) -> None:
                 source_forms TEXT NOT NULL DEFAULT '[]',
                 data_quality_flags TEXT NOT NULL DEFAULT '[]',
                 computed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE(manager_id, target_identifier)
+                UNIQUE(manager_id, target_identifier),
+                CHECK (status IN ('active', 'monitoring', 'closed', 'unknown'))
             )""")
         conn.execute("""CREATE TABLE IF NOT EXISTS activism_campaign_timeline (
                 timeline_id INTEGER PRIMARY KEY,
@@ -72,10 +73,11 @@ def ensure_activism_campaign_tables(conn: Any) -> None:
                 filing_count INTEGER NOT NULL DEFAULT 0,
                 event_count INTEGER NOT NULL DEFAULT 0,
                 latest_event_type TEXT,
-                source_forms JSONB NOT NULL DEFAULT '[]'::jsonb,
-                data_quality_flags JSONB NOT NULL DEFAULT '[]'::jsonb,
+                source_forms TEXT NOT NULL DEFAULT '[]',
+                data_quality_flags TEXT NOT NULL DEFAULT '[]',
                 computed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE(manager_id, target_identifier)
+                UNIQUE(manager_id, target_identifier),
+                CHECK (status IN ('active', 'monitoring', 'closed', 'unknown'))
             )""")
         conn.execute("""CREATE TABLE IF NOT EXISTS activism_campaign_timeline (
                 timeline_id BIGSERIAL PRIMARY KEY,
@@ -88,7 +90,7 @@ def ensure_activism_campaign_tables(conn: Any) -> None:
                 ownership_pct NUMERIC(8,4),
                 summary TEXT NOT NULL,
                 source_url TEXT,
-                UNIQUE NULLS NOT DISTINCT(campaign_id, filing_id, event_id)
+                UNIQUE(campaign_id, filing_id, event_id)
             )""")
     else:
         raise TypeError(f"Unsupported database connection type: {type(conn)!r}")
@@ -101,6 +103,12 @@ def ensure_activism_campaign_tables(conn: Any) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_activism_campaign_timeline_campaign "
         "ON activism_campaign_timeline(campaign_id, event_date)"
+    )
+    # Both SQLite and PostgreSQL treat NULLs as distinct in a UNIQUE constraint, so the
+    # composite key above cannot stop duplicate filing-only rows. A partial index can.
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_activism_campaign_timeline_filing_only "
+        "ON activism_campaign_timeline(campaign_id, filing_id) WHERE event_id IS NULL"
     )
 
 
@@ -166,45 +174,29 @@ def _upsert_campaign(
         _json(forms),
         _json(flags),
     )
-    if is_sqlite(conn):
-        conn.execute(
-            "INSERT INTO activism_campaigns(manager_id, target_identifier, target_company, first_filed, "
-            "last_filed, status, peak_ownership_pct, latest_ownership_pct, filing_count, event_count, "
-            "latest_event_type, source_forms, data_quality_flags, computed_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP) "
-            "ON CONFLICT(manager_id, target_identifier) DO UPDATE SET "
-            "target_company=excluded.target_company, first_filed=excluded.first_filed, "
-            "last_filed=excluded.last_filed, status=excluded.status, peak_ownership_pct=excluded.peak_ownership_pct, "
-            "latest_ownership_pct=excluded.latest_ownership_pct, filing_count=excluded.filing_count, "
-            "event_count=excluded.event_count, latest_event_type=excluded.latest_event_type, "
-            "source_forms=excluded.source_forms, data_quality_flags=excluded.data_quality_flags, "
-            "computed_at=CURRENT_TIMESTAMP",
-            values,
+    conn.execute(
+        "INSERT INTO activism_campaigns(manager_id, target_identifier, target_company, first_filed, "
+        "last_filed, status, peak_ownership_pct, latest_ownership_pct, filing_count, event_count, "
+        "latest_event_type, source_forms, data_quality_flags, computed_at) "
+        f"VALUES ({', '.join([ph] * 13)}, CURRENT_TIMESTAMP) "
+        "ON CONFLICT(manager_id, target_identifier) DO UPDATE SET "
+        "target_company=excluded.target_company, first_filed=excluded.first_filed, "
+        "last_filed=excluded.last_filed, status=excluded.status, peak_ownership_pct=excluded.peak_ownership_pct, "
+        "latest_ownership_pct=excluded.latest_ownership_pct, filing_count=excluded.filing_count, "
+        "event_count=excluded.event_count, latest_event_type=excluded.latest_event_type, "
+        "source_forms=excluded.source_forms, data_quality_flags=excluded.data_quality_flags, "
+        "computed_at=CURRENT_TIMESTAMP",
+        values,
+    )
+    row = conn.execute(
+        f"SELECT campaign_id FROM activism_campaigns WHERE manager_id = {ph} AND target_identifier = {ph}",
+        (manager_id, target_identifier),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(
+            "activism campaign upsert did not yield a campaign_id for "
+            f"manager_id={manager_id} target_identifier={target_identifier!r}"
         )
-        row = conn.execute(
-            "SELECT campaign_id FROM activism_campaigns WHERE manager_id = ? AND target_identifier = ?",
-            (manager_id, target_identifier),
-        ).fetchone()
-    else:
-        conn.execute(
-            "INSERT INTO activism_campaigns(manager_id, target_identifier, target_company, first_filed, "
-            "last_filed, status, peak_ownership_pct, latest_ownership_pct, filing_count, event_count, "
-            "latest_event_type, source_forms, data_quality_flags, computed_at) "
-            f"VALUES ({', '.join([ph] * 13)}, CURRENT_TIMESTAMP) "
-            "ON CONFLICT(manager_id, target_identifier) DO UPDATE SET "
-            "target_company=excluded.target_company, first_filed=excluded.first_filed, "
-            "last_filed=excluded.last_filed, status=excluded.status, peak_ownership_pct=excluded.peak_ownership_pct, "
-            "latest_ownership_pct=excluded.latest_ownership_pct, filing_count=excluded.filing_count, "
-            "event_count=excluded.event_count, latest_event_type=excluded.latest_event_type, "
-            "source_forms=excluded.source_forms, data_quality_flags=excluded.data_quality_flags, "
-            "computed_at=CURRENT_TIMESTAMP",
-            values,
-        )
-        row = conn.execute(
-            f"SELECT campaign_id FROM activism_campaigns WHERE manager_id = {ph} AND target_identifier = {ph}",
-            (manager_id, target_identifier),
-        ).fetchone()
-    assert row is not None
     return int(row[0])
 
 
@@ -214,12 +206,10 @@ def materialize_activism_campaigns(conn: Any, since: date | None = None) -> Camp
         return CampaignRunSummary(skip_reasons={"missing_activism_filings_table": 1})
     ensure_activism_campaign_tables(conn)
     ph = get_placeholder(conn)
-    where = "WHERE af.filed_date >= " + ph if since else ""
     rows = conn.execute(
         "SELECT af.filing_id, af.manager_id, af.filing_type, af.subject_company, af.subject_cusip, "
         "af.ownership_pct, af.filed_date, af.url FROM activism_filings af "
-        f"{where} ORDER BY af.manager_id, af.subject_cusip, af.subject_company, af.filed_date, af.filing_id",
-        (since,) if since else (),
+        "ORDER BY af.manager_id, af.filed_date, af.filing_id"
     ).fetchall()
     events_by_filing: dict[int, list[tuple[Any, ...]]] = defaultdict(list)
     if table_exists(conn, "activism_events"):
@@ -237,11 +227,31 @@ def materialize_activism_campaigns(conn: Any, since: date | None = None) -> Camp
             continue
         grouped[(int(row[1]), identifier)].append(row)
 
+    # `since` selects which campaigns to refresh; each selected campaign is still
+    # recomputed from its full filing history so incremental runs cannot shrink
+    # aggregates such as filing_count or first_filed.
+    if since is not None:
+        cutoff = str(since)
+        grouped = defaultdict(
+            list,
+            {
+                key: filings
+                for key, filings in grouped.items()
+                if any(str(row[6]) >= cutoff for row in filings)
+            },
+        )
+
     timeline_count = 0
     for (manager_id, identifier), filings in grouped.items():
+        # Group members are collected across differing raw cusip/company spellings,
+        # so order inside the group by filing date rather than trusting the SQL sort.
+        filings.sort(key=lambda row: (str(row[6]), int(row[0])))
         first, latest = filings[0], filings[-1]
         ownerships = [float(row[5]) for row in filings if row[5] is not None]
-        events = [event for row in filings for event in events_by_filing[int(row[0])]]
+        events = sorted(
+            (event for row in filings for event in events_by_filing[int(row[0])]),
+            key=lambda event: (str(event[3]), int(event[0])),
+        )
         campaign_id = _upsert_campaign(
             conn,
             manager_id=manager_id,
@@ -258,69 +268,44 @@ def materialize_activism_campaigns(conn: Any, since: date | None = None) -> Camp
             forms=sorted({str(row[2]) for row in filings}),
             flags=_target_identifier(latest[4], latest[3])[1],
         )
+        insert_sql = (
+            "INSERT INTO activism_campaign_timeline(campaign_id, filing_id, event_id, event_date, "
+            "event_type, form_type, ownership_pct, summary, source_url) "
+            f"VALUES ({', '.join([ph] * 9)})"
+        )
         for filing in filings:
             filing_id = int(filing[0])
             event_rows = events_by_filing.get(filing_id) or [
                 (None, filing_id, "initial_filing", filing[6])
             ]
-            for event_id, _event_filing_id, event_type, detected_at in event_rows:
-                event_date = (
-                    str(detected_at).split("T", 1)[0] if event_id is not None else str(filing[6])
+            # Clear the whole filing rather than the rows about to be rewritten: a filing
+            # first materialized without events leaves an event_id IS NULL row that no
+            # later per-event delete would match.
+            conn.execute(
+                f"DELETE FROM activism_campaign_timeline WHERE campaign_id = {ph} AND filing_id = {ph}",
+                (campaign_id, filing_id),
+            )
+            for event_id, _event_filing_id, event_type, _detected_at in event_rows:
+                conn.execute(
+                    insert_sql,
+                    (
+                        campaign_id,
+                        filing_id,
+                        event_id,
+                        # detected_at records ingestion time, so the filing date is the
+                        # only stable ordering key for a backfilled timeline.
+                        str(filing[6]),
+                        event_type,
+                        filing[2],
+                        filing[5],
+                        _timeline_summary(
+                            str(filing[2]),
+                            str(filing[3]),
+                            float(filing[5]) if filing[5] is not None else None,
+                        ),
+                        filing[7],
+                    ),
                 )
-                if is_sqlite(conn):
-                    # SQLite UNIQUE constraints consider NULL values distinct, so a
-                    # filing-only timeline row (event_id NULL) needs an explicit
-                    # replacement to keep reruns append-safe.
-                    conn.execute(
-                        "DELETE FROM activism_campaign_timeline WHERE campaign_id = ? AND filing_id = ? "
-                        "AND event_id IS ?",
-                        (campaign_id, filing_id, event_id),
-                    )
-                    conn.execute(
-                        "INSERT INTO activism_campaign_timeline(campaign_id, filing_id, event_id, event_date, "
-                        "event_type, form_type, ownership_pct, summary, source_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
-                        "",
-                        (
-                            campaign_id,
-                            filing_id,
-                            event_id,
-                            event_date,
-                            event_type,
-                            filing[2],
-                            filing[5],
-                            _timeline_summary(
-                                str(filing[2]),
-                                str(filing[3]),
-                                float(filing[5]) if filing[5] is not None else None,
-                            ),
-                            filing[7],
-                        ),
-                    )
-                else:
-                    conn.execute(
-                        "DELETE FROM activism_campaign_timeline WHERE campaign_id = %s AND filing_id = %s "
-                        "AND event_id IS NOT DISTINCT FROM %s",
-                        (campaign_id, filing_id, event_id),
-                    )
-                    conn.execute(
-                        "INSERT INTO activism_campaign_timeline(campaign_id, filing_id, event_id, event_date, "
-                        "event_type, form_type, ownership_pct, summary, source_url) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
-                        (
-                            campaign_id,
-                            filing_id,
-                            event_id,
-                            event_date,
-                            event_type,
-                            filing[2],
-                            filing[5],
-                            _timeline_summary(
-                                str(filing[2]),
-                                str(filing[3]),
-                                float(filing[5]) if filing[5] is not None else None,
-                            ),
-                            filing[7],
-                        ),
-                    )
                 timeline_count += 1
     conn.commit()
     return CampaignRunSummary(

--- a/etl/activism_flow.py
+++ b/etl/activism_flow.py
@@ -327,7 +327,6 @@ async def fetch_activism_filings(manager_id: int, since: str) -> list[dict[str, 
         )
 
     conn.commit()
-    materialize_activism_campaigns(conn)
     conn.close()
     return inserted
 
@@ -343,6 +342,16 @@ async def fetch_all_managers(since: str) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
     for manager_id in manager_ids:
         rows.extend(await fetch_activism_filings.fn(manager_id, since))
+
+    # Materialization rebuilds every campaign it touches, so it runs once for the whole
+    # ingest rather than once per manager, and it must never discard committed filings.
+    conn = connect_db(DB_PATH)
+    try:
+        materialize_activism_campaigns(conn)
+    except Exception:
+        logger.exception("Activism campaign materialization failed", extra={"since": since})
+    finally:
+        conn.close()
     return rows
 
 

--- a/etl/activism_flow.py
+++ b/etl/activism_flow.py
@@ -20,6 +20,7 @@ from adapters.base import (
     resolve_manager_id_column,
 )
 from alerts.integration import fire_alerts_for_event
+from etl.activism_campaign_flow import materialize_activism_campaigns
 from etl.activism_detection import (
     ALERT_EVENT_TYPE,
     AlertEvent,
@@ -326,6 +327,7 @@ async def fetch_activism_filings(manager_id: int, since: str) -> list[dict[str, 
         )
 
     conn.commit()
+    materialize_activism_campaigns(conn)
     conn.close()
     return inserted
 

--- a/schema.sql
+++ b/schema.sql
@@ -139,7 +139,9 @@ CREATE TABLE IF NOT EXISTS activism_campaigns (
     source_forms text NOT NULL DEFAULT '[]',
     data_quality_flags text NOT NULL DEFAULT '[]',
     computed_at timestamptz NOT NULL DEFAULT now(),
-    UNIQUE (manager_id, target_identifier)
+    UNIQUE (manager_id, target_identifier),
+    CONSTRAINT ck_activism_campaigns_status
+        CHECK (status IN ('active', 'monitoring', 'closed', 'unknown'))
 );
 CREATE INDEX IF NOT EXISTS idx_activism_campaigns_manager ON activism_campaigns(manager_id);
 CREATE INDEX IF NOT EXISTS idx_activism_campaigns_status ON activism_campaigns(status);
@@ -159,6 +161,8 @@ CREATE TABLE IF NOT EXISTS activism_campaign_timeline (
 );
 CREATE INDEX IF NOT EXISTS idx_activism_campaign_timeline_campaign
     ON activism_campaign_timeline(campaign_id, event_date);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_activism_campaign_timeline_filing_only
+    ON activism_campaign_timeline (campaign_id, filing_id) WHERE event_id IS NULL;
 
 CREATE TABLE IF NOT EXISTS holdings (
     holding_id bigserial PRIMARY KEY,

--- a/schema.sql
+++ b/schema.sql
@@ -123,6 +123,43 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_activism_events_unique_threshold
     ON activism_events (manager_id, filing_id, event_type, threshold_crossed)
     WHERE threshold_crossed IS NOT NULL;
 
+CREATE TABLE IF NOT EXISTS activism_campaigns (
+    campaign_id bigserial PRIMARY KEY,
+    manager_id bigint NOT NULL REFERENCES managers(manager_id),
+    target_identifier text NOT NULL,
+    target_company text NOT NULL,
+    first_filed date NOT NULL,
+    last_filed date NOT NULL,
+    status text NOT NULL,
+    peak_ownership_pct numeric(8,4),
+    latest_ownership_pct numeric(8,4),
+    filing_count integer NOT NULL DEFAULT 0,
+    event_count integer NOT NULL DEFAULT 0,
+    latest_event_type text,
+    source_forms text NOT NULL DEFAULT '[]',
+    data_quality_flags text NOT NULL DEFAULT '[]',
+    computed_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (manager_id, target_identifier)
+);
+CREATE INDEX IF NOT EXISTS idx_activism_campaigns_manager ON activism_campaigns(manager_id);
+CREATE INDEX IF NOT EXISTS idx_activism_campaigns_status ON activism_campaigns(status);
+
+CREATE TABLE IF NOT EXISTS activism_campaign_timeline (
+    timeline_id bigserial PRIMARY KEY,
+    campaign_id bigint NOT NULL REFERENCES activism_campaigns(campaign_id),
+    filing_id bigint NOT NULL REFERENCES activism_filings(filing_id),
+    event_id bigint REFERENCES activism_events(event_id),
+    event_date date NOT NULL,
+    event_type text NOT NULL,
+    form_type text NOT NULL,
+    ownership_pct numeric(8,4),
+    summary text NOT NULL,
+    source_url text,
+    UNIQUE (campaign_id, filing_id, event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_activism_campaign_timeline_campaign
+    ON activism_campaign_timeline(campaign_id, event_date);
+
 CREATE TABLE IF NOT EXISTS holdings (
     holding_id bigserial PRIMARY KEY,
     filing_id bigint NOT NULL REFERENCES filings(filing_id),

--- a/tests/test_activism_api.py
+++ b/tests/test_activism_api.py
@@ -8,6 +8,7 @@ import httpx
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from api.activism import query_activism_campaigns
 from api.chat import app
 from etl.activism_campaign_flow import materialize_activism_campaigns
 from tests.route_helpers import route_paths
@@ -309,4 +310,60 @@ def test_campaign_endpoints_return_grouped_timeline(tmp_path, monkeypatch):
 
     timeline = asyncio.run(_request(f"/api/activism/campaigns/{campaign['campaign_id']}/timeline"))
     assert timeline.status_code == 200
-    assert [entry["form_type"] for entry in timeline.json()] == ["SC 13D", "SC 13D/A", "SC 13D/A"]
+    entries = timeline.json()
+    assert [entry["form_type"] for entry in entries] == ["SC 13D", "SC 13D/A", "SC 13D/A"]
+    # Ordering is deterministic by filing date, so the two amendment events cannot swap.
+    assert [entry["event_type"] for entry in entries] == [
+        "initial_stake",
+        "threshold_crossing",
+        "stake_increase",
+    ]
+    assert [entry["event_date"] for entry in entries] == [
+        "2024-05-01",
+        "2024-05-03",
+        "2024-05-03",
+    ]
+
+
+def test_campaign_list_applies_target_date_and_limit_filters(tmp_path, monkeypatch):
+    db_path = tmp_path / "activism.db"
+    _seed_db(db_path)
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    by_target = asyncio.run(
+        _request("/api/activism/campaigns", params={"target_identifier": "88160r101"})
+    )
+    assert by_target.status_code == 200
+    assert [row["target_company"] for row in by_target.json()] == ["Tesla, Inc."]
+
+    filed_from = asyncio.run(
+        _request("/api/activism/campaigns", params={"filed_from": "2024-05-03"})
+    )
+    assert [row["target_identifier"] for row in filed_from.json()] == ["037833100"]
+
+    filed_to = asyncio.run(_request("/api/activism/campaigns", params={"filed_to": "2024-05-01"}))
+    assert [row["target_identifier"] for row in filed_to.json()] == ["037833100"]
+
+    limited = asyncio.run(_request("/api/activism/campaigns", params={"limit": 1}))
+    assert len(limited.json()) == 1
+
+
+def test_campaign_query_drops_non_finite_ownership(tmp_path):
+    """SQLite REAL keeps Infinity; every consumer of the query layer must see None."""
+    db_path = tmp_path / "activism.db"
+    _seed_db(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE activism_campaigns SET peak_ownership_pct = 1e999, "
+            "latest_ownership_pct = 1e999 WHERE target_identifier = '037833100'"
+        )
+        conn.commit()
+
+        campaigns = query_activism_campaigns(conn, target_identifier="037833100")
+    finally:
+        conn.close()
+
+    assert len(campaigns) == 1
+    assert campaigns[0].peak_ownership_pct is None
+    assert campaigns[0].latest_ownership_pct is None

--- a/tests/test_activism_api.py
+++ b/tests/test_activism_api.py
@@ -9,6 +9,7 @@ import httpx
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from api.chat import app
+from etl.activism_campaign_flow import materialize_activism_campaigns
 from tests.route_helpers import route_paths
 
 
@@ -174,6 +175,7 @@ def _seed_db(db_path: Path) -> None:
                 ),
             ],
         )
+        materialize_activism_campaigns(conn)
         conn.commit()
     finally:
         conn.close()
@@ -189,6 +191,9 @@ def test_activism_router_is_registered(tmp_path, monkeypatch):
         "/api/activism/events",
         "/api/activism/timeline/{manager_id}",
         "/api/activism/active-campaigns",
+        "/api/activism/campaigns",
+        "/api/activism/campaigns/{campaign_id}",
+        "/api/activism/campaigns/{campaign_id}/timeline",
     }
     assert expected_paths.issubset(route_paths(app.routes))
 
@@ -279,3 +284,29 @@ def test_active_campaigns_applies_threshold(tmp_path, monkeypatch):
     assert payload[0]["subject_company"] == "Apple Inc."
     assert payload[0]["event_count"] == 3
     assert payload[0]["latest_event_type"] == "stake_increase"
+
+
+def test_campaign_endpoints_return_grouped_timeline(tmp_path, monkeypatch):
+    db_path = tmp_path / "activism.db"
+    _seed_db(db_path)
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    response = asyncio.run(
+        _request("/api/activism/campaigns", params={"manager_id": 1, "status": "active"})
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    campaign = payload[0]
+    assert campaign["target_identifier"] == "037833100"
+    assert campaign["filing_count"] == 2
+    assert campaign["first_filed"] == "2024-05-01"
+    assert campaign["last_filed"] == "2024-05-03"
+
+    detail = asyncio.run(_request(f"/api/activism/campaigns/{campaign['campaign_id']}"))
+    assert detail.status_code == 200
+    assert detail.json()["target_company"] == "Apple Inc."
+
+    timeline = asyncio.run(_request(f"/api/activism/campaigns/{campaign['campaign_id']}/timeline"))
+    assert timeline.status_code == 200
+    assert [entry["form_type"] for entry in timeline.json()] == ["SC 13D", "SC 13D/A", "SC 13D/A"]

--- a/tests/test_activism_campaign_flow.py
+++ b/tests/test_activism_campaign_flow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from datetime import date
 
 from etl.activism_campaign_flow import materialize_activism_campaigns
 
@@ -52,6 +53,98 @@ def test_materialize_campaigns_groups_amendments_by_manager_and_target() -> None
         ("2024-05-01", "initial_filing", "SC 13D"),
         ("2024-05-03", "threshold_crossing", "SC 13D/A"),
     ]
+
+
+def test_materialize_campaigns_orders_group_members_by_filing_date() -> None:
+    """Case-only cusip differences group together but sort apart in raw SQL order."""
+    conn = _conn()
+    conn.executemany(
+        "INSERT INTO activism_filings VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1, 1, "SC 13D", "Tesla, Inc.", "88160r101", 5.1, "2024-05-01", "https://sec/1"),
+            (2, 1, "SC 13G", "Tesla, Inc.", "88160R101", 3.2, "2024-05-05", "https://sec/2"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO activism_events VALUES (?, ?, ?, ?)",
+        [
+            (10, 2, "stake_decrease", "2024-05-05T09:00:00"),
+            (11, 1, "initial_stake", "2024-06-01T09:00:00"),
+        ],
+    )
+
+    materialize_activism_campaigns(conn)
+
+    row = conn.execute(
+        "SELECT first_filed, last_filed, status, latest_ownership_pct, latest_event_type "
+        "FROM activism_campaigns"
+    ).fetchone()
+    assert row == ("2024-05-01", "2024-05-05", "monitoring", 3.2, "initial_stake")
+
+
+def test_materialize_campaigns_dates_timeline_by_filing_not_detection() -> None:
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO activism_filings VALUES "
+        "(1, 1, 'SC 13D', 'Example Corp', '123456789', 5.1, '2024-05-01', 'https://sec/1')"
+    )
+    conn.execute(
+        "INSERT INTO activism_events VALUES (10, 1, 'initial_stake', '2026-01-15T09:00:00')"
+    )
+
+    materialize_activism_campaigns(conn)
+
+    assert conn.execute("SELECT event_date FROM activism_campaign_timeline").fetchall() == [
+        ("2024-05-01",)
+    ]
+
+
+def test_materialize_campaigns_rerun_replaces_filing_only_timeline_rows() -> None:
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO activism_filings VALUES "
+        "(1, 1, 'SC 13D', 'Example Corp', '123456789', 5.1, '2024-05-01', 'https://sec/1')"
+    )
+
+    first = materialize_activism_campaigns(conn)
+    assert first.timeline_rows_written == 1
+
+    # The filing gains an event only after its first materialization.
+    conn.execute(
+        "INSERT INTO activism_events VALUES (10, 1, 'initial_stake', '2024-05-02T09:00:00')"
+    )
+    second = materialize_activism_campaigns(conn)
+
+    assert second.timeline_rows_written == 1
+    rows = conn.execute("SELECT event_id, event_type FROM activism_campaign_timeline").fetchall()
+    assert rows == [(10, "initial_stake")]
+
+    # A third pass with no source change must stay append-safe.
+    materialize_activism_campaigns(conn)
+    assert conn.execute("SELECT COUNT(*) FROM activism_campaign_timeline").fetchone() == (1,)
+
+
+def test_materialize_campaigns_since_recomputes_full_campaign_history() -> None:
+    conn = _conn()
+    conn.executemany(
+        "INSERT INTO activism_filings VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1, 1, "SC 13D", "Example Corp", "123456789", 5.1, "2024-05-01", "https://sec/1"),
+            (2, 1, "SC 13D/A", "Example Corp", "123456789", 9.4, "2024-05-03", "https://sec/2"),
+            (3, 2, "SC 13G", "Other Corp", "987654321", 4.0, "2024-01-02", "https://sec/3"),
+        ],
+    )
+    materialize_activism_campaigns(conn)
+
+    summary = materialize_activism_campaigns(conn, since=date(2024, 5, 3))
+
+    # Only the campaign touched since the cutoff is refreshed ...
+    assert summary.campaigns_written == 1
+    # ... and it keeps the aggregates of its full history, not of the filtered slice.
+    assert conn.execute(
+        "SELECT filing_count, first_filed, peak_ownership_pct FROM activism_campaigns "
+        "WHERE target_identifier = '123456789'"
+    ).fetchone() == (2, "2024-05-01", 9.4)
 
 
 def test_materialize_campaigns_keeps_missing_cusip_names_separate() -> None:

--- a/tests/test_activism_campaign_flow.py
+++ b/tests/test_activism_campaign_flow.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sqlite3
+
+from etl.activism_campaign_flow import materialize_activism_campaigns
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute(
+        "CREATE TABLE activism_filings (filing_id INTEGER PRIMARY KEY, manager_id INTEGER, "
+        "filing_type TEXT, subject_company TEXT, subject_cusip TEXT, ownership_pct REAL, "
+        "filed_date TEXT, url TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE activism_events (event_id INTEGER PRIMARY KEY, filing_id INTEGER, "
+        "event_type TEXT, detected_at TEXT)"
+    )
+    conn.execute("INSERT INTO managers VALUES (1, 'Activist')")
+    return conn
+
+
+def test_materialize_campaigns_groups_amendments_by_manager_and_target() -> None:
+    conn = _conn()
+    conn.executemany(
+        "INSERT INTO activism_filings VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1, 1, "SC 13D", "Example Corp", "123456789", 5.1, "2024-05-01", "https://sec/1"),
+            (2, 1, "SC 13D/A", "Example Corp", "123456789", 9.4, "2024-05-03", "https://sec/2"),
+            (3, 1, "SC 13G", "Other Corp", "987654321", 4.0, "2024-05-02", "https://sec/3"),
+        ],
+    )
+    conn.execute(
+        "INSERT INTO activism_events VALUES (10, 2, 'threshold_crossing', '2024-05-03T09:00:00')"
+    )
+
+    summary = materialize_activism_campaigns(conn)
+
+    assert summary.campaigns_written == 2
+    campaigns = conn.execute(
+        "SELECT target_identifier, status, filing_count, peak_ownership_pct FROM activism_campaigns "
+        "ORDER BY target_identifier"
+    ).fetchall()
+    assert campaigns == [("123456789", "active", 2, 9.4), ("987654321", "monitoring", 1, 4.0)]
+    timeline = conn.execute(
+        "SELECT event_date, event_type, form_type FROM activism_campaign_timeline "
+        "WHERE campaign_id = (SELECT campaign_id FROM activism_campaigns WHERE target_identifier = '123456789') "
+        "ORDER BY event_date, form_type, event_id"
+    ).fetchall()
+    assert timeline == [
+        ("2024-05-01", "initial_filing", "SC 13D"),
+        ("2024-05-03", "threshold_crossing", "SC 13D/A"),
+    ]
+
+
+def test_materialize_campaigns_keeps_missing_cusip_names_separate() -> None:
+    conn = _conn()
+    conn.executemany(
+        "INSERT INTO activism_filings VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1, 1, "SC 13D", "Alpha Holdings", None, 5.1, "2024-05-01", "https://sec/1"),
+            (2, 1, "SC 13D", "Beta Holdings", None, 5.1, "2024-05-01", "https://sec/2"),
+        ],
+    )
+
+    materialize_activism_campaigns(conn)
+
+    rows = conn.execute(
+        "SELECT target_identifier, data_quality_flags FROM activism_campaigns ORDER BY target_identifier"
+    ).fetchall()
+    assert rows == [
+        ("name:ALPHA HOLDINGS", '["missing_cusip"]'),
+        ("name:BETA HOLDINGS", '["missing_cusip"]'),
+    ]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -19,6 +19,8 @@ EXPECTED_TABLES = {
     "filings",
     "activism_filings",
     "activism_events",
+    "activism_campaigns",
+    "activism_campaign_timeline",
     "alert_rules",
     "alert_history",
     "chat_feedback",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9,6 +9,7 @@ from alembic.config import Config
 
 from adapters.prices import ensure_price_cache_table
 from alembic import command
+from etl.activism_campaign_flow import ensure_activism_campaign_tables
 from etl.backtest_flow import ensure_backtest_tables
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -67,6 +68,117 @@ def test_schema_upgrade_creates_expected_objects(monkeypatch, tmp_path):
             for row in conn.execute("SELECT name FROM sqlite_master WHERE type='view'").fetchall()
         }
         assert EXPECTED_VIEWS.issubset(views), f"Missing views: {EXPECTED_VIEWS - views}"
+
+
+def test_activism_campaign_migration_generates_sqlite_primary_keys(monkeypatch, tmp_path):
+    """Migration 015 must assign campaign/timeline IDs without callers supplying them."""
+    monkeypatch.delenv("DB_URL", raising=False)
+    db_path = tmp_path / "schema.db"
+    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("INSERT INTO managers(manager_id, name) VALUES (1, 'Activist')")
+        conn.execute(
+            "INSERT INTO activism_filings(filing_id, manager_id, filing_type, subject_company, "
+            "filed_date, url) VALUES (1, 1, 'SC 13D', 'Example Corp', '2024-05-01', "
+            "'https://sec.example/1')"
+        )
+        campaign = conn.execute(
+            "INSERT INTO activism_campaigns(manager_id, target_identifier, target_company, "
+            "first_filed, last_filed, status) VALUES (1, '123456789', 'Example Corp', "
+            "'2024-05-01', '2024-05-01', 'active')"
+        )
+        assert campaign.lastrowid is not None
+        timeline = conn.execute(
+            "INSERT INTO activism_campaign_timeline(campaign_id, filing_id, event_date, "
+            "event_type, form_type, summary) VALUES (?, 1, '2024-05-01', 'initial_filing', "
+            "'SC 13D', 'Filed SC 13D for Example Corp.')",
+            (campaign.lastrowid,),
+        )
+        assert timeline.lastrowid is not None
+
+
+def test_activism_campaign_migration_constrains_status_and_filing_only_rows(monkeypatch, tmp_path):
+    monkeypatch.delenv("DB_URL", raising=False)
+    db_path = tmp_path / "schema.db"
+    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("INSERT INTO managers(manager_id, name) VALUES (1, 'Activist')")
+        conn.execute(
+            "INSERT INTO activism_filings(filing_id, manager_id, filing_type, subject_company, "
+            "filed_date, url) VALUES (1, 1, 'SC 13D', 'Example Corp', '2024-05-01', "
+            "'https://sec.example/1')"
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO activism_campaigns(manager_id, target_identifier, target_company, "
+                "first_filed, last_filed, status) VALUES (1, '123456789', 'Example Corp', "
+                "'2024-05-01', '2024-05-01', 'bogus')"
+            )
+        campaign = conn.execute(
+            "INSERT INTO activism_campaigns(manager_id, target_identifier, target_company, "
+            "first_filed, last_filed, status) VALUES (1, '123456789', 'Example Corp', "
+            "'2024-05-01', '2024-05-01', 'active')"
+        )
+        insert_filing_only = (
+            "INSERT INTO activism_campaign_timeline(campaign_id, filing_id, event_date, "
+            "event_type, form_type, summary) VALUES (?, 1, '2024-05-01', 'initial_filing', "
+            "'SC 13D', 'Filed SC 13D for Example Corp.')"
+        )
+        conn.execute(insert_filing_only, (campaign.lastrowid,))
+        # event_id IS NULL rows are not deduplicated by the composite UNIQUE constraint.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(insert_filing_only, (campaign.lastrowid,))
+
+
+def test_activism_campaign_migration_uses_timezone_aware_computed_at():
+    """schema.sql declares timestamptz; the migration must not drift to a naive type."""
+    migration = (ROOT / "alembic" / "versions" / "016_activism_campaigns.py").read_text(
+        encoding="utf-8"
+    )
+    computed_at = re.search(r'"computed_at",\s*(sa\.DateTime\([^)]*\))', migration)
+    assert computed_at is not None
+    assert computed_at.group(1) == "sa.DateTime(timezone=True)"
+
+
+def test_activism_campaign_definitions_stay_in_sync(monkeypatch, tmp_path):
+    """Keep migration, runtime SQLite DDL, and canonical schema.sql column sets aligned."""
+    monkeypatch.delenv("DB_URL", raising=False)
+    db_path = tmp_path / "migrated.db"
+    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+
+    tables = {"activism_campaigns", "activism_campaign_timeline"}
+    with sqlite3.connect(db_path) as migrated, sqlite3.connect(":memory:") as runtime:
+        ensure_activism_campaign_tables(runtime)
+        migrated_columns = {
+            table: {row[1] for row in migrated.execute(f"PRAGMA table_info({table})")}
+            for table in tables
+        }
+        runtime_columns = {
+            table: {row[1] for row in runtime.execute(f"PRAGMA table_info({table})")}
+            for table in tables
+        }
+
+    schema = (ROOT / "schema.sql").read_text(encoding="utf-8")
+    schema_columns = {}
+    for table in tables:
+        definition = re.search(
+            rf"CREATE TABLE IF NOT EXISTS {table} \((.*?)\n\);", schema, flags=re.DOTALL
+        )
+        assert definition is not None
+        schema_columns[table] = {
+            line.strip().split()[0]
+            for line in definition.group(1).splitlines()
+            if line.strip()
+            and not line.lstrip().startswith(
+                ("PRIMARY", "FOREIGN", "UNIQUE", "CONSTRAINT", "CHECK")
+            )
+        }
+
+    assert runtime_columns == migrated_columns == schema_columns
 
 
 def test_schema_foreign_keys(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #1466

## Summary

- adds a durable `activism_campaigns` read model and linked deterministic timeline rows, with Alembic 015 and `schema.sql` parity;
- materializes 13D/13G filing families by manager plus target identifier, retaining CUSIP-missing quality flags and lifecycle status;
- exposes campaign list, detail, and timeline endpoints while leaving the existing active-campaigns route intact.

## Acceptance evidence

- [x] 13D plus 13D/A for one manager/issuer produce one ordered campaign timeline.
- [x] Separate manager/issuer pairs remain separate campaigns.
- [x] Missing-CUSIP fallbacks are explicit and remain distinct by normalized company name.
- [x] Migration and `schema.sql` include the campaign and timeline tables.
- [x] Read-only campaign list, detail, and timeline API routes are covered.
- [x] Deliberate break: collapsing target identity to a manager-only constant fails the grouping test (`1 != 2`); reverted before the final run.

## Validation

- `pytest -q tests/test_activism_campaign_flow.py tests/test_activism_api.py tests/test_schema.py tests/test_activism_dialect_portability.py` (19 passed)
- `ruff check` on changed Python files
- `black --check --target-version py312` on changed Python files

## Non-goals

No campaign returns, public price redistribution, letters/agreement archive, or campaign-success scoring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added activism campaign tracking with summaries, ownership metrics, statuses, and data-quality indicators.
  * Added chronological campaign timelines covering related filings, events, forms, dates, and summaries.
  * Added API endpoints to list campaigns, view campaign details, and retrieve timelines.
  * Campaign data is automatically generated from newly ingested activism filings and events.
* **Bug Fixes**
  * Added filtering by campaign, manager, target, status, and filing date.
  * Improved handling of incomplete source data, including name-based campaigns without identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->