### PR TITLE
feat(attribution): position-level returns since disclosure (#1465)

### DIFF
--- a/alembic/versions/019_manager_attribution.py
+++ b/alembic/versions/019_manager_attribution.py
@@ -1,0 +1,62 @@
+"""Add manager_attribution for position-level performance (#1465).
+
+Revision ID: 019
+Revises: 018
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from alembic import op
+
+revision = "019"
+down_revision = "018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sqlite_autoincrement_id = sa.BigInteger().with_variant(sa.Integer(), "sqlite")
+    op.create_table(
+        "manager_attribution",
+        sa.Column("attribution_id", sqlite_autoincrement_id, autoincrement=True),
+        sa.Column("manager_id", sa.BigInteger(), nullable=False),
+        sa.Column("filing_id", sa.BigInteger(), nullable=True),
+        sa.Column("disclosure_date", sa.Date(), nullable=False),
+        sa.Column("as_of_date", sa.Date(), nullable=False),
+        sa.Column("security_key", sa.Text(), nullable=False),
+        sa.Column("ticker", sa.Text(), nullable=True),
+        sa.Column("cusip", sa.Text(), nullable=True),
+        sa.Column("name_of_issuer", sa.Text(), nullable=True),
+        sa.Column("disclosure_price", sa.Float(), nullable=True),
+        sa.Column("as_of_price", sa.Float(), nullable=True),
+        sa.Column("position_return", sa.Float(), nullable=True),
+        sa.Column("value_usd", sa.Float(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default=text("'filled'")),
+        sa.Column("skip_reason", sa.Text(), nullable=True),
+        sa.Column(
+            "computed_at",
+            sa.DateTime(timezone=True),
+            server_default=text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("attribution_id", name=op.f("pk_manager_attribution")),
+        sa.UniqueConstraint(
+            "manager_id",
+            "filing_id",
+            "security_key",
+            "as_of_date",
+            name="uq_manager_attribution_period_security",
+        ),
+    )
+    op.create_index(
+        "idx_manager_attribution_manager",
+        "manager_attribution",
+        ["manager_id", "as_of_date"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_manager_attribution_manager", table_name="manager_attribution")
+    op.drop_table("manager_attribution")

--- a/alembic/versions/019_manager_attribution.py
+++ b/alembic/versions/019_manager_attribution.py
@@ -55,8 +55,20 @@ def upgrade() -> None:
         "manager_attribution",
         ["manager_id", "as_of_date"],
     )
+    # SQLite and PostgreSQL both treat NULLs as distinct in a UNIQUE constraint, so the
+    # composite key above cannot dedupe rows whose disclosure filing is unidentifiable.
+    # Mirrors the partial-index pattern in 016_activism_campaigns.
+    op.create_index(
+        "uq_manager_attribution_no_filing",
+        "manager_attribution",
+        ["manager_id", "security_key", "as_of_date"],
+        unique=True,
+        sqlite_where=text("filing_id IS NULL"),
+        postgresql_where=text("filing_id IS NULL"),
+    )
 
 
 def downgrade() -> None:
+    op.drop_index("uq_manager_attribution_no_filing", table_name="manager_attribution")
     op.drop_index("idx_manager_attribution_manager", table_name="manager_attribution")
     op.drop_table("manager_attribution")

--- a/alembic/versions/020_manager_attribution.py
+++ b/alembic/versions/020_manager_attribution.py
@@ -1,7 +1,7 @@
 """Add manager_attribution for position-level performance (#1465).
 
-Revision ID: 019
-Revises: 018
+Revision ID: 020
+Revises: 019
 """
 
 from __future__ import annotations
@@ -11,8 +11,8 @@ from sqlalchemy import text
 
 from alembic import op
 
-revision = "019"
-down_revision = "018"
+revision = "020"
+down_revision = "019"
 branch_labels = None
 depends_on = None
 

--- a/api/signals.py
+++ b/api/signals.py
@@ -99,7 +99,8 @@ def _to_date(value: Any) -> date:
         return value
     if isinstance(value, datetime):
         return value.date()
-    return date.fromisoformat(str(value))
+    # Slice so ISO timestamps ("2024-05-01T12:00:00Z") parse as their date part.
+    return date.fromisoformat(str(value)[:10])
 
 
 def _resolve_latest_report_date(conn: Any, table_name: str) -> date | None:
@@ -466,7 +467,7 @@ async def get_conviction_scores(
     response_model=ManagerAttributionResponse,
     summary="List position attribution for a manager",
 )
-async def get_manager_attribution(
+def get_manager_attribution(
     manager_id: int,
     as_of_date: date | None = None,
     limit: int = Query(200, ge=1, le=1000),
@@ -493,8 +494,8 @@ async def get_manager_attribution(
         PositionAttribution(
             manager_id=int(row["manager_id"]),
             filing_id=int(row["filing_id"]) if row.get("filing_id") is not None else None,
-            disclosure_date=_coerce_date_value(row["disclosure_date"]),
-            as_of_date=_coerce_date_value(row["as_of_date"]),
+            disclosure_date=_to_date(row["disclosure_date"]),
+            as_of_date=_to_date(row["as_of_date"]),
             security_key=str(row["security_key"]),
             ticker=str(row["ticker"]) if row.get("ticker") else None,
             cusip=str(row["cusip"]) if row.get("cusip") else None,
@@ -507,9 +508,13 @@ async def get_manager_attribution(
         for row in rows
     ]
     summary = summarize_manager_attribution(positions)
+    # Unfiltered reads span every as-of window, so a single top-level value would
+    # misrepresent the rows. Only report one when the rows actually share it.
+    window_dates = {p.as_of_date for p in positions}
+    resolved_as_of = as_of_date or (window_dates.pop() if len(window_dates) == 1 else None)
     return ManagerAttributionResponse(
         manager_id=manager_id,
-        as_of_date=as_of_date or (positions[0].as_of_date if positions else None),
+        as_of_date=resolved_as_of,
         positions=int(summary["positions"]),
         positions_skipped=int(summary["positions_skipped"]),
         realized_return=summary["realized_return"],
@@ -531,11 +536,3 @@ async def get_manager_attribution(
             for p in positions
         ],
     )
-
-
-def _coerce_date_value(value: Any) -> date:
-    if isinstance(value, date) and not isinstance(value, datetime):
-        return value
-    if isinstance(value, datetime):
-        return value.date()
-    return date.fromisoformat(str(value)[:10])

--- a/api/signals.py
+++ b/api/signals.py
@@ -61,6 +61,30 @@ class ConvictionScoreResponse(BaseModel):
     short_interest_source: str | None = None
 
 
+class AttributionPositionResponse(BaseModel):
+    filing_id: int | None
+    disclosure_date: date
+    as_of_date: date
+    security_key: str
+    ticker: str | None
+    cusip: str | None
+    name_of_issuer: str | None
+    position_return: float | None
+    value_usd: float | None
+    status: str
+    skip_reason: str | None = None
+
+
+class ManagerAttributionResponse(BaseModel):
+    manager_id: int
+    as_of_date: date | None
+    positions: int
+    positions_skipped: int
+    realized_return: float | None
+    hit_rate: float | None
+    rows: list[AttributionPositionResponse]
+
+
 def _to_float(value: Any) -> float | None:
     if value is None:
         return None
@@ -319,7 +343,7 @@ def query_conviction_scores(
     if annotate_insider is not None or annotate_short_interest is not None:
         try:
             hold_rows = conn.execute(
-                "SELECT cusip, resolved_ticker FROM holdings " f"WHERE filing_id = {ph}",
+                f"SELECT cusip, resolved_ticker FROM holdings WHERE filing_id = {ph}",
                 (resolved_filing_id,),
             ).fetchall()
             for hold in hold_rows:
@@ -435,3 +459,83 @@ async def get_conviction_scores(
         )
     finally:
         conn.close()
+
+
+@router.get(
+    "/api/signals/attribution/{manager_id}",
+    response_model=ManagerAttributionResponse,
+    summary="List position attribution for a manager",
+)
+async def get_manager_attribution(
+    manager_id: int,
+    as_of_date: date | None = None,
+    limit: int = Query(200, ge=1, le=1000),
+) -> ManagerAttributionResponse:
+    """Read-only derived returns since disclosure. Raw prices are not redistributed."""
+    from etl.attribution_flow import (
+        PositionAttribution,
+        query_manager_attribution,
+        summarize_manager_attribution,
+    )
+
+    conn = connect_db()
+    try:
+        rows = query_manager_attribution(
+            conn,
+            manager_id,
+            as_of_date=as_of_date,
+            limit=limit,
+        )
+    finally:
+        conn.close()
+
+    positions = [
+        PositionAttribution(
+            manager_id=int(row["manager_id"]),
+            filing_id=int(row["filing_id"]) if row.get("filing_id") is not None else None,
+            disclosure_date=_coerce_date_value(row["disclosure_date"]),
+            as_of_date=_coerce_date_value(row["as_of_date"]),
+            security_key=str(row["security_key"]),
+            ticker=str(row["ticker"]) if row.get("ticker") else None,
+            cusip=str(row["cusip"]) if row.get("cusip") else None,
+            name_of_issuer=str(row["name_of_issuer"]) if row.get("name_of_issuer") else None,
+            value_usd=_to_float(row.get("value_usd")),
+            position_return=_to_float(row.get("position_return")),
+            status=str(row.get("status") or "filled"),
+            skip_reason=str(row["skip_reason"]) if row.get("skip_reason") else None,
+        )
+        for row in rows
+    ]
+    summary = summarize_manager_attribution(positions)
+    return ManagerAttributionResponse(
+        manager_id=manager_id,
+        as_of_date=as_of_date or (positions[0].as_of_date if positions else None),
+        positions=int(summary["positions"]),
+        positions_skipped=int(summary["positions_skipped"]),
+        realized_return=summary["realized_return"],
+        hit_rate=summary["hit_rate"],
+        rows=[
+            AttributionPositionResponse(
+                filing_id=p.filing_id,
+                disclosure_date=p.disclosure_date,
+                as_of_date=p.as_of_date,
+                security_key=p.security_key,
+                ticker=p.ticker,
+                cusip=p.cusip,
+                name_of_issuer=p.name_of_issuer,
+                position_return=p.position_return,
+                value_usd=p.value_usd,
+                status=p.status,
+                skip_reason=p.skip_reason,
+            )
+            for p in positions
+        ],
+    )
+
+
+def _coerce_date_value(value: Any) -> date:
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return date.fromisoformat(str(value)[:10])

--- a/etl/attribution_flow.py
+++ b/etl/attribution_flow.py
@@ -1,0 +1,469 @@
+"""Position-level performance attribution over disclosed holdings (#1465 / design #1402).
+
+For each disclosed position, compute the buy-and-hold return from the disclosure
+date forward using ``holdings_as_of`` plumbing + the free-source price adapter.
+Manager-level realized return and hit-rate are aggregates over filled positions.
+
+INTERNAL USE ONLY for raw prices: the API surfaces derived returns, not closes.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from adapters.base import get_placeholder, get_table_columns, is_sqlite
+from adapters.prices import PriceAdapter
+from etl.backtest_flow import decision_cutoff, enforce_no_lookahead, visible_holdings
+from utils.numeric import finite_float_or_none
+
+logger = logging.getLogger(__name__)
+
+
+def _is_missing_postgres_table_error(exc: Exception) -> bool:
+    message = str(exc)
+    return (
+        "does not exist" in message
+        or getattr(exc, "pgcode", None) == "42P01"
+        or "UndefinedTable" in exc.__class__.__name__
+    )
+
+
+def ensure_manager_attribution_table(conn: Any) -> None:
+    """Create ``manager_attribution`` on SQLite; fail fast when Postgres has no schema."""
+    if isinstance(conn, sqlite3.Connection):
+        conn.execute("""CREATE TABLE IF NOT EXISTS manager_attribution (
+                attribution_id INTEGER PRIMARY KEY,
+                manager_id INTEGER NOT NULL,
+                filing_id INTEGER,
+                disclosure_date DATE NOT NULL,
+                as_of_date DATE NOT NULL,
+                security_key TEXT NOT NULL,
+                ticker TEXT,
+                cusip TEXT,
+                name_of_issuer TEXT,
+                disclosure_price REAL,
+                as_of_price REAL,
+                position_return REAL,
+                value_usd REAL,
+                status TEXT NOT NULL DEFAULT 'filled',
+                skip_reason TEXT,
+                computed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (manager_id, filing_id, security_key, as_of_date)
+            )""")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_manager_attribution_manager "
+            "ON manager_attribution(manager_id, as_of_date)"
+        )
+        return
+
+    try:
+        conn.execute("SELECT 1 FROM manager_attribution LIMIT 1")
+    except Exception as exc:
+        if _is_missing_postgres_table_error(exc):
+            raise RuntimeError(
+                "manager_attribution table is missing on Postgres; apply schema migrations first"
+            ) from exc
+        raise
+
+
+@dataclass
+class PositionAttribution:
+    """One disclosed position's forward return since its disclosure date."""
+
+    manager_id: int
+    filing_id: int | None
+    disclosure_date: date
+    as_of_date: date
+    security_key: str
+    ticker: str | None
+    cusip: str | None
+    name_of_issuer: str | None
+    value_usd: float | None = None
+    disclosure_price: float | None = None
+    as_of_price: float | None = None
+    position_return: float | None = None
+    status: str = "filled"
+    skip_reason: str | None = None
+
+
+@dataclass
+class AttributionReport:
+    """Position rows plus manager-level aggregates for one as-of window."""
+
+    manager_id: int
+    as_of_date: date
+    positions: list[PositionAttribution] = field(default_factory=list)
+    realized_return: float | None = None
+    hit_rate: float | None = None
+
+    @property
+    def filled(self) -> list[PositionAttribution]:
+        return [p for p in self.positions if p.status == "filled"]
+
+    @property
+    def skipped(self) -> list[PositionAttribution]:
+        return [p for p in self.positions if p.status != "filled"]
+
+
+def _coerce_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def _security_key(row: dict[str, Any]) -> str | None:
+    ticker = row.get("resolved_ticker")
+    if ticker:
+        return str(ticker).strip().upper()
+    cusip = row.get("cusip")
+    return str(cusip).strip() if cusip else None
+
+
+def _ticker_for(row: dict[str, Any]) -> str | None:
+    ticker = row.get("resolved_ticker")
+    return str(ticker).strip().upper() if ticker else None
+
+
+def derive_disclosure_dates(
+    conn: Any,
+    manager_id: int,
+    *,
+    start_date: date | None,
+    end_date: date,
+) -> list[date]:
+    """Distinct filing disclosure dates that define attribution periods."""
+    if "filed_date" not in get_table_columns(conn, "filings"):
+        return []
+    ph = get_placeholder(conn)
+    where = [f"manager_id = {ph}", "filed_date IS NOT NULL", f"filed_date <= {ph}"]
+    params: list[Any] = [manager_id, end_date.isoformat()]
+    if start_date is not None:
+        where.append(f"filed_date >= {ph}")
+        params.append(start_date.isoformat())
+    rows = conn.execute(
+        f"SELECT DISTINCT filed_date FROM filings WHERE {' AND '.join(where)} ORDER BY filed_date",
+        tuple(params),
+    ).fetchall()
+    dates = [_coerce_date(row[0]) for row in rows]
+    return [d for d in dates if d is not None]
+
+
+def _filing_id_for_disclosure(conn: Any, manager_id: int, disclosure_date: date) -> int | None:
+    """Pick the manager's latest filing filed on ``disclosure_date``."""
+    if "filed_date" not in get_table_columns(conn, "filings"):
+        return None
+    ph = get_placeholder(conn)
+    row = conn.execute(
+        "SELECT filing_id FROM filings "
+        f"WHERE manager_id = {ph} AND filed_date = {ph} "
+        "ORDER BY filing_id DESC LIMIT 1",
+        (manager_id, disclosure_date.isoformat()),
+    ).fetchone()
+    if not row:
+        return None
+    return int(row[0])
+
+
+def _holdings_for_disclosure(
+    conn: Any,
+    manager_id: int,
+    disclosure_date: date,
+) -> tuple[int | None, list[dict[str, Any]]]:
+    """Return (filing_id, holdings) knowable at disclosure for that period.
+
+    Uses ``visible_holdings`` (``holdings_as_of`` + the local look-ahead guard) so
+    a future knowledge_time cannot leak into the disclosure-period decision set.
+    Among the as-of snapshot, keep rows belonging to the disclosure filing when
+    that filing is identifiable; otherwise keep the full visible set.
+    """
+    filing_id = _filing_id_for_disclosure(conn, manager_id, disclosure_date)
+    visible = visible_holdings(conn, manager_id, disclosure_date)
+    if filing_id is None:
+        return None, visible
+    period_rows = [row for row in visible if int(row.get("filing_id") or -1) == filing_id]
+    return filing_id, period_rows if period_rows else visible
+
+
+def attribute_position(
+    row: dict[str, Any],
+    *,
+    manager_id: int,
+    filing_id: int | None,
+    disclosure_date: date,
+    as_of_date: date,
+    price_adapter: PriceAdapter,
+    entry_date: date | None = None,
+) -> PositionAttribution:
+    """Compute one position's forward return.
+
+    ``entry_date`` defaults to ``disclosure_date``. The deliberate-break path
+    passes an earlier entry to prove look-behind would corrupt the return.
+    """
+    start = entry_date if entry_date is not None else disclosure_date
+    security_key = _security_key(row) or "UNKNOWN"
+    ticker = _ticker_for(row)
+    cusip = str(row["cusip"]) if row.get("cusip") else None
+    position = PositionAttribution(
+        manager_id=manager_id,
+        filing_id=filing_id,
+        disclosure_date=disclosure_date,
+        as_of_date=as_of_date,
+        security_key=security_key,
+        ticker=ticker,
+        cusip=cusip,
+        name_of_issuer=str(row["name_of_issuer"]) if row.get("name_of_issuer") else None,
+        value_usd=finite_float_or_none(row.get("value_usd"), min_value=0.0),
+    )
+
+    if start > as_of_date:
+        position.status = "skipped"
+        position.skip_reason = "entry_after_as_of"
+        return position
+
+    if not ticker:
+        position.status = "skipped"
+        position.skip_reason = "unresolved_ticker"
+        logger.warning("Holding has no resolved ticker; skipping", extra={"cusip": cusip})
+        return position
+
+    disclosure_price = price_adapter.close_on_or_before(ticker, start)
+    as_of_price = price_adapter.close_on_or_before(ticker, as_of_date)
+    if disclosure_price is None or as_of_price is None or disclosure_price <= 0:
+        position.status = "skipped"
+        position.skip_reason = "missing_price"
+        logger.warning(
+            "Missing price for attribution; excluded from metrics",
+            extra={
+                "ticker": ticker,
+                "disclosure_date": disclosure_date.isoformat(),
+                "as_of_date": as_of_date.isoformat(),
+            },
+        )
+        return position
+
+    position.disclosure_price = disclosure_price
+    position.as_of_price = as_of_price
+    position.position_return = (as_of_price - disclosure_price) / disclosure_price
+    return position
+
+
+def _aggregate(report: AttributionReport) -> None:
+    filled = report.filled
+    if not filled:
+        report.realized_return = None
+        report.hit_rate = None
+        return
+    returns = [p.position_return for p in filled if p.position_return is not None]
+    if not returns:
+        report.realized_return = None
+        report.hit_rate = None
+        return
+    report.realized_return = sum(returns) / len(returns)
+    report.hit_rate = sum(1 for value in returns if value > 0) / len(returns)
+
+
+def run_attribution(
+    conn: Any,
+    manager_id: int,
+    as_of_date: date,
+    *,
+    price_adapter: PriceAdapter,
+    start_date: date | None = None,
+    disclosure_dates: Sequence[date] | None = None,
+    entry_date_offset_days: int = 0,
+    persist: bool = True,
+) -> AttributionReport:
+    """Attribute disclosed positions from each disclosure date forward to ``as_of_date``.
+
+    ``entry_date_offset_days`` is for the deliberate-break demonstration: a negative
+    offset starts the return window before disclosure and must fail the hand-computed
+    acceptance assertion. Production callers leave it at 0.
+    """
+    report = AttributionReport(manager_id=manager_id, as_of_date=as_of_date)
+    dates = list(disclosure_dates) if disclosure_dates is not None else None
+    if dates is None:
+        dates = derive_disclosure_dates(
+            conn, manager_id, start_date=start_date, end_date=as_of_date
+        )
+    dates = sorted(
+        {d for d in dates if d <= as_of_date and (start_date is None or d >= start_date)}
+    )
+
+    # Deduplicate by (filing, security) so a security disclosed once is attributed once
+    # for this as-of window, even if it reappears in later as-of snapshots.
+    seen: set[tuple[int | None, str]] = set()
+    for disclosure_date in dates:
+        filing_id, holdings = _holdings_for_disclosure(conn, manager_id, disclosure_date)
+        entry_date = disclosure_date + timedelta(days=int(entry_date_offset_days))
+
+        for row in holdings:
+            key = _security_key(row)
+            if key is None:
+                key = "UNKNOWN"
+            dedupe = (filing_id, key)
+            if dedupe in seen:
+                continue
+            seen.add(dedupe)
+            report.positions.append(
+                attribute_position(
+                    row,
+                    manager_id=manager_id,
+                    filing_id=filing_id,
+                    disclosure_date=disclosure_date,
+                    as_of_date=as_of_date,
+                    price_adapter=price_adapter,
+                    entry_date=entry_date,
+                )
+            )
+
+    _aggregate(report)
+    if persist:
+        persist_attribution(conn, report)
+    return report
+
+
+def persist_attribution(conn: Any, report: AttributionReport) -> int:
+    """Upsert position rows for this manager/as-of window; returns rows written."""
+    ensure_manager_attribution_table(conn)
+    ph = get_placeholder(conn)
+    written = 0
+
+    def write_rows() -> int:
+        count = 0
+        excluded = "excluded" if is_sqlite(conn) else "EXCLUDED"
+        sql = (
+            "INSERT INTO manager_attribution("
+            "manager_id, filing_id, disclosure_date, as_of_date, security_key, "
+            "ticker, cusip, name_of_issuer, disclosure_price, as_of_price, "
+            "position_return, value_usd, status, skip_reason) "
+            f"VALUES ({', '.join([ph] * 14)}) "
+            "ON CONFLICT(manager_id, filing_id, security_key, as_of_date) DO UPDATE SET "
+            f"ticker={excluded}.ticker, cusip={excluded}.cusip, "
+            f"name_of_issuer={excluded}.name_of_issuer, "
+            f"disclosure_price={excluded}.disclosure_price, "
+            f"as_of_price={excluded}.as_of_price, "
+            f"position_return={excluded}.position_return, "
+            f"value_usd={excluded}.value_usd, "
+            f"status={excluded}.status, skip_reason={excluded}.skip_reason"
+        )
+        for position in report.positions:
+            conn.execute(
+                sql,
+                (
+                    position.manager_id,
+                    position.filing_id,
+                    position.disclosure_date.isoformat(),
+                    position.as_of_date.isoformat(),
+                    position.security_key,
+                    position.ticker,
+                    position.cusip,
+                    position.name_of_issuer,
+                    position.disclosure_price,
+                    position.as_of_price,
+                    position.position_return,
+                    position.value_usd,
+                    position.status,
+                    position.skip_reason,
+                ),
+            )
+            count += 1
+        return count
+
+    if isinstance(conn, sqlite3.Connection):
+        with conn:
+            written = write_rows()
+    else:
+        with conn.transaction():
+            written = write_rows()
+    return written
+
+
+def query_manager_attribution(
+    conn: Any,
+    manager_id: int,
+    *,
+    as_of_date: date | None = None,
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    """Read-only position attribution rows (derived returns; no price redistribution)."""
+    if not get_table_columns(conn, "manager_attribution"):
+        return []
+    ph = get_placeholder(conn)
+    where = [f"manager_id = {ph}"]
+    params: list[Any] = [manager_id]
+    if as_of_date is not None:
+        where.append(f"as_of_date = {ph}")
+        params.append(as_of_date.isoformat())
+    params.append(max(1, int(limit)))
+    rows = conn.execute(
+        "SELECT attribution_id, manager_id, filing_id, disclosure_date, as_of_date, "
+        "security_key, ticker, cusip, name_of_issuer, position_return, value_usd, "
+        "status, skip_reason, computed_at "
+        f"FROM manager_attribution WHERE {' AND '.join(where)} "
+        f"ORDER BY disclosure_date, security_key LIMIT {ph}",
+        tuple(params),
+    ).fetchall()
+    keys = (
+        "attribution_id",
+        "manager_id",
+        "filing_id",
+        "disclosure_date",
+        "as_of_date",
+        "security_key",
+        "ticker",
+        "cusip",
+        "name_of_issuer",
+        "position_return",
+        "value_usd",
+        "status",
+        "skip_reason",
+        "computed_at",
+    )
+    return [dict(zip(keys, row, strict=False)) for row in rows]
+
+
+def summarize_manager_attribution(positions: Sequence[PositionAttribution]) -> dict[str, Any]:
+    """Manager-level realized return + hit-rate over filled positions."""
+    filled = [p for p in positions if p.status == "filled" and p.position_return is not None]
+    if not filled:
+        return {
+            "positions": 0,
+            "positions_skipped": sum(1 for p in positions if p.status != "filled"),
+            "realized_return": None,
+            "hit_rate": None,
+        }
+    returns = [p.position_return for p in filled if p.position_return is not None]
+    return {
+        "positions": len(filled),
+        "positions_skipped": sum(1 for p in positions if p.status != "filled"),
+        "realized_return": sum(returns) / len(returns),
+        "hit_rate": sum(1 for value in returns if value > 0) / len(returns),
+    }
+
+
+# Re-export the look-ahead helpers so tests can demonstrate the deliberate break
+# against the same decision cutoff the production path uses.
+__all__ = [
+    "AttributionReport",
+    "PositionAttribution",
+    "attribute_position",
+    "decision_cutoff",
+    "enforce_no_lookahead",
+    "ensure_manager_attribution_table",
+    "persist_attribution",
+    "query_manager_attribution",
+    "run_attribution",
+    "summarize_manager_attribution",
+]

--- a/etl/attribution_flow.py
+++ b/etl/attribution_flow.py
@@ -36,28 +36,37 @@ def _is_missing_postgres_table_error(exc: Exception) -> bool:
 def ensure_manager_attribution_table(conn: Any) -> None:
     """Create ``manager_attribution`` on SQLite; fail fast when Postgres has no schema."""
     if isinstance(conn, sqlite3.Connection):
+        # Declared types mirror migration 019's SQLite rendering exactly; the schema
+        # parity test compares PRAGMA table_info types, not just column names.
         conn.execute("""CREATE TABLE IF NOT EXISTS manager_attribution (
                 attribution_id INTEGER PRIMARY KEY,
-                manager_id INTEGER NOT NULL,
-                filing_id INTEGER,
+                manager_id BIGINT NOT NULL,
+                filing_id BIGINT,
                 disclosure_date DATE NOT NULL,
                 as_of_date DATE NOT NULL,
                 security_key TEXT NOT NULL,
                 ticker TEXT,
                 cusip TEXT,
                 name_of_issuer TEXT,
-                disclosure_price REAL,
-                as_of_price REAL,
-                position_return REAL,
-                value_usd REAL,
+                disclosure_price FLOAT,
+                as_of_price FLOAT,
+                position_return FLOAT,
+                value_usd FLOAT,
                 status TEXT NOT NULL DEFAULT 'filled',
                 skip_reason TEXT,
-                computed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                computed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                 UNIQUE (manager_id, filing_id, security_key, as_of_date)
             )""")
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_manager_attribution_manager "
             "ON manager_attribution(manager_id, as_of_date)"
+        )
+        # NULLs are distinct under UNIQUE, so filing-less rows need a partial index to
+        # stay dedupable. Keeps the runtime contract identical to migration 019.
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_manager_attribution_no_filing "
+            "ON manager_attribution(manager_id, security_key, as_of_date) "
+            "WHERE filing_id IS NULL"
         )
         return
 
@@ -187,13 +196,16 @@ def _holdings_for_disclosure(
     a future knowledge_time cannot leak into the disclosure-period decision set.
     Among the as-of snapshot, keep rows belonging to the disclosure filing when
     that filing is identifiable; otherwise keep the full visible set.
+
+    An identified filing with no visible rows yields an empty list rather than the
+    full snapshot: attributing other filings' holdings to this ``filing_id`` would
+    persist — and surface through the API — a filing reference they do not belong to.
     """
     filing_id = _filing_id_for_disclosure(conn, manager_id, disclosure_date)
     visible = visible_holdings(conn, manager_id, disclosure_date)
     if filing_id is None:
         return None, visible
-    period_rows = [row for row in visible if int(row.get("filing_id") or -1) == filing_id]
-    return filing_id, period_rows if period_rows else visible
+    return filing_id, [row for row in visible if int(row.get("filing_id") or -1) == filing_id]
 
 
 def attribute_position(
@@ -238,8 +250,10 @@ def attribute_position(
         logger.warning("Holding has no resolved ticker; skipping", extra={"cusip": cusip})
         return position
 
-    disclosure_price = price_adapter.close_on_or_before(ticker, start)
-    as_of_price = price_adapter.close_on_or_before(ticker, as_of_date)
+    # finite_float_or_none also rejects NaN/inf: NaN survives a `<= 0` guard and would
+    # poison position_return, the aggregates, and finally JSON serialization.
+    disclosure_price = finite_float_or_none(price_adapter.close_on_or_before(ticker, start))
+    as_of_price = finite_float_or_none(price_adapter.close_on_or_before(ticker, as_of_date))
     if disclosure_price is None or as_of_price is None or disclosure_price <= 0:
         position.status = "skipped"
         position.skip_reason = "missing_price"
@@ -260,18 +274,10 @@ def attribute_position(
 
 
 def _aggregate(report: AttributionReport) -> None:
-    filled = report.filled
-    if not filled:
-        report.realized_return = None
-        report.hit_rate = None
-        return
-    returns = [p.position_return for p in filled if p.position_return is not None]
-    if not returns:
-        report.realized_return = None
-        report.hit_rate = None
-        return
-    report.realized_return = sum(returns) / len(returns)
-    report.hit_rate = sum(1 for value in returns if value > 0) / len(returns)
+    """Fill the report's manager-level metrics from the single aggregation definition."""
+    summary = summarize_manager_attribution(report.positions)
+    report.realized_return = summary["realized_return"]
+    report.hit_rate = summary["hit_rate"]
 
 
 def run_attribution(
@@ -301,9 +307,11 @@ def run_attribution(
         {d for d in dates if d <= as_of_date and (start_date is None or d >= start_date)}
     )
 
-    # Deduplicate by (filing, security) so a security disclosed once is attributed once
-    # for this as-of window, even if it reappears in later as-of snapshots.
-    seen: set[tuple[int | None, str]] = set()
+    # Deduplicate by security alone so a security is attributed once for this as-of
+    # window. ``dates`` is ascending, so the earliest disclosure wins; keying by
+    # (filing, security) would attribute the same security once per filing that
+    # re-discloses it and double-count it in the manager aggregates.
+    seen: set[str] = set()
     for disclosure_date in dates:
         filing_id, holdings = _holdings_for_disclosure(conn, manager_id, disclosure_date)
         entry_date = disclosure_date + timedelta(days=int(entry_date_offset_days))
@@ -312,10 +320,9 @@ def run_attribution(
             key = _security_key(row)
             if key is None:
                 key = "UNKNOWN"
-            dedupe = (filing_id, key)
-            if dedupe in seen:
+            if key in seen:
                 continue
-            seen.add(dedupe)
+            seen.add(key)
             report.positions.append(
                 attribute_position(
                     row,
@@ -343,13 +350,8 @@ def persist_attribution(conn: Any, report: AttributionReport) -> int:
     def write_rows() -> int:
         count = 0
         excluded = "excluded" if is_sqlite(conn) else "EXCLUDED"
-        sql = (
-            "INSERT INTO manager_attribution("
-            "manager_id, filing_id, disclosure_date, as_of_date, security_key, "
-            "ticker, cusip, name_of_issuer, disclosure_price, as_of_price, "
-            "position_return, value_usd, status, skip_reason) "
-            f"VALUES ({', '.join([ph] * 14)}) "
-            "ON CONFLICT(manager_id, filing_id, security_key, as_of_date) DO UPDATE SET "
+        update_clause = (
+            "DO UPDATE SET "
             f"ticker={excluded}.ticker, cusip={excluded}.cusip, "
             f"name_of_issuer={excluded}.name_of_issuer, "
             f"disclosure_price={excluded}.disclosure_price, "
@@ -358,9 +360,27 @@ def persist_attribution(conn: Any, report: AttributionReport) -> int:
             f"value_usd={excluded}.value_usd, "
             f"status={excluded}.status, skip_reason={excluded}.skip_reason"
         )
+        insert_clause = (
+            "INSERT INTO manager_attribution("
+            "manager_id, filing_id, disclosure_date, as_of_date, security_key, "
+            "ticker, cusip, name_of_issuer, disclosure_price, as_of_price, "
+            "position_return, value_usd, status, skip_reason) "
+            f"VALUES ({', '.join([ph] * 14)}) "
+        )
+        # A NULL filing_id never matches the four-column unique constraint, so those
+        # rows must target the partial index instead or every run re-inserts them.
+        sql_with_filing = (
+            f"{insert_clause}"
+            f"ON CONFLICT(manager_id, filing_id, security_key, as_of_date) {update_clause}"
+        )
+        sql_without_filing = (
+            f"{insert_clause}"
+            "ON CONFLICT(manager_id, security_key, as_of_date) WHERE filing_id IS NULL "
+            f"{update_clause}"
+        )
         for position in report.positions:
             conn.execute(
-                sql,
+                sql_with_filing if position.filing_id is not None else sql_without_filing,
                 (
                     position.manager_id,
                     position.filing_id,

--- a/schema.sql
+++ b/schema.sql
@@ -320,10 +320,10 @@ CREATE TABLE IF NOT EXISTS manager_attribution (
     ticker text,
     cusip text,
     name_of_issuer text,
-    disclosure_price real,
-    as_of_price real,
-    position_return real,
-    value_usd real,
+    disclosure_price double precision,
+    as_of_price double precision,
+    position_return double precision,
+    value_usd double precision,
     status text NOT NULL DEFAULT 'filled',
     skip_reason text,
     computed_at timestamptz DEFAULT now(),
@@ -331,6 +331,9 @@ CREATE TABLE IF NOT EXISTS manager_attribution (
 );
 CREATE INDEX IF NOT EXISTS idx_manager_attribution_manager
     ON manager_attribution (manager_id, as_of_date);
+-- NULL filing_id rows escape the UNIQUE constraint above, so they need a partial index.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_manager_attribution_no_filing
+    ON manager_attribution (manager_id, security_key, as_of_date) WHERE filing_id IS NULL;
 
 CREATE TABLE IF NOT EXISTS identifier_resolution_cache (
     cusip text PRIMARY KEY,

--- a/schema.sql
+++ b/schema.sql
@@ -308,6 +308,30 @@ CREATE TABLE IF NOT EXISTS backtest_results (
 );
 CREATE INDEX IF NOT EXISTS idx_backtest_results_run ON backtest_results (run_id);
 
+-- Position-level performance attribution since disclosure (#1465 / design #1402).
+-- Derived returns may be surfaced via the signals API; raw prices are internal-use only.
+CREATE TABLE IF NOT EXISTS manager_attribution (
+    attribution_id bigserial PRIMARY KEY,
+    manager_id bigint NOT NULL,
+    filing_id bigint,
+    disclosure_date date NOT NULL,
+    as_of_date date NOT NULL,
+    security_key text NOT NULL,
+    ticker text,
+    cusip text,
+    name_of_issuer text,
+    disclosure_price real,
+    as_of_price real,
+    position_return real,
+    value_usd real,
+    status text NOT NULL DEFAULT 'filled',
+    skip_reason text,
+    computed_at timestamptz DEFAULT now(),
+    UNIQUE (manager_id, filing_id, security_key, as_of_date)
+);
+CREATE INDEX IF NOT EXISTS idx_manager_attribution_manager
+    ON manager_attribution (manager_id, as_of_date);
+
 CREATE TABLE IF NOT EXISTS identifier_resolution_cache (
     cusip text PRIMARY KEY,
     ticker text,

--- a/tests/test_attribution_flow.py
+++ b/tests/test_attribution_flow.py
@@ -127,6 +127,180 @@ def test_two_positions_yield_hand_computed_returns(tmp_path: Path) -> None:
     assert {row["ticker"] for row in stored} == {"AAA", "BBB"}
 
 
+def test_repeated_runs_do_not_duplicate_stored_rows(tmp_path: Path) -> None:
+    """Persistence is idempotent: re-running the same window upserts, never appends."""
+    conn = _connect(tmp_path)
+    _seed_two_positions(conn)
+    adapter = _adapter(conn)
+
+    for _ in range(2):
+        run_attribution(
+            conn,
+            manager_id=1,
+            as_of_date=AS_OF,
+            price_adapter=adapter,
+            disclosure_dates=[DISCLOSURE],
+        )
+
+    stored = query_manager_attribution(conn, 1, as_of_date=AS_OF)
+    assert len(stored) == 2
+    assert {row["ticker"] for row in stored} == {"AAA", "BBB"}
+
+
+def test_repeated_runs_do_not_duplicate_rows_without_a_filing_id(tmp_path: Path) -> None:
+    """NULL filing_id rows escape the UNIQUE constraint, so they need the partial index.
+
+    Without the partial unique index plus its matching ON CONFLICT target, every run
+    inserts another copy and the manager aggregates drift.
+    """
+    conn = _connect(tmp_path)
+    _seed_two_positions(conn)
+    # No filing carries this disclosure date, so _holdings_for_disclosure yields
+    # filing_id=None for the whole visible set.
+    unfiled_disclosure = date(2024, 5, 2)
+    adapter = PriceAdapter(
+        conn,
+        source="test",
+        fetcher=_make_fetcher(
+            {
+                "AAA": {**PRICES["AAA"], unfiled_disclosure: 100.0},
+                "BBB": {**PRICES["BBB"], unfiled_disclosure: 50.0},
+            }
+        ),
+    )
+
+    for _ in range(2):
+        report = run_attribution(
+            conn,
+            manager_id=1,
+            as_of_date=AS_OF,
+            price_adapter=adapter,
+            disclosure_dates=[unfiled_disclosure],
+        )
+        assert all(p.filing_id is None for p in report.positions)
+
+    stored = query_manager_attribution(conn, 1, as_of_date=AS_OF)
+    assert len(stored) == 2
+    assert all(row["filing_id"] is None for row in stored)
+
+
+def test_skip_paths_are_recorded_and_excluded_from_metrics(tmp_path: Path) -> None:
+    """Unresolved tickers and missing prices are skipped, not folded into the aggregates."""
+    conn = _connect(tmp_path)
+    _seed_two_positions(conn)
+    # CCC has a ticker but no prices; DDD has no resolved ticker at all.
+    conn.execute(
+        "INSERT INTO holdings(filing_id, cusip, resolved_ticker, name_of_issuer, shares, "
+        "value_usd, knowledge_time) VALUES (10, 'CCC000000', 'CCC', 'CCC Corp', 100, "
+        "1000000.0, '2024-05-01T12:00:00Z')"
+    )
+    conn.execute(
+        "INSERT INTO holdings(filing_id, cusip, resolved_ticker, name_of_issuer, shares, "
+        "value_usd, knowledge_time) VALUES (10, 'DDD000000', NULL, 'DDD Corp', 100, "
+        "1000000.0, '2024-05-01T12:00:00Z')"
+    )
+    conn.commit()
+
+    report = run_attribution(
+        conn,
+        manager_id=1,
+        as_of_date=AS_OF,
+        price_adapter=_adapter(conn),
+        disclosure_dates=[DISCLOSURE],
+    )
+
+    by_key = {p.security_key: p for p in report.skipped}
+    assert by_key["CCC"].skip_reason == "missing_price"
+    assert by_key["DDD000000"].skip_reason == "unresolved_ticker"
+
+    # Metrics still reflect only the two priced positions.
+    assert report.realized_return == pytest.approx(0.05)
+    assert report.hit_rate == pytest.approx(0.5)
+    summary = summarize_manager_attribution(report.positions)
+    assert summary["positions"] == 2
+    assert summary["positions_skipped"] == 2
+
+
+def test_non_finite_price_is_skipped_rather_than_poisoning_metrics(tmp_path: Path) -> None:
+    """A NaN close passes a bare `<= 0` guard; it must not reach position_return."""
+    conn = _connect(tmp_path)
+    _seed_two_positions(conn)
+    adapter = PriceAdapter(
+        conn,
+        source="test",
+        fetcher=_make_fetcher({**PRICES, "BBB": {**PRICES["BBB"], AS_OF: float("nan")}}),
+    )
+
+    report = run_attribution(
+        conn,
+        manager_id=1,
+        as_of_date=AS_OF,
+        price_adapter=adapter,
+        disclosure_dates=[DISCLOSURE],
+        persist=False,
+    )
+
+    skipped = {p.ticker: p for p in report.skipped}
+    assert skipped["BBB"].skip_reason == "missing_price"
+    assert all(p.position_return == p.position_return for p in report.filled)  # no NaN
+    assert report.realized_return == pytest.approx(0.30)
+
+
+def test_security_disclosed_twice_is_attributed_once(tmp_path: Path) -> None:
+    """Re-disclosure in a later filing must not double-count the security."""
+    conn = _connect(tmp_path)
+    _seed_two_positions(conn)
+    later_disclosure = date(2024, 6, 3)
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source) "
+        "VALUES (12, 1, '13F-HR', '2024-04-30', '2024-06-03', 'us')"
+    )
+    conn.execute(
+        "INSERT INTO holdings(filing_id, cusip, resolved_ticker, name_of_issuer, shares, "
+        "value_usd, knowledge_time) VALUES (12, 'AAA000000', 'AAA', 'AAA Corp', 1000, "
+        "5000000.0, '2024-06-03T12:00:00Z')"
+    )
+    conn.commit()
+
+    report = run_attribution(
+        conn,
+        manager_id=1,
+        as_of_date=AS_OF,
+        price_adapter=_adapter(conn),
+        disclosure_dates=[DISCLOSURE, later_disclosure],
+        persist=False,
+    )
+
+    aaa = [p for p in report.positions if p.security_key == "AAA"]
+    assert len(aaa) == 1
+    # The earliest disclosure wins, so the hand-computed 100 -> 130 path is preserved.
+    assert aaa[0].disclosure_date == DISCLOSURE
+    assert aaa[0].position_return == pytest.approx(0.30)
+
+
+def test_identified_filing_without_visible_rows_yields_no_positions(tmp_path: Path) -> None:
+    """An empty period must not borrow another filing's holdings under its filing_id."""
+    conn = _connect(tmp_path)
+    _seed_two_positions(conn)
+    empty_disclosure = date(2024, 6, 3)
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source) "
+        "VALUES (13, 1, '13F-HR', '2024-04-30', '2024-06-03', 'us')"
+    )
+    conn.commit()
+
+    report = run_attribution(
+        conn,
+        manager_id=1,
+        as_of_date=AS_OF,
+        price_adapter=_adapter(conn),
+        disclosure_dates=[empty_disclosure],
+        persist=False,
+    )
+
+    assert report.positions == []
+
+
 def test_no_lookahead_excludes_future_knowledge(tmp_path: Path) -> None:
     """Returns only use holdings knowable at disclosure — never a later amendment."""
     conn = _connect(tmp_path)

--- a/tests/test_attribution_flow.py
+++ b/tests/test_attribution_flow.py
@@ -1,0 +1,203 @@
+"""Acceptance tests for position-level performance attribution (#1465 / design #1402)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from adapters.prices import PriceAdapter
+from etl.attribution_flow import (
+    enforce_no_lookahead,
+    query_manager_attribution,
+    run_attribution,
+    summarize_manager_attribution,
+)
+
+# Hand-computed paths: AAA 100 -> 130 = +30%; BBB 50 -> 40 = -20%.
+# Equal-weight manager realized return = (0.30 + (-0.20)) / 2 = 0.05; hit-rate = 0.5.
+PRICES: dict[str, dict[date, float]] = {
+    "AAA": {
+        date(2024, 5, 1): 100.0,
+        date(2024, 4, 30): 90.0,  # pre-disclosure close used by the deliberate break
+        date(2024, 8, 1): 130.0,
+    },
+    "BBB": {
+        date(2024, 5, 1): 50.0,
+        date(2024, 4, 30): 55.0,
+        date(2024, 8, 1): 40.0,
+    },
+}
+
+DISCLOSURE = date(2024, 5, 1)
+AS_OF = date(2024, 8, 1)
+
+
+def _make_fetcher(prices: dict[str, dict[date, float]]):
+    def fetcher(ticker: str, start: date, end: date) -> dict[date, float]:
+        return {d: p for d, p in prices.get(ticker, {}).items() if start <= d <= end}
+
+    return fetcher
+
+
+def _connect(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "attribution.db")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE managers (manager_id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute("""
+        CREATE TABLE filings (
+            filing_id INTEGER PRIMARY KEY,
+            manager_id INTEGER NOT NULL,
+            type TEXT NOT NULL,
+            period_end TEXT,
+            filed_date TEXT,
+            source TEXT NOT NULL
+        )
+        """)
+    conn.execute("""
+        CREATE TABLE holdings (
+            holding_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            filing_id INTEGER NOT NULL,
+            cusip TEXT,
+            resolved_ticker TEXT,
+            name_of_issuer TEXT,
+            shares INTEGER,
+            value_usd REAL,
+            knowledge_time TEXT NOT NULL,
+            superseded_at TEXT,
+            version INTEGER NOT NULL DEFAULT 1
+        )
+        """)
+    conn.execute("INSERT INTO managers(manager_id, name) VALUES (1, 'Test Manager')")
+    conn.commit()
+    return conn
+
+
+def _seed_two_positions(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source) "
+        "VALUES (10, 1, '13F-HR', '2024-03-31', '2024-05-01', 'us')"
+    )
+    conn.execute(
+        "INSERT INTO holdings(filing_id, cusip, resolved_ticker, name_of_issuer, shares, "
+        "value_usd, knowledge_time) VALUES (10, 'AAA000000', 'AAA', 'AAA Corp', 1000, "
+        "5000000.0, '2024-05-01T12:00:00Z')"
+    )
+    conn.execute(
+        "INSERT INTO holdings(filing_id, cusip, resolved_ticker, name_of_issuer, shares, "
+        "value_usd, knowledge_time) VALUES (10, 'BBB000000', 'BBB', 'BBB Corp', 2000, "
+        "3000000.0, '2024-05-01T12:00:00Z')"
+    )
+    conn.commit()
+
+
+def _adapter(conn: sqlite3.Connection) -> PriceAdapter:
+    return PriceAdapter(conn, source="test", fetcher=_make_fetcher(PRICES))
+
+
+def test_two_positions_yield_hand_computed_returns(tmp_path: Path) -> None:
+    """Acceptance: known post-disclosure paths produce exact position + manager metrics."""
+    conn = _connect(tmp_path)
+    _seed_two_positions(conn)
+
+    report = run_attribution(
+        conn,
+        manager_id=1,
+        as_of_date=AS_OF,
+        price_adapter=_adapter(conn),
+        disclosure_dates=[DISCLOSURE],
+    )
+
+    by_ticker = {p.ticker: p for p in report.filled}
+    assert set(by_ticker) == {"AAA", "BBB"}
+    assert by_ticker["AAA"].position_return == pytest.approx(0.30)
+    assert by_ticker["BBB"].position_return == pytest.approx(-0.20)
+    assert report.realized_return == pytest.approx(0.05)
+    assert report.hit_rate == pytest.approx(0.5)
+
+    summary = summarize_manager_attribution(report.positions)
+    assert summary["realized_return"] == pytest.approx(0.05)
+    assert summary["hit_rate"] == pytest.approx(0.5)
+    assert summary["positions"] == 2
+
+    stored = query_manager_attribution(conn, 1, as_of_date=AS_OF)
+    assert len(stored) == 2
+    assert {row["ticker"] for row in stored} == {"AAA", "BBB"}
+
+
+def test_no_lookahead_excludes_future_knowledge(tmp_path: Path) -> None:
+    """Returns only use holdings knowable at disclosure — never a later amendment."""
+    conn = _connect(tmp_path)
+    _seed_two_positions(conn)
+    # Amendment filed later must not enter the May 1 decision set.
+    conn.execute(
+        "INSERT INTO filings(filing_id, manager_id, type, period_end, filed_date, source) "
+        "VALUES (11, 1, '13F-HR/A', '2024-03-31', '2024-05-15', 'us')"
+    )
+    conn.execute(
+        "INSERT INTO holdings(filing_id, cusip, resolved_ticker, name_of_issuer, shares, "
+        "value_usd, knowledge_time) VALUES (11, 'CCC000000', 'CCC', 'CCC Corp', 100, "
+        "1000000.0, '2024-05-15T12:00:00Z')"
+    )
+    conn.commit()
+
+    leaked = enforce_no_lookahead(
+        [
+            {
+                "cusip": "CCC000000",
+                "resolved_ticker": "CCC",
+                "knowledge_time": "2024-05-15T12:00:00Z",
+            }
+        ],
+        DISCLOSURE,
+    )
+    assert leaked == []
+
+    report = run_attribution(
+        conn,
+        manager_id=1,
+        as_of_date=AS_OF,
+        price_adapter=_adapter(conn),
+        disclosure_dates=[DISCLOSURE],
+    )
+    assert {p.ticker for p in report.filled} == {"AAA", "BBB"}
+    assert all(p.disclosure_date == DISCLOSURE for p in report.positions)
+
+
+def test_deliberate_break_starting_before_disclosure_fails(tmp_path: Path) -> None:
+    """Deliberate-break: starting the return window before disclosure corrupts returns.
+
+    Restoring the production offset (0) recovers the hand-computed path.
+    """
+    conn = _connect(tmp_path)
+    _seed_two_positions(conn)
+    adapter = _adapter(conn)
+
+    broken = run_attribution(
+        conn,
+        manager_id=1,
+        as_of_date=AS_OF,
+        price_adapter=adapter,
+        disclosure_dates=[DISCLOSURE],
+        entry_date_offset_days=-1,
+        persist=False,
+    )
+    by_ticker = {p.ticker: p for p in broken.filled}
+    # AAA: 90 -> 130 = 40/90; BBB: 55 -> 40 = -15/55 — not the acceptance numbers.
+    assert by_ticker["AAA"].position_return != pytest.approx(0.30)
+    assert by_ticker["BBB"].position_return != pytest.approx(-0.20)
+    assert broken.realized_return != pytest.approx(0.05)
+
+    restored = run_attribution(
+        conn,
+        manager_id=1,
+        as_of_date=AS_OF,
+        price_adapter=adapter,
+        disclosure_dates=[DISCLOSURE],
+        entry_date_offset_days=0,
+        persist=False,
+    )
+    assert restored.realized_return == pytest.approx(0.05)
+    assert {p.ticker: p.position_return for p in restored.filled}["AAA"] == pytest.approx(0.30)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10,6 +10,7 @@ from alembic.config import Config
 from adapters.prices import ensure_price_cache_table
 from alembic import command
 from etl.activism_campaign_flow import ensure_activism_campaign_tables
+from etl.attribution_flow import ensure_manager_attribution_table
 from etl.backtest_flow import ensure_backtest_tables
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -255,6 +256,60 @@ def test_backtest_schema_contract_stays_in_sync_across_all_three_definitions(mon
     with sqlite3.connect(db_path) as migrated, sqlite3.connect(":memory:") as runtime:
         ensure_price_cache_table(runtime)
         ensure_backtest_tables(runtime)
+        migrated_columns = {
+            table: {row[1] for row in migrated.execute(f"PRAGMA table_info({table})")}
+            for table in tables
+        }
+        runtime_columns = {
+            table: {row[1] for row in runtime.execute(f"PRAGMA table_info({table})")}
+            for table in tables
+        }
+
+    schema = (ROOT / "schema.sql").read_text(encoding="utf-8")
+    schema_columns = {}
+    for table in tables:
+        definition = re.search(
+            rf"CREATE TABLE IF NOT EXISTS {table} \((.*?)\n\);", schema, flags=re.DOTALL
+        )
+        assert definition is not None
+        schema_columns[table] = {
+            line.strip().split()[0]
+            for line in definition.group(1).splitlines()
+            if line.strip()
+            and not line.lstrip().startswith(("PRIMARY", "FOREIGN", "UNIQUE", "CONSTRAINT"))
+        }
+
+    assert runtime_columns == migrated_columns == schema_columns
+
+
+def test_manager_attribution_migration_uses_sqlite_autoincrement_primary_key(monkeypatch, tmp_path):
+    """Migration 019 must generate attribution_id without callers supplying BIGINT keys."""
+    monkeypatch.delenv("DB_URL", raising=False)
+    db_path = tmp_path / "schema.db"
+    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+
+    with sqlite3.connect(db_path) as conn:
+        inserted = conn.execute(
+            "INSERT INTO manager_attribution("
+            "manager_id, filing_id, disclosure_date, as_of_date, security_key) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (1, 10, "2024-05-01", "2024-08-01", "AAA"),
+        )
+        assert inserted.lastrowid is not None
+        assert (
+            conn.execute("SELECT attribution_id FROM manager_attribution").fetchone()[0] is not None
+        )
+
+
+def test_manager_attribution_schema_contract_stays_in_sync(monkeypatch, tmp_path):
+    """Keep migration, runtime SQLite DDL, and schema.sql column contracts aligned."""
+    monkeypatch.delenv("DB_URL", raising=False)
+    db_path = tmp_path / "migrated.db"
+    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+
+    tables = {"manager_attribution"}
+    with sqlite3.connect(db_path) as migrated, sqlite3.connect(":memory:") as runtime:
+        ensure_manager_attribution_table(runtime)
         migrated_columns = {
             table: {row[1] for row in migrated.execute(f"PRAGMA table_info({table})")}
             for table in tables

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -246,25 +246,21 @@ def test_short_interest_migration_uses_sqlite_autoincrement_primary_key(monkeypa
         assert conn.execute("SELECT metric_id FROM short_interest").fetchone()[0] is not None
 
 
-def test_backtest_schema_contract_stays_in_sync_across_all_three_definitions(monkeypatch, tmp_path):
-    """Keep migration, runtime SQLite DDL, and canonical schema.sql column contracts aligned."""
-    monkeypatch.delenv("DB_URL", raising=False)
-    db_path = tmp_path / "migrated.db"
-    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+def _sqlite_column_names(conn, tables):
+    return {
+        table: {row[1] for row in conn.execute(f"PRAGMA table_info({table})")} for table in tables
+    }
 
-    tables = {"price_cache", "backtest_runs", "backtest_results"}
-    with sqlite3.connect(db_path) as migrated, sqlite3.connect(":memory:") as runtime:
-        ensure_price_cache_table(runtime)
-        ensure_backtest_tables(runtime)
-        migrated_columns = {
-            table: {row[1] for row in migrated.execute(f"PRAGMA table_info({table})")}
-            for table in tables
-        }
-        runtime_columns = {
-            table: {row[1] for row in runtime.execute(f"PRAGMA table_info({table})")}
-            for table in tables
-        }
 
+def _sqlite_column_types(conn, tables):
+    """Declared type per column (``PRAGMA table_info`` row 2), normalized for comparison."""
+    return {
+        table: {row[1]: row[2].upper() for row in conn.execute(f"PRAGMA table_info({table})")}
+        for table in tables
+    }
+
+
+def _schema_sql_column_names(tables):
     schema = (ROOT / "schema.sql").read_text(encoding="utf-8")
     schema_columns = {}
     for table in tables:
@@ -278,8 +274,47 @@ def test_backtest_schema_contract_stays_in_sync_across_all_three_definitions(mon
             if line.strip()
             and not line.lstrip().startswith(("PRIMARY", "FOREIGN", "UNIQUE", "CONSTRAINT"))
         }
+    return schema_columns
 
-    assert runtime_columns == migrated_columns == schema_columns
+
+def _assert_schema_contract_in_sync(
+    monkeypatch, tmp_path, tables, setup_runtime, *, compare_types=False
+):
+    """Migration, runtime SQLite DDL, and schema.sql must agree on their column contracts.
+
+    Column names alone miss declared-type drift between the migration and the runtime
+    DDL, so ``compare_types`` additionally pins the ``PRAGMA table_info`` type column.
+    It is off for the backtest tables because they carry 17 pre-existing mismatches
+    from #1464 (for example ``price_cache.close_usd`` NUMERIC vs REAL, which is a real
+    affinity difference); reconciling those belongs to that table's owner, not here.
+    """
+    monkeypatch.delenv("DB_URL", raising=False)
+    db_path = tmp_path / "migrated.db"
+    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+
+    with sqlite3.connect(db_path) as migrated, sqlite3.connect(":memory:") as runtime:
+        setup_runtime(runtime)
+        migrated_columns = _sqlite_column_names(migrated, tables)
+        runtime_columns = _sqlite_column_names(runtime, tables)
+        if compare_types:
+            assert _sqlite_column_types(runtime, tables) == _sqlite_column_types(migrated, tables)
+
+    assert runtime_columns == migrated_columns == _schema_sql_column_names(tables)
+
+
+def test_backtest_schema_contract_stays_in_sync_across_all_three_definitions(monkeypatch, tmp_path):
+    """Keep migration, runtime SQLite DDL, and canonical schema.sql column contracts aligned."""
+
+    def setup_runtime(runtime):
+        ensure_price_cache_table(runtime)
+        ensure_backtest_tables(runtime)
+
+    _assert_schema_contract_in_sync(
+        monkeypatch,
+        tmp_path,
+        {"price_cache", "backtest_runs", "backtest_results"},
+        setup_runtime,
+    )
 
 
 def test_manager_attribution_migration_uses_sqlite_autoincrement_primary_key(monkeypatch, tmp_path):
@@ -303,37 +338,13 @@ def test_manager_attribution_migration_uses_sqlite_autoincrement_primary_key(mon
 
 def test_manager_attribution_schema_contract_stays_in_sync(monkeypatch, tmp_path):
     """Keep migration, runtime SQLite DDL, and schema.sql column contracts aligned."""
-    monkeypatch.delenv("DB_URL", raising=False)
-    db_path = tmp_path / "migrated.db"
-    command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
-
-    tables = {"manager_attribution"}
-    with sqlite3.connect(db_path) as migrated, sqlite3.connect(":memory:") as runtime:
-        ensure_manager_attribution_table(runtime)
-        migrated_columns = {
-            table: {row[1] for row in migrated.execute(f"PRAGMA table_info({table})")}
-            for table in tables
-        }
-        runtime_columns = {
-            table: {row[1] for row in runtime.execute(f"PRAGMA table_info({table})")}
-            for table in tables
-        }
-
-    schema = (ROOT / "schema.sql").read_text(encoding="utf-8")
-    schema_columns = {}
-    for table in tables:
-        definition = re.search(
-            rf"CREATE TABLE IF NOT EXISTS {table} \((.*?)\n\);", schema, flags=re.DOTALL
-        )
-        assert definition is not None
-        schema_columns[table] = {
-            line.strip().split()[0]
-            for line in definition.group(1).splitlines()
-            if line.strip()
-            and not line.lstrip().startswith(("PRIMARY", "FOREIGN", "UNIQUE", "CONSTRAINT"))
-        }
-
-    assert runtime_columns == migrated_columns == schema_columns
+    _assert_schema_contract_in_sync(
+        monkeypatch,
+        tmp_path,
+        {"manager_attribution"},
+        ensure_manager_attribution_table,
+        compare_types=True,
+    )
 
 
 def test_filings_raw_key_unique_index(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
Implements #1465 / design #1402: position-level performance attribution as a view over `holdings_as_of` + the existing free-source price adapter (no parallel price/as-of system).

## What landed
- `etl/attribution_flow.py`: per (manager, security, disclosure period), buy-and-hold return from disclosure date to as-of; manager realized return + hit-rate aggregates; persists `manager_attribution`.
- Alembic `019` + `schema.sql` + runtime SQLite DDL kept in sync.
- Read-only API: `GET /api/signals/attribution/{manager_id}` (derived returns only; raw prices not redistributed).

## Test gate
`tests/test_attribution_flow.py`:
- two known post-disclosure price paths → hand-computed AAA +30%, BBB −20%, manager realized 5%, hit-rate 50%
- no look-ahead (future knowledge_time excluded)
- **Deliberate break → restore:** `entry_date_offset_days=-1` fails the hand-computed assertion; restoring offset 0 returns green

Also: migration autoincrement + three-way schema contract tests for `manager_attribution`.

## Validation
```
pytest tests/test_attribution_flow.py + attribution schema contract tests → pass
ruff check/format → clean
black --fast → clean
scripts/check_dialect_portability.py → exit 0
```

Closes #1465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added position- and manager-level performance attribution.
  * Added an API endpoint to view attribution results, returns, totals, and hit rates.
  * Added support for storing attribution details, including prices, values, statuses, and skip reasons.
  * Added safeguards to prevent future information from affecting historical calculations.

* **Tests**
  * Added coverage for return calculations, summaries, persistence, schema consistency, and look-ahead prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->