### PR TITLE
fix(alembic): give the activism-documents migration a unique revision

### DIFF
--- a/alembic/versions/021_activism_documents.py
+++ b/alembic/versions/021_activism_documents.py
@@ -6,8 +6,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision = "020"
-down_revision = "019"
+revision = "021"
+down_revision = "020"
 branch_labels = None
 depends_on = None
 

--- a/tests/test_alembic_revision_graph.py
+++ b/tests/test_alembic_revision_graph.py
@@ -27,22 +27,42 @@ def _script_directory() -> ScriptDirectory:
     return ScriptDirectory.from_config(config)
 
 
+def _migration_files() -> list[Path]:
+    """Every migration script, regardless of naming convention.
+
+    Alembic does not require numeric filenames, so this must not glob `[0-9]*`.
+    """
+    return sorted(
+        path
+        for path in VERSIONS.glob("*.py")
+        if path.name != "__init__.py" and not path.name.startswith("_")
+    )
+
+
 def _declared_revision(path: Path) -> str | None:
-    """Read the module-level `revision` literal without importing the migration."""
+    """Read the module-level `revision` literal without importing the migration.
+
+    Handles the annotated form (`revision: str = "021"`) that Alembic's newer
+    script template emits as well as the plain assignment.
+    """
     for node in ast.parse(path.read_text(encoding="utf-8")).body:
-        if not isinstance(node, ast.Assign):
+        if isinstance(node, ast.Assign):
+            targets: tuple[ast.expr, ...] = tuple(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = (node.target,)
+        else:
             continue
-        for target in node.targets:
-            if isinstance(target, ast.Name) and target.id == "revision":
-                if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
-                    return node.value.value
+        if not any(isinstance(target, ast.Name) and target.id == "revision" for target in targets):
+            continue
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            return node.value.value
     return None
 
 
 def test_revision_identifiers_are_unique():
     """Parse the files rather than the revision map, which keys by id and hides collisions."""
     by_revision: dict[str, list[str]] = defaultdict(list)
-    for path in sorted(VERSIONS.glob("[0-9]*.py")):
+    for path in _migration_files():
         revision = _declared_revision(path)
         assert revision is not None, f"{path.name} declares no module-level revision id"
         by_revision[revision].append(path.name)
@@ -68,7 +88,11 @@ def test_migration_graph_has_exactly_one_head():
 
 def test_every_migration_reaches_the_base():
     script_directory = _script_directory()
-    (head,) = script_directory.get_heads()
+    heads = script_directory.get_heads()
+    # Assert before indexing so a multi-head graph reports the violation rather
+    # than raising an unpacking ValueError from this test's own setup.
+    assert len(heads) == 1, f"expected exactly one head, got {sorted(heads)}"
+    head = heads[0]
 
     walked = {script.revision for script in script_directory.walk_revisions("base", head)}
     orphans = sorted(

--- a/tests/test_alembic_revision_graph.py
+++ b/tests/test_alembic_revision_graph.py
@@ -1,0 +1,83 @@
+"""The migration graph must stay linear with exactly one head.
+
+Two feature branches numbered their migration from the same parent, so `020`
+was declared twice on `main` and every `alembic upgrade head` raised
+`MultipleHeads: 020, 020` (CI run 30655077499). Nothing failed until the second
+branch merged, because each PR only ever saw its own revision id. These checks
+read the revision map directly, so a collision fails on the branch that
+introduces it rather than on `main` after the merge.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+VERSIONS = ROOT / "alembic" / "versions"
+
+
+def _script_directory() -> ScriptDirectory:
+    config = Config(str(ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(ROOT / "alembic"))
+    return ScriptDirectory.from_config(config)
+
+
+def _declared_revision(path: Path) -> str | None:
+    """Read the module-level `revision` literal without importing the migration."""
+    for node in ast.parse(path.read_text(encoding="utf-8")).body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "revision":
+                if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                    return node.value.value
+    return None
+
+
+def test_revision_identifiers_are_unique():
+    """Parse the files rather than the revision map, which keys by id and hides collisions."""
+    by_revision: dict[str, list[str]] = defaultdict(list)
+    for path in sorted(VERSIONS.glob("[0-9]*.py")):
+        revision = _declared_revision(path)
+        assert revision is not None, f"{path.name} declares no module-level revision id"
+        by_revision[revision].append(path.name)
+
+    duplicates = {rev: files for rev, files in by_revision.items() if len(files) > 1}
+
+    assert not duplicates, (
+        f"duplicate alembic revision identifier(s): {duplicates}. "
+        "Two migrations claim the same revision id, so alembic cannot resolve "
+        "the upgrade path. Renumber the migration that merged later."
+    )
+
+
+def test_migration_graph_has_exactly_one_head():
+    heads = _script_directory().get_heads()
+
+    assert len(heads) == 1, (
+        f"alembic has {len(heads)} heads ({sorted(heads)}), expected exactly one. "
+        "A new migration must set down_revision to the current head; rebase and "
+        "renumber if another migration landed first."
+    )
+
+
+def test_every_migration_reaches_the_base():
+    script_directory = _script_directory()
+    (head,) = script_directory.get_heads()
+
+    walked = {script.revision for script in script_directory.walk_revisions("base", head)}
+    orphans = sorted(
+        script.revision
+        for script in script_directory.walk_revisions()
+        if script.revision not in walked
+    )
+
+    assert not orphans, (
+        f"migration(s) {orphans} are not reachable from base..{head}; "
+        "their down_revision points outside the main chain."
+    )

--- a/tests/test_app_health.py
+++ b/tests/test_app_health.py
@@ -130,6 +130,9 @@ def test_health_livez_ok():
 @pytest.mark.asyncio
 async def test_health_app_reports_failed_dependencies(tmp_path, monkeypatch):
     _configure_health_env(monkeypatch, tmp_path)
+    # Real backoff sleeps would consume most of the 0.18s budget, so a slow runner
+    # reports "timeout" instead of the dependency error this test is asserting on.
+    monkeypatch.setattr(chat, "_HEALTH_RETRY_BACKOFFS", ())
 
     def _raise_minio(_timeout_seconds):
         raise RuntimeError("minio down")
@@ -458,6 +461,10 @@ async def test_circuit_breaker_allows_dependency_after_cooldown(monkeypatch):
 @pytest.mark.asyncio
 async def test_health_app_reports_circuit_breaker_open(tmp_path, monkeypatch):
     _configure_health_env(monkeypatch, tmp_path)
+    # Without this the first check races the 0.18s budget against real backoff
+    # sleeps and records "timeout", which is a different failure reason than the
+    # dependency error the circuit is supposed to report here.
+    monkeypatch.setattr(chat, "_HEALTH_RETRY_BACKOFFS", ())
     monkeypatch.setattr(
         chat, "_MINIO_CIRCUIT", chat.CircuitBreaker(failure_threshold=1, reset_timeout_s=60.0)
     )


### PR DESCRIPTION
Bounded closer follow-up. `main` is currently red; this restores it.

## Defect 1 — duplicate Alembic revision `020` (breaks every migration)

#1503 (source #1465) and #1506 (source #1468) each numbered their migration from parent `019` and merged 63 seconds apart, so `main` now declares `revision = "020"` twice:

- `alembic/versions/020_manager_attribution.py` — `revision = "020"`, `down_revision = "019"`
- `alembic/versions/020_activism_documents.py` — `revision = "020"`, `down_revision = "019"`

Every `alembic upgrade head` therefore raises `alembic.script.revision.MultipleHeads: Multiple heads are present for given argument 'head'; 020, 020`. CI run [30655077499](https://github.com/stranske/Manager-Database/actions/runs/30655077499) fails on both python 3.12 and 3.13 at head `9b258139`. Both verifier providers on #1506 independently identified this (openai `FAIL` 96%, anthropic `CONCERNS` 75%).

**Fix:** renumber the later-merged migration to `021_activism_documents.py` with `revision = "021"`, `down_revision = "020"`. No content change — the table, constraints, index, and downgrade are untouched, and no other file in the repo referenced either revision id.

**Test gate:** `tests/test_alembic_revision_graph.py` — three checks (unique revision ids, exactly one head, every migration reachable from base). The uniqueness check parses the version files with `ast` rather than reading Alembic's revision map, because the map is keyed by revision id and silently collapses a duplicate.

Deliberate break demonstrated: restoring `revision = "020"` / `down_revision = "019"` fails all three (`duplicate alembic revision identifier(s): {'020': ['020_manager_attribution.py', '021_activism_documents.py']}` and `alembic has 2 heads (['020', '020'])`); reverting to `021` returns them to green. This gate fails on the branch that introduces a collision, instead of on `main` after the second merge.

## Defect 2 — two health tests race their own timeout budget

`tests/test_app_health.py::test_health_app_reports_circuit_breaker_open` failed on python 3.12 only in CI run [30655013058](https://github.com/stranske/Manager-Database/actions/runs/30655013058) with `AssertionError: assert 'timeout' == 'minio down'`, at head `c9e56a70` — before the migration collision existed, so it is a separate defect.

`_configure_health_env` sets `HEALTH_SUMMARY_TIMEOUT_S=0.18`, while `_HEALTH_RETRY_BACKOFFS = (0.1, 0.2, 0.4)` makes the retry loop *really* sleep 0.1s before re-raising. That leaves ~80ms of slack before `asyncio.wait_for` fires and `_run_dependency_check` records `"timeout"` instead of propagating the dependency error the test asserts on. A loaded runner loses that slack; 3.13 passed and 3.12 failed in the same run.

**Fix:** the two tests that assert on the propagated error string now set `_HEALTH_RETRY_BACKOFFS = ()`, the same idiom `test_circuit_breaker_opens_after_three_failures`, `test_circuit_breaker_opens_after_three_timeouts`, and `test_circuit_breaker_allows_dependency_after_cooldown` already use. Retry behaviour itself is unchanged, and the timeout-focused tests still exercise the real budget.

Causality confirmed rather than assumed: with backoffs left in place and the budget shaved to `0.12` (emulating a slower runner) the test reproduces the exact CI assertion `assert 'timeout' == 'minio down'`; adding `_HEALTH_RETRY_BACKOFFS = ()` makes it pass at that same budget. That probe was scratch and is not part of this PR.

## Validation

- `pytest tests/test_alembic_revision_graph.py` — 3 passed
- `pytest tests/test_schema.py tests/test_alembic_logging_isolation.py tests/test_config_migration_consistency.py tests/test_alembic_revision_graph.py` — 27 passed (these are the suites that call `alembic upgrade head` and were failing on `main`)
- `pytest tests/test_app_health.py` — 18 passed
- `ruff check` clean; `black --check` clean on `black==26.5.1`, matching the `requirements.lock` / `pyproject.toml` pin

## Non-goals

Does not address the `#1465` verifier concern about the nullable-`filing_id` partial unique index omitting `disclosure_date`; that is a separate schema-grain question tracked on #1465.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Database Updates**
  * Added the migration needed to create and remove activism document storage.

* **Tests**
  * Added validation to ensure database migrations form a valid, complete chain with a single latest revision.
  * Improved health-check tests to provide clearer results when dependencies fail or circuit breakers open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->