### PR TITLE
test(conviction): stop reloaded conviction_flow env overrides leaking across tests

### DIFF
--- a/tests/test_crowded_contrarian.py
+++ b/tests/test_crowded_contrarian.py
@@ -482,11 +482,30 @@ def test_conviction_flow_runs_scoring_then_crowded_then_contrarian_then_alerts(m
     }
 
 
-def test_conviction_flow_deployment_uses_nightly_defaults(monkeypatch):
+@pytest.fixture
+def reload_conviction_module(monkeypatch):
+    """Reload ``etl.conviction_flow``, then restore the module for later tests.
+
+    The module resolves its deployment cron/timezone from the environment at
+    import time, so a reload under patched env vars would otherwise leave the
+    overridden schedule on the shared module object for the rest of the session.
+    """
+
+    def _reload():
+        return importlib.reload(conviction_module)
+
+    yield _reload
+
+    monkeypatch.delenv("CONVICTION_FLOW_CRON", raising=False)
+    monkeypatch.delenv("CONVICTION_FLOW_TIMEZONE", raising=False)
+    importlib.reload(conviction_module)
+
+
+def test_conviction_flow_deployment_uses_nightly_defaults(monkeypatch, reload_conviction_module):
     monkeypatch.delenv("CONVICTION_FLOW_CRON", raising=False)
     monkeypatch.delenv("CONVICTION_FLOW_TIMEZONE", raising=False)
     monkeypatch.setenv("TZ", "UTC")
-    module = importlib.reload(conviction_module)
+    module = reload_conviction_module()
 
     assert module.CONVICTION_FLOW_NIGHTLY_CRON == "0 2 * * *"
     assert module.CONVICTION_FLOW_TIMEZONE == "UTC"
@@ -495,13 +514,22 @@ def test_conviction_flow_deployment_uses_nightly_defaults(monkeypatch):
     assert schedule.timezone == "UTC"
 
 
-def test_conviction_flow_deployment_allows_env_overrides(monkeypatch):
+def test_conviction_flow_deployment_allows_env_overrides(monkeypatch, reload_conviction_module):
     monkeypatch.setenv("CONVICTION_FLOW_CRON", "15 3 * * *")
     monkeypatch.setenv("CONVICTION_FLOW_TIMEZONE", "America/New_York")
-    module = importlib.reload(conviction_module)
+    module = reload_conviction_module()
 
     assert module.CONVICTION_FLOW_NIGHTLY_CRON == "15 3 * * *"
     assert module.CONVICTION_FLOW_TIMEZONE == "America/New_York"
     schedule = module.conviction_flow_deployment.schedules[0].schedule
     assert schedule.cron == "15 3 * * *"
     assert schedule.timezone == "America/New_York"
+
+
+def test_conviction_module_schedule_restored_after_env_override_reload():
+    """Guards ``tests/test_conviction_flow.py`` against leaked reload state."""
+    assert conviction_module.CONVICTION_FLOW_NIGHTLY_CRON == "0 2 * * *"
+    assert conviction_module.CONVICTION_FLOW_TIMEZONE != "America/New_York"
+    schedule = conviction_module.conviction_deployment.schedules[0].schedule
+    assert schedule.cron == "0 2 * * *"
+    assert schedule.timezone != "America/New_York"


### PR DESCRIPTION
## Problem

`tests/test_crowded_contrarian.py` reloads `etl.conviction_flow` while `CONVICTION_FLOW_CRON` / `CONVICTION_FLOW_TIMEZONE` are monkeypatched, and never restores the module. Because the module resolves its deployment schedule from the environment at import time:

```python
CONVICTION_FLOW_NIGHTLY_CRON = os.getenv("CONVICTION_FLOW_CRON", "0 2 * * *")
CONVICTION_FLOW_TIMEZONE = os.getenv("CONVICTION_FLOW_TIMEZONE", os.getenv("TZ", "UTC"))
conviction_flow_deployment = conviction_flow.to_deployment(..., schedule=Cron(...))
```

the overridden schedule stays on the shared module object for the rest of the pytest session. Any later test that reads the module-level deployment then sees `15 3 * * *` / `America/New_York`.

Reproduced on current `main` (`872569b`):

```
$ pytest -o addopts= tests/test_crowded_contrarian.py tests/test_conviction_flow.py::test_conviction_deployment_nightly_utc_schedule
FAILED tests/test_conviction_flow.py::test_conviction_deployment_nightly_utc_schedule
E       AssertionError: assert '15 3 * * *' == '0 2 * * *'
```

CI has been green only by accident of collection order: pytest collects files alphabetically, so `test_conviction_flow.py` runs *before* `test_crowded_contrarian.py`. Any reordering, sharding, `-p randomly`, or `-k`/path selection that puts the crowding tests first turns this into a confusing red that looks like a scheduling bug rather than test pollution.

## Fix

A `reload_conviction_module` fixture owns the reload and restores the pristine module on teardown by dropping the env overrides and reloading again. Both deployment tests now go through it. The teardown deliberately does **not** force `TZ`, so the restored timezone matches whatever the module saw at original import.

A new regression test, `test_conviction_module_schedule_restored_after_env_override_reload`, runs right after the override test and asserts the shared module is back to the nightly default — this is the gate that fails if the restore is ever dropped again.

## Test gate

- Previously failing order now passes: `pytest -o addopts= tests/test_crowded_contrarian.py tests/test_manager_similarity_flow.py tests/test_conviction_flow.py tests/test_alert_engine.py` = **38 passed** (was 1 failed / 36 passed on `main`).
- Narrow repro passes: `pytest -o addopts= tests/test_crowded_contrarian.py tests/test_conviction_flow.py::test_conviction_deployment_nightly_utc_schedule` = **16 passed**.
- CI's alphabetical order still passes: `pytest -o addopts= tests/test_alert_engine.py tests/test_conviction_flow.py tests/test_crowded_contrarian.py tests/test_manager_similarity_flow.py` = **38 passed**.
- **Deliberate-break demonstration:** with the teardown `importlib.reload` removed, the narrow repro fails on *both* the new gate and the original victim test —
  `FAILED tests/test_crowded_contrarian.py::test_conviction_module_schedule_restored_after_env_override_reload` and
  `FAILED tests/test_conviction_flow.py::test_conviction_deployment_nightly_utc_schedule` (2 failed, 14 passed). The break was reverted and the suite re-run green.
- `ruff check` clean; `black --check` clean; `git diff --check` clean.

## Scope

Tests only — one file, +32/-4. No production module, migration, or schema change. Found by the closer lane while validating the rebase of #1498 onto `main` after #1497 merged; kept out of that PR because it is unrelated to the short-interest feature.
