### PR TITLE
feat(llm): support profile slots so the chat path tracks reviewed selections

### DIFF
--- a/config/llm_slots.json
+++ b/config/llm_slots.json
@@ -3,17 +3,17 @@
     {
       "name": "slot1",
       "provider": "openai",
-      "model": "gpt-5.4"
+      "profile": "verifier-balanced"
     },
     {
       "name": "slot2",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-6"
+      "profile": "verifier-balanced"
     },
     {
       "name": "slot3",
       "provider": "github-models",
-      "model": "codex-mini-latest"
+      "profile": "verifier-balanced"
     }
   ]
 }

--- a/llm/client.py
+++ b/llm/client.py
@@ -139,8 +139,25 @@ def _load_slot_config() -> list[SlotDefinition]:
             continue
         provider = _normalize_provider(str(entry.get("provider", "")))
         model = str(entry.get("model", "")).strip()
+        profile = str(entry.get("profile") or "").strip()
         tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()
-        if provider and not model and tier:
+        if provider and not model and profile:
+            # A profile slot resolves to the single reviewed selection for that
+            # profile/provider, mirroring tools/llm_registry.load_slot_config.
+            # Without this, a profile-driven slot file (the form Workflows now
+            # ships) resolves to nothing here and the chat path serves no model.
+            model = (
+                _llm_registry.select_model_for_profile(
+                    provider=provider, profile=profile, registry=registry
+                )
+                or ""
+            )
+            if not model:
+                logger.warning(
+                    "Skipping slot with unresolved reviewed profile: %s/%s", profile, provider
+                )
+                continue
+        elif provider and not model and tier:
             model = select_model_for_tier(provider=provider, tier=tier, registry=registry) or ""
         if not provider or not model:
             continue

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -65,6 +65,22 @@ def _write_lifecycle_registry(tmp_path) -> str:
     return str(registry_path)
 
 
+def _reviewed_model(provider: str) -> str:
+    """Return the registry's reviewed ``verifier-balanced`` selection for a provider.
+
+    Tests that exercise the *ambient* config must assert the resolver serves the
+    reviewed selection, not a hardcoded model id. Pinning literals here meant a
+    synced model-registry refresh (which advances the reviewed selection) turned
+    into a CI failure with no underlying defect. Hermetic tests below that write
+    their own registry/slot fixtures keep using explicit ids on purpose.
+    """
+    from tools.llm_registry import select_model_for_profile
+
+    model = select_model_for_profile(provider=provider)
+    assert model, f"no reviewed selection for {provider}; registry is misconfigured"
+    return model
+
+
 class _FakeClient:
     pass
 
@@ -78,7 +94,7 @@ def test_build_chat_client_returns_openai_when_key_available(monkeypatch):
 
     assert client_info is not None
     assert client_info.provider == "openai"
-    assert client_info.model == "gpt-5.4"
+    assert client_info.model == _reviewed_model("openai")
 
 
 def test_build_chat_client_falls_back_to_anthropic(monkeypatch):
@@ -90,7 +106,7 @@ def test_build_chat_client_falls_back_to_anthropic(monkeypatch):
 
     assert client_info is not None
     assert client_info.provider == "anthropic"
-    assert client_info.model == "claude-opus-4-6"
+    assert client_info.model == _reviewed_model("anthropic")
 
 
 def test_build_chat_client_returns_none_when_no_keys(monkeypatch):
@@ -300,3 +316,86 @@ def test_blank_slot_env_model_falls_back_to_slot_model(monkeypatch, tmp_path):
     assert client_info.provider == "openai"
     assert client_info.model == "gpt-5.4"
     assert captured == ["gpt-5.4"]
+
+
+def test_profile_slot_resolves_reviewed_selection(monkeypatch, tmp_path):
+    """A profile-driven slot file must resolve via the reviewed selection.
+
+    Workflows now ships config/llm_slots.json in profile form (no model pins).
+    Before profile support existed here, such a file resolved to zero slots and
+    the chat path served no model at all.
+    """
+    registry_path = tmp_path / "model_registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "model_id": "gpt-reviewed",
+                        "provider": "openai",
+                        "lifecycle": "current",
+                    }
+                ],
+                "selections": [
+                    {
+                        "profile": "verifier-balanced",
+                        "provider": "openai",
+                        "model_id": "gpt-reviewed",
+                        "status": "provisional",
+                        "evidence_ids": ["catalog-review"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "llm_slots.json"
+    config_path.write_text(
+        json.dumps(
+            {"slots": [{"name": "slot1", "provider": "openai", "profile": "verifier-balanced"}]}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
+    monkeypatch.setenv(ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("MANAGER_DB_ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(llm_client, "create_llm", lambda config: _FakeClient())
+
+    client_info = llm_client.build_chat_client()
+
+    assert client_info is not None
+    assert client_info.provider == "openai"
+    assert client_info.model == "gpt-reviewed"
+
+
+def test_profile_slot_with_unresolvable_profile_fails_closed(monkeypatch, tmp_path):
+    """A profile with no reviewed selection must not fall back to a default model."""
+    registry_path = tmp_path / "model_registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "models": [{"model_id": "gpt-5.4", "provider": "openai", "lifecycle": "current"}],
+                "selections": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "llm_slots.json"
+    config_path.write_text(
+        json.dumps(
+            {"slots": [{"name": "slot1", "provider": "openai", "profile": "verifier-balanced"}]}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGCHAIN_SLOT_CONFIG", str(config_path))
+    monkeypatch.setenv(ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv("MANAGER_DB_OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("MANAGER_DB_ANTHROPIC_API_KEY", raising=False)
+
+    def _fail(config):
+        raise AssertionError(f"unresolved profile slot reached create_llm: {config.model_name}")
+
+    monkeypatch.setattr(llm_client, "create_llm", _fail)
+
+    assert llm_client.build_chat_client() is None


### PR DESCRIPTION
## Why

Manager-Database was pinned to frozen model ids and would **not** pick up an advanced reviewed selection. Two independent causes, both verified against `main`:

1. **`config/llm_slots.json` pins don't track the registry.** The shared resolver deliberately *retains* an unprofiled pin while the pinned model is still `lifecycle: current` (`tools/llm_registry.py`, the `explicit_entry ... lifecycle == "current"` branch). Probed with a registry whose selections had advanced:

   | slot | pinned | resolved | why |
   |---|---|---|---|
   | slot1 openai | `gpt-5.4` | **`gpt-5.4`** | pin still `current` → retained |
   | slot2 anthropic | `claude-sonnet-4-6` | `claude-sonnet-5` | pin absent from registry → falls through to selection |
   | slot3 github-models | `codex-mini-latest` | **`codex-mini-latest`** | pin still `current` → retained |

   So only slot2 followed the selection, and only by accident of its pin being invalid.

2. **`llm/client.py` had no `profile` support.** Workflows now ships `config/llm_slots.json` in profile form (no model pins). Verified: with that file set via `LANGCHAIN_SLOT_CONFIG`, `_load_slot_config()` returned `[]` and `build_chat_client()` returned `None` — the chat path would serve **no model at all**.

`config/llm_slots.json` is `sync_mode: create_only` in the Workflows manifest ("repos may customize provider preferences"), so it can only be changed here.

## What changed

- **`llm/client.py`** — an explicitly configured slot entry may now name a `profile`, resolved via `llm_registry.select_model_for_profile`, alongside the existing explicit `model` and legacy `quality_tier`/`tier`. An unresolvable profile is **skipped (fails closed)**, never silently replaced by a default. This mirrors `tools/llm_registry.load_slot_config` semantics. The `lifecycle`/blocked eligibility checks from #1490 are untouched.
- **`config/llm_slots.json`** — migrated to the profile form, so all three slots resolve from the reviewed `verifier-balanced` selections.
- **`tests/test_llm_client.py`** — the two tests that read the *ambient* config now assert the reviewed selection instead of hardcoding `gpt-5.4` / `claude-opus-4-6`. A synced registry refresh was otherwise a guaranteed CI failure with no underlying defect. Hermetic tests that write their own registry/slot fixtures deliberately keep explicit ids.

## Test gate

- `test_profile_slot_resolves_reviewed_selection` — a profile-only slot resolves to the reviewed selection for that profile/provider.
- `test_profile_slot_with_unresolvable_profile_fails_closed` — a profile with no matching selection serves nothing; the fake `create_llm` raises if reached.
- **Deliberate break → revert:** neutralizing the profile read (`profile = ""`) makes `test_profile_slot_resolves_reviewed_selection` FAIL; restoring it returns all 13 to green.

## Verification

```
pytest tests/test_llm_client.py                  -> 13 passed
tools/check_model_registry_freshness.py          -> 0 blocking (profile slots accepted)
ruff check / ruff format --check                 -> clean
probe: profile slots + advanced registry -> slot1 gpt-5.6-terra, slot2 claude-sonnet-5, slot3 openai/gpt-5
```

Pairs with stranske/Workflows#2852, which advances the reviewed selections. Order-independent: this PR is correct against the current registry too (it resolves today's selections), and starts tracking the new ones as soon as the registry syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)