### PR TITLE
feat: archive activism documents and profiles

### DIFF
--- a/alembic/versions/020_activism_documents.py
+++ b/alembic/versions/020_activism_documents.py
@@ -1,0 +1,41 @@
+"""Add activism document references for campaign archive profiles (#1468)."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "020"
+down_revision = "019"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "activism_documents",
+        sa.Column("document_id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "campaign_id",
+            sa.Integer(),
+            sa.ForeignKey("activism_campaigns.campaign_id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "filing_id", sa.Integer(), sa.ForeignKey("activism_filings.filing_id"), nullable=False
+        ),
+        sa.Column("doc_type", sa.Text(), nullable=False),
+        sa.Column("source_url", sa.Text(), nullable=True),
+        sa.Column("raw_key", sa.Text(), nullable=True),
+        sa.Column("filed_date", sa.Date(), nullable=False),
+        sa.UniqueConstraint("campaign_id", "filing_id", "doc_type", "source_url"),
+    )
+    op.create_index(
+        "idx_activism_documents_campaign", "activism_documents", ["campaign_id", "filed_date"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_activism_documents_campaign", table_name="activism_documents")
+    op.drop_table("activism_documents")

--- a/api/activism.py
+++ b/api/activism.py
@@ -89,6 +89,23 @@ class ActivismCampaignTimelineResponse(BaseModel):
     source_url: str | None
 
 
+class ActivismDocumentResponse(BaseModel):
+    document_id: int
+    filing_id: int
+    doc_type: str
+    source_url: str | None
+    raw_key: str | None
+    filed_date: date
+
+
+class ManagerActivismProfileResponse(BaseModel):
+    manager_id: int
+    manager_name: str | None
+    campaign_count: int
+    average_window_return: float | None
+    sectors: list[str] = Field(default_factory=list)
+
+
 def _to_float(value: Any) -> float | None:
     if value is None:
         return None
@@ -462,6 +479,52 @@ def query_activism_campaign_timeline(
     ]
 
 
+def query_activism_documents(conn: Any, campaign_id: int) -> list[ActivismDocumentResponse]:
+    if not table_exists(conn, "activism_documents"):
+        return []
+    ph = get_placeholder(conn)
+    rows = conn.execute(
+        "SELECT document_id, filing_id, doc_type, source_url, raw_key, filed_date "
+        f"FROM activism_documents WHERE campaign_id = {ph} "
+        "ORDER BY filed_date ASC, filing_id ASC, document_id ASC",
+        (campaign_id,),
+    ).fetchall()
+    return [
+        ActivismDocumentResponse(
+            document_id=int(row[0]),
+            filing_id=int(row[1]),
+            doc_type=str(row[2]),
+            source_url=str(row[3]) if row[3] is not None else None,
+            raw_key=str(row[4]) if row[4] is not None else None,
+            filed_date=_to_date(row[5]),
+        )
+        for row in rows
+    ]
+
+
+def query_manager_activism_profile(
+    conn: Any, manager_id: int
+) -> ManagerActivismProfileResponse | None:
+    if not table_exists(conn, "activism_campaigns"):
+        return None
+    ph = get_placeholder(conn)
+    row = conn.execute(
+        "SELECT ac.manager_id, m.name, COUNT(*), AVG(ac.window_return) "
+        "FROM activism_campaigns ac LEFT JOIN managers m ON m.manager_id = ac.manager_id "
+        f"WHERE ac.manager_id = {ph} GROUP BY ac.manager_id, m.name",
+        (manager_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return ManagerActivismProfileResponse(
+        manager_id=int(row[0]),
+        manager_name=str(row[1]) if row[1] is not None else None,
+        campaign_count=int(row[2]),
+        average_window_return=_to_float(row[3]),
+        sectors=[],
+    )
+
+
 @router.get(
     "/api/activism/filings",
     response_model=list[ActivismFilingResponse],
@@ -596,5 +659,31 @@ async def get_activism_campaign_timeline(
     conn = connect_db()
     try:
         return query_activism_campaign_timeline(conn, campaign_id)
+    finally:
+        conn.close()
+
+
+@router.get(
+    "/api/activism/campaigns/{campaign_id}/documents",
+    response_model=list[ActivismDocumentResponse],
+    summary="List campaign document references",
+)
+async def get_activism_campaign_documents(campaign_id: int) -> list[ActivismDocumentResponse]:
+    conn = connect_db()
+    try:
+        return query_activism_documents(conn, campaign_id)
+    finally:
+        conn.close()
+
+
+@router.get(
+    "/api/activism/managers/{manager_id}/profile",
+    response_model=ManagerActivismProfileResponse | None,
+    summary="Get an activist manager campaign profile",
+)
+async def get_manager_activism_profile(manager_id: int) -> ManagerActivismProfileResponse | None:
+    conn = connect_db()
+    try:
+        return query_manager_activism_profile(conn, manager_id)
     finally:
         conn.close()

--- a/etl/activism_campaign_flow.py
+++ b/etl/activism_campaign_flow.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any, Protocol
 
-from adapters.base import get_placeholder, is_postgres, is_sqlite, table_exists
+from adapters.base import get_placeholder, get_table_columns, is_postgres, is_sqlite, table_exists
 from adapters.prices import PriceAdapter
 
 
@@ -84,6 +84,16 @@ def ensure_activism_campaign_tables(conn: Any) -> None:
                 source_url TEXT,
                 UNIQUE(campaign_id, filing_id, event_id)
             )""")
+        conn.execute("""CREATE TABLE IF NOT EXISTS activism_documents (
+                document_id INTEGER PRIMARY KEY,
+                campaign_id INTEGER NOT NULL REFERENCES activism_campaigns(campaign_id),
+                filing_id INTEGER NOT NULL REFERENCES activism_filings(filing_id),
+                doc_type TEXT NOT NULL,
+                source_url TEXT,
+                raw_key TEXT,
+                filed_date TEXT NOT NULL,
+                UNIQUE(campaign_id, filing_id, doc_type, source_url)
+            )""")
     elif is_postgres(conn):
         conn.execute("""CREATE TABLE IF NOT EXISTS activism_campaigns (
                 campaign_id BIGSERIAL PRIMARY KEY,
@@ -121,10 +131,24 @@ def ensure_activism_campaign_tables(conn: Any) -> None:
                 source_url TEXT,
                 UNIQUE(campaign_id, filing_id, event_id)
             )""")
+        conn.execute("""CREATE TABLE IF NOT EXISTS activism_documents (
+                document_id BIGSERIAL PRIMARY KEY,
+                campaign_id BIGINT NOT NULL REFERENCES activism_campaigns(campaign_id),
+                filing_id BIGINT NOT NULL REFERENCES activism_filings(filing_id),
+                doc_type TEXT NOT NULL,
+                source_url TEXT,
+                raw_key TEXT,
+                filed_date DATE NOT NULL,
+                UNIQUE(campaign_id, filing_id, doc_type, source_url)
+            )""")
     else:
         raise TypeError(f"Unsupported database connection type: {type(conn)!r}")
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_activism_campaigns_manager ON activism_campaigns(manager_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activism_documents_campaign "
+        "ON activism_documents(campaign_id, filed_date)"
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_activism_campaigns_status ON activism_campaigns(status)"
@@ -275,6 +299,37 @@ def _campaign_return(
     return value if math.isfinite(value) else None
 
 
+def _document_references(row: tuple[Any, ...]) -> list[tuple[str, str | None, str | None]]:
+    """Return safe document-reference metadata without ingesting document contents."""
+    url = str(row[7]) if row[7] else None
+    raw_key = str(row[8]) if len(row) > 8 and row[8] else None
+    references: list[tuple[str, str | None, str | None]] = [("filing", url, raw_key)]
+    if len(row) <= 9 or not row[9]:
+        return references
+    try:
+        metadata = json.loads(str(row[9]))
+    except (TypeError, ValueError):
+        return references
+    if not isinstance(metadata, list):
+        return references
+    for item in metadata:
+        if not isinstance(item, dict):
+            continue
+        reference_url = item.get("url") or item.get("href")
+        reference_key = item.get("raw_key") or item.get("key")
+        if not reference_url and not reference_key:
+            continue
+        doc_type = str(item.get("doc_type") or item.get("type") or "exhibit").strip() or "exhibit"
+        references.append(
+            (
+                doc_type,
+                str(reference_url) if reference_url else None,
+                str(reference_key) if reference_key else None,
+            )
+        )
+    return references
+
+
 def materialize_activism_campaigns(
     conn: Any, since: date | None = None, *, price_adapter: PriceLookup | None = None
 ) -> CampaignRunSummary:
@@ -288,9 +343,14 @@ def materialize_activism_campaigns(
     if price_adapter is None and table_exists(conn, "identifier_resolution_cache"):
         price_adapter = PriceAdapter(conn)
     ph = get_placeholder(conn)
+    filing_columns = get_table_columns(conn, "activism_filings")
+    raw_key_sql = "af.raw_key" if "raw_key" in filing_columns else "NULL"
+    document_metadata_sql = (
+        "af.document_references" if "document_references" in filing_columns else "NULL"
+    )
     rows = conn.execute(
         "SELECT af.filing_id, af.manager_id, af.filing_type, af.subject_company, af.subject_cusip, "
-        "af.ownership_pct, af.filed_date, af.url FROM activism_filings af "
+        f"af.ownership_pct, af.filed_date, af.url, {raw_key_sql}, {document_metadata_sql} FROM activism_filings af "
         "ORDER BY af.manager_id, af.filed_date, af.filing_id"
     ).fetchall()
     events_by_filing: dict[int, list[tuple[Any, ...]]] = defaultdict(list)
@@ -397,6 +457,16 @@ def materialize_activism_campaigns(
                     ),
                 )
                 timeline_count += 1
+            conn.execute(
+                f"DELETE FROM activism_documents WHERE campaign_id = {ph} AND filing_id = {ph}",
+                (campaign_id, filing_id),
+            )
+            for doc_type, source_url, raw_key in _document_references(filing):
+                conn.execute(
+                    "INSERT INTO activism_documents(campaign_id, filing_id, doc_type, source_url, raw_key, filed_date) "
+                    f"VALUES ({', '.join([ph] * 6)})",
+                    (campaign_id, filing_id, doc_type, source_url, raw_key, str(filing[6])),
+                )
     conn.commit()
     return CampaignRunSummary(
         len(rows), len(grouped), timeline_count, sum(skipped.values()), dict(skipped)

--- a/schema.sql
+++ b/schema.sql
@@ -168,6 +168,19 @@ CREATE INDEX IF NOT EXISTS idx_activism_campaign_timeline_campaign
 CREATE UNIQUE INDEX IF NOT EXISTS uq_activism_campaign_timeline_filing_only
     ON activism_campaign_timeline (campaign_id, filing_id) WHERE event_id IS NULL;
 
+CREATE TABLE IF NOT EXISTS activism_documents (
+    document_id bigserial PRIMARY KEY,
+    campaign_id bigint NOT NULL REFERENCES activism_campaigns(campaign_id),
+    filing_id bigint NOT NULL REFERENCES activism_filings(filing_id),
+    doc_type text NOT NULL,
+    source_url text,
+    raw_key text,
+    filed_date date NOT NULL,
+    UNIQUE (campaign_id, filing_id, doc_type, source_url)
+);
+CREATE INDEX IF NOT EXISTS idx_activism_documents_campaign
+    ON activism_documents(campaign_id, filed_date);
+
 CREATE TABLE IF NOT EXISTS holdings (
     holding_id bigserial PRIMARY KEY,
     filing_id bigint NOT NULL REFERENCES filings(filing_id),

--- a/tests/test_activism_api.py
+++ b/tests/test_activism_api.py
@@ -195,6 +195,8 @@ def test_activism_router_is_registered(tmp_path, monkeypatch):
         "/api/activism/campaigns",
         "/api/activism/campaigns/{campaign_id}",
         "/api/activism/campaigns/{campaign_id}/timeline",
+        "/api/activism/campaigns/{campaign_id}/documents",
+        "/api/activism/managers/{manager_id}/profile",
     }
     assert expected_paths.issubset(route_paths(app.routes))
 
@@ -323,6 +325,20 @@ def test_campaign_endpoints_return_grouped_timeline(tmp_path, monkeypatch):
         "2024-05-03",
         "2024-05-03",
     ]
+
+    documents = asyncio.run(
+        _request(f"/api/activism/campaigns/{campaign['campaign_id']}/documents")
+    )
+    assert documents.status_code == 200
+    assert [(item["doc_type"], item["source_url"]) for item in documents.json()] == [
+        ("filing", "https://sec.example/10"),
+        ("filing", "https://sec.example/11"),
+    ]
+
+    profile = asyncio.run(_request("/api/activism/managers/1/profile"))
+    assert profile.status_code == 200
+    assert profile.json()["campaign_count"] == 1
+    assert profile.json()["sectors"] == []
 
 
 def test_campaign_list_applies_target_date_and_limit_filters(tmp_path, monkeypatch):

--- a/tests/test_activism_campaign_flow.py
+++ b/tests/test_activism_campaign_flow.py
@@ -53,6 +53,14 @@ def test_materialize_campaigns_groups_amendments_by_manager_and_target() -> None
         ("2024-05-01", "initial_filing", "SC 13D"),
         ("2024-05-03", "threshold_crossing", "SC 13D/A"),
     ]
+    documents = conn.execute(
+        "SELECT doc_type, source_url FROM activism_documents ORDER BY filing_id"
+    ).fetchall()
+    assert documents == [
+        ("filing", "https://sec/1"),
+        ("filing", "https://sec/2"),
+        ("filing", "https://sec/3"),
+    ]
 
 
 def test_materialize_campaigns_orders_group_members_by_filing_date() -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -22,6 +22,7 @@ EXPECTED_TABLES = {
     "activism_events",
     "activism_campaigns",
     "activism_campaign_timeline",
+    "activism_documents",
     "alert_rules",
     "alert_history",
     "chat_feedback",
@@ -157,7 +158,7 @@ def test_activism_campaign_definitions_stay_in_sync(monkeypatch, tmp_path):
     db_path = tmp_path / "migrated.db"
     command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
 
-    tables = {"activism_campaigns", "activism_campaign_timeline"}
+    tables = {"activism_campaigns", "activism_campaign_timeline", "activism_documents"}
     with sqlite3.connect(db_path) as migrated, sqlite3.connect(":memory:") as runtime:
         ensure_activism_campaign_tables(runtime)
         migrated_columns = {


### PR DESCRIPTION
## Summary
- materialize per-campaign filing and exhibit document references without copying document text
- expose campaign documents and manager campaign-profile APIs
- keep Alembic, canonical schema, and SQLite runtime definitions aligned

## Validation
- `uv run pytest -q tests/test_activism_campaign_flow.py tests/test_activism_api.py tests/test_schema.py`
- `uv run ruff check etl/activism_campaign_flow.py api/activism.py tests/test_activism_campaign_flow.py tests/test_activism_api.py tests/test_schema.py alembic/versions/020_activism_documents.py`
- `uv run black --fast --check etl/activism_campaign_flow.py api/activism.py tests/test_activism_campaign_flow.py tests/test_activism_api.py tests/test_schema.py alembic/versions/020_activism_documents.py`

Closes #1468