### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -675,12 +675,31 @@ def _fallback_evaluation(
     )
 
 
+def _coerce_response_content(content: object) -> str:
+    """Return text from provider response blocks without losing a safe fallback."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        text_blocks = [
+            block["text"]
+            for block in content
+            if isinstance(block, dict) and isinstance(block.get("text"), str)
+        ]
+        if text_blocks:
+            # Concatenate without a separator: a provider may split one JSON
+            # document across blocks, and an inserted newline inside a string
+            # literal would make the reassembled payload invalid JSON.
+            return "".join(text_blocks)
+    return json.dumps(content, default=str)
+
+
 def _parse_llm_response(
-    content: str, provider: str, *, client: object | None = None
+    content: object, provider: str, *, client: object | None = None
 ) -> EvaluationResult:
+    content_text = _coerce_response_content(content)
     repair = _build_verifier_repair_callback(client) if client is not None else None
     parsed = parse_structured_output(
-        content,
+        content_text,
         EvaluationPayload,
         repair=repair,
         max_repair_attempts=SCHEMA_REPAIR_POLICY.max_attempts,
@@ -704,7 +723,7 @@ def _parse_llm_response(
             summary=None,
             provider_used=provider,
             used_llm=True,
-            raw_content=content,
+            raw_content=content_text,
             error=error,
         )
 
@@ -717,7 +736,7 @@ def _parse_llm_response(
         summary=payload.summary,
         provider_used=provider,
         used_llm=True,
-        raw_content=parsed.raw_content or content,
+        raw_content=parsed.raw_content or content_text,
     )
 
 
@@ -725,11 +744,14 @@ def _build_verifier_repair_callback(client: object) -> Callable[[str, str, str],
     repair = build_repair_callback(client)
 
     def _repair(schema_json: str, validation_errors: str, raw_response: str) -> str | None:
-        return repair(
+        repaired = repair(
             schema_json,
             validation_errors,
             _cap_prompt_text(raw_response, EVAL_SCHEMA_REPAIR_BUDGET_TOKENS),
         )
+        if not repaired:
+            return None
+        return _coerce_response_content(repaired)
 
     return _repair
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- pr_verifier.py: PR verifier - validates PR changes against acceptance criteria

### Files Skipped
- .github/workflows/pr-00-gate.yml: Maintains a fully custom Gate workflow; never overwrite (replaces the hard-coded custom_gate_repos list in maint-68).
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `376c3d7f338dc88b2360ccc5f07a39b8c66fc4bf`
**Template hash:** `96b68c6bcac4`
**Consumer-sync plan ID:** `sha256:96b68c6bcac46543ab549e173e746fe99091467e1c083e16949b0a48d09e1656`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-96b68c6bcac4`
**Consumer repo:** `stranske/Manager-Database`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Manager-Database","source_repository":"stranske/Workflows","source_sha":"376c3d7f338dc88b2360ccc5f07a39b8c66fc4bf","template_hash":"96b68c6bcac4","plan_id":"sha256:96b68c6bcac46543ab549e173e746fe99091467e1c083e16949b0a48d09e1656","sync_phase":"canary","sync_branch":"sync/workflows-96b68c6bcac4","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"30735049502","run_attempt":"1","changes_count":1} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:96b68c6bcac46543ab549e173e746fe99091467e1c083e16949b0a48d09e1656","generation":"96b68c6bcac4","repository":"stranske/Manager-Database","desired_tree_hash":"1d3fdaee349c839f94a613eeb7c723be76b1af59","source_commit":"376c3d7f338dc88b2360ccc5f07a39b8c66fc4bf","lease_expires_at":"2026-08-05T05:59:15Z","predecessor_prs":[],"successor_prs":[]} -->