### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -27,8 +27,8 @@ model_profile_trial_contract:
 execution_profiles:
   codex-default:
     agent: codex
-    model: gpt-5.5
-    fallback_model: gpt-5.4
+    model: gpt-5.6-terra
+    fallback_model: gpt-5.5
     runner: reusable-codex-run
     capacity_pool: codex-standard
     safety: standard

--- a/.github/scripts/verifier_verdict_json.py
+++ b/.github/scripts/verifier_verdict_json.py
@@ -79,11 +79,17 @@ def build_verdict(output: str) -> dict[str, Any]:
         verdict = _normalize_verdict(candidate.get("verdict"))
         if not verdict:
             continue
+        candidate_needs_attention = candidate.get("needs_attention")
+        needs_attention = (
+            candidate_needs_attention
+            if isinstance(candidate_needs_attention, bool)
+            else verdict != "pass"
+        )
         return {
             **candidate,
             "verdict": verdict,
             "source": "structured-json",
-            "needs_attention": bool(candidate.get("needs_attention", verdict != "pass")),
+            "needs_attention": needs_attention,
         }
 
     return {

--- a/WORKFLOW_USER_GUIDE.md
+++ b/WORKFLOW_USER_GUIDE.md
@@ -781,17 +781,16 @@ The Workflows repository includes maintenance workflows that handle sync, update
 ---
 
 ### `maint-52-sync-dev-versions.yml` - Sync Dev Versions
-**Purpose:** Updates development environment versions
+**Purpose:** Central Workflows propagation workflow; it has no consumer-template counterpart.
 
-**Trigger:** On push to main or manual
+**Trigger:** Runs only in the central Workflows repository after a settled source commit
 
 **What It Does:**
-- Syncs Python version from `.python-version`
-- Updates Node.js version in workflows
-- Updates action versions in workflows
-- Commits version bumps
+- Uses the central `autofix-versions.env` pin set
+- Opens at most one propagation PR per consumer repository
+- Records the settled canonical source commit in each delivery marker
 
-**Use When:** After dependency updates
+**Use When:** Observe central propagation; do not copy or configure this workflow in a consumer repo
 
 ---
 
@@ -830,17 +829,16 @@ The Workflows repository includes maintenance workflows that handle sync, update
 ---
 
 ### `maint-auto-update-pypi-versions.yml` - Auto-Update PyPI Packages
-**Purpose:** Automatically updates Python package versions
+**Purpose:** Central Workflows source-proposal workflow; it has no consumer-template counterpart.
 
-**Trigger:** Daily scheduled
+**Trigger:** Monday 03:00 UTC or an explicit central security override
 
 **What It Does:**
-- Checks PyPI for latest versions
-- Updates minor/patch versions automatically
-- Creates PR for major version updates
-- Runs CI to validate
+- Checks PyPI for the central dev-tool pin set
+- Batches routine changes into one mutable weekly source PR
+- Runs source validation before the consumer propagation lane can start
 
-**Safety:** Only auto-merges patch versions
+**Safety:** Consumer repos must not create partial copies of the central pin update
 
 ---
 
@@ -1117,20 +1115,15 @@ The Workflows repository includes maintenance workflows that handle sync, update
 ---
 
 ### `maint-50-tool-version-check.yml` - Tool Version Audit
-**Purpose:** Checks versions of all development tools
+**Purpose:** Central read-only freshness audit; it has no consumer-template counterpart.
 
-**Trigger:** Weekly scheduled
+**Trigger:** Weekly in the central Workflows repository
 
 **Checks:**
-- Python version
-- Node.js version
-- pip version
-- git version
-- gh version
-- docker version
-- Action versions
+- PyPI freshness for the central developer-tool pin set (`black`, `ruff`, `mypy`, `pytest`, related tooling)
+- Canonical pin alignment evidence only (no runtime/CLI/Action version inventory)
 
-**Result:** Report on outdated tools
+**Result:** Freshness evidence only; it never creates a competing update issue or PR
 
 ---
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -32,6 +32,7 @@ ASSERTION_DIFF_RE = re.compile(
     r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
 )
 DEFAULT_TIMEOUT_SECONDS = 120
+PYTEST_RUNTIME_DEPENDENCIES = ("pyyaml==6.0.3",)
 
 
 @dataclass(frozen=True)
@@ -128,6 +129,33 @@ def parse_deliberate_break_spec(markdown: str) -> DeliberateBreakSpec | None:
 
 def _pytest_command(test_id: str) -> tuple[str, ...]:
     return (sys.executable, "-m", "pytest", test_id, "-q")
+
+
+def _ensure_pytest_runtime_deps() -> None:
+    """Install lightweight deps Gate test-quality may not preinstall.
+
+    Gate's test-quality job installs only ``pytest``. Deliberate-break may still
+    collect tests that import PyYAML (for example via ``sync_manifest_compiler``).
+    Installing here avoids editing ``pr-00-gate.yml``, which forces an
+    Actions ``action_required`` approval wait on workflow-touching PRs.
+    """
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                *PYTEST_RUNTIME_DEPENDENCIES,
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
 
 
 def _run(
@@ -244,6 +272,37 @@ def verify_spec(
                     changed_assertions=tampered,
                 )
 
+    except subprocess.TimeoutExpired as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-timeout",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            timeout=exc.timeout,
+        )
+
+    try:
+        _ensure_pytest_runtime_deps()
+    except subprocess.TimeoutExpired as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-timeout",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            timeout=exc.timeout,
+        )
+    except subprocess.CalledProcessError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-install-failed",
+            detail=exc.stderr or str(exc),
+        )
+    except OSError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-install-unavailable",
+            detail=str(exc),
+        )
+
+    try:
         head_run = _run(spec.command, repo)
     except subprocess.TimeoutExpired as exc:
         return _json_result(

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -675,12 +675,39 @@ def _fallback_evaluation(
     )
 
 
+def _text_from_response_content(content: object) -> str | None:
+    """Return provider text, or None when the payload carries no text blocks."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        text_blocks = [
+            block["text"]
+            for block in content
+            if isinstance(block, dict) and isinstance(block.get("text"), str)
+        ]
+        if text_blocks:
+            # Concatenate without a separator: a provider may split one JSON
+            # document across blocks, and an inserted newline inside a string
+            # literal would make the reassembled payload invalid JSON.
+            return "".join(text_blocks)
+    return None
+
+
+def _coerce_response_content(content: object) -> str:
+    """Return text from provider response blocks without losing a safe fallback."""
+    text = _text_from_response_content(content)
+    if text is not None:
+        return text
+    return json.dumps(content, default=str)
+
+
 def _parse_llm_response(
-    content: str, provider: str, *, client: object | None = None
+    content: object, provider: str, *, client: object | None = None
 ) -> EvaluationResult:
+    content_text = _coerce_response_content(content)
     repair = _build_verifier_repair_callback(client) if client is not None else None
     parsed = parse_structured_output(
-        content,
+        content_text,
         EvaluationPayload,
         repair=repair,
         max_repair_attempts=SCHEMA_REPAIR_POLICY.max_attempts,
@@ -704,7 +731,7 @@ def _parse_llm_response(
             summary=None,
             provider_used=provider,
             used_llm=True,
-            raw_content=content,
+            raw_content=content_text,
             error=error,
         )
 
@@ -717,7 +744,7 @@ def _parse_llm_response(
         summary=payload.summary,
         provider_used=provider,
         used_llm=True,
-        raw_content=parsed.raw_content or content,
+        raw_content=parsed.raw_content or content_text,
     )
 
 
@@ -725,11 +752,21 @@ def _build_verifier_repair_callback(client: object) -> Callable[[str, str, str],
     repair = build_repair_callback(client)
 
     def _repair(schema_json: str, validation_errors: str, raw_response: str) -> str | None:
-        return repair(
+        repaired = repair(
             schema_json,
             validation_errors,
             _cap_prompt_text(raw_response, EVAL_SCHEMA_REPAIR_BUDGET_TOKENS),
         )
+        if not repaired:
+            return None
+        # The repair path must be stricter than the parse path. A reply of only
+        # thinking/metadata blocks, or of empty text blocks, is still truthy, and
+        # serializing it would hand the parser block metadata dressed up as a
+        # repair attempt — burning the one retry on noise.
+        text = _text_from_response_content(repaired)
+        if text is None or not text.strip():
+            return None
+        return text
 
     return _repair
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- check_deliberate_break.py: Opt-in Gate helper that proves named deliberate-break acceptance tests fail against the base implementation
- registry.yml: Agent registry - source of truth for agent keys and runner workflow mapping
- verifier_verdict_json.py: Extracts structured post-merge verifier verdict JSON without trusting diff text
- pr_verifier.py: PR verifier - validates PR changes against acceptance criteria
- WORKFLOW_USER_GUIDE.md: Workflow user guide - explains the CI/agent system for repo consumers

### Files Skipped
- .github/workflows/pr-00-gate.yml: Maintains a fully custom Gate workflow; never overwrite (replaces the hard-coded custom_gate_repos list in maint-68).
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `628a72520398d27262610ce6fda4dbbff7e84303`
**Template hash:** `66c434a698c8`
**Consumer-sync plan ID:** `sha256:66c434a698c815ccc2f424a4dd91191523e1a4e63bd21b83111800e2358052db`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-66c434a698c8`
**Consumer repo:** `stranske/Manager-Database`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Manager-Database","source_repository":"stranske/Workflows","source_sha":"628a72520398d27262610ce6fda4dbbff7e84303","template_hash":"66c434a698c8","plan_id":"sha256:66c434a698c815ccc2f424a4dd91191523e1a4e63bd21b83111800e2358052db","sync_phase":"canary","sync_branch":"sync/workflows-66c434a698c8","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"30872664151","run_attempt":"1","changes_count":5} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:66c434a698c815ccc2f424a4dd91191523e1a4e63bd21b83111800e2358052db","generation":"66c434a698c8","repository":"stranske/Manager-Database","desired_tree_hash":"e90dfb071a510844dc1fad49d426a0eb2fb8abca","source_commit":"628a72520398d27262610ce6fda4dbbff7e84303","lease_expires_at":"2026-08-07T02:44:47Z","predecessor_prs":[],"successor_prs":[]} -->