### PR TITLE
fix(alembic): stop migrations from disabling existing loggers

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -13,7 +13,11 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # disable_existing_loggers defaults to True, which would switch off every logger
+    # created before this runs. Under pytest that silences application loggers for the
+    # rest of the session, so any later caplog assertion fails purely on collection
+    # order (see tests/test_alembic_logging_isolation.py).
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/tests/test_alembic_logging_isolation.py
+++ b/tests/test_alembic_logging_isolation.py
@@ -1,0 +1,66 @@
+"""Running a migration must not disable loggers that already exist.
+
+`alembic/env.py` calls `logging.config.fileConfig`, whose `disable_existing_loggers`
+argument defaults to True. With the default, any test that runs `command.upgrade`
+switches off every logger created before it for the rest of the pytest session, so a
+later test asserting on log output fails or passes purely by collection order. That is
+how `tests/test_backtest_flow.py::test_missing_price_skips_position_without_crashing`
+fails when it runs after `tests/test_schema.py` but passes on its own.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from alembic.config import Config
+
+from alembic import command
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _alembic_config(url: str) -> Config:
+    config = Config(str(ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(ROOT / "alembic"))
+    config.set_main_option("sqlalchemy.url", url)
+    return config
+
+
+class _RecordingHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+def test_migration_does_not_disable_preexisting_loggers(monkeypatch, tmp_path):
+    """A logger created before a migration is still enabled and still emits after it.
+
+    The probe carries its own handler rather than using `caplog`, because `fileConfig`
+    always rebuilds the root logger's handlers. The regression being guarded is the
+    `disabled` flag that `disable_existing_loggers=True` sets on every existing logger.
+    """
+    monkeypatch.delenv("DB_URL", raising=False)
+    logger = logging.getLogger("tests.alembic_logging_isolation.probe")
+    handler = _RecordingHandler()
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        logger.warning("before migration")
+        assert handler.messages == ["before migration"]
+
+        command.upgrade(_alembic_config(f"sqlite:///{tmp_path / 'migrated.db'}"), "head")
+
+        assert logger.disabled is False, (
+            "alembic env.py disabled an existing logger; pass "
+            "disable_existing_loggers=False to fileConfig"
+        )
+        assert logger.isEnabledFor(logging.WARNING)
+
+        logger.warning("after migration")
+        assert handler.messages == ["before migration", "after migration"]
+    finally:
+        logger.removeHandler(handler)


### PR DESCRIPTION
## Problem

`alembic/env.py` configures logging with:

```python
fileConfig(config.config_file_name)
```

`logging.config.fileConfig` defaults to `disable_existing_loggers=True`, so the first migration a pytest session runs sets `disabled = True` on **every logger created before that point** — and they stay disabled for the rest of the session. Any later test that asserts on log output then fails or passes purely by collection order.

This is a latent `main` defect, in the same family as the reload-pollution bug fixed by #1499.

## Reproduction

```
$ pytest tests/test_backtest_flow.py::test_missing_price_skips_position_without_crashing
1 passed

$ pytest tests/test_schema.py tests/test_backtest_flow.py
FAILED tests/test_backtest_flow.py::test_missing_price_skips_position_without_crashing
E   AssertionError: assert 'Missing price for position' in ''
```

`tests/test_schema.py` runs `command.upgrade(..., "head")`, which disables `etl.backtest_flow`'s logger. CI is green today only because the default collection order happens to be favourable — the same fragility that hid the #1499 defect until a new test file shifted the order.

Found while addressing review on #1503, which adds tests to `tests/test_schema.py`.

## Change

- `alembic/env.py`: pass `disable_existing_loggers=False`, with a comment recording why.
- `tests/test_alembic_logging_isolation.py`: regression gate. A probe logger with its own handler is warmed up, a migration runs to head, and the test asserts the logger is still enabled and still emits. It deliberately avoids `caplog` because `fileConfig` always rebuilds the root logger's handlers; the regression being guarded is the `disabled` flag, not handler survival.

## Validation

- `pytest tests/test_alembic_logging_isolation.py` — passes.
- `pytest tests/test_alembic_logging_isolation.py tests/test_schema.py tests/test_backtest_flow.py` — **31 passed**; the ordering failure above no longer reproduces.
- **Deliberate break**: reverting to `fileConfig(config.config_file_name)` fails *both* the new gate and `test_missing_price_skips_position_without_crashing`; restoring the fix makes all 31 pass again.
- `ruff check .` and `black --check .` clean.

## Non-goals

No application logging behavior changes. The alembic logger configuration in `alembic.ini` is untouched; only the disabling of unrelated pre-existing loggers stops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing application logging during database migrations.
  * Prevented previously configured loggers from being disabled when migrations run.

* **Tests**
  * Added regression coverage to verify logging continues before and after migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->