### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -10,8 +10,6 @@ filed with no label and no Tasks/Acceptance block is invisible to the entire
 pipeline — nothing validates it, nothing optimises it, nothing claims it. Local
 automation that files *findings* rather than *work orders* therefore produces
 issues no agent can ever pick up: good evidence, permanently unactionable.
-(Observed in Fine-Art-Archive #406-409: four well-evidenced audit findings, zero
-labels, no Tasks section between them.)
 
 Used at both ends:
   * `agents-issue-format-guard.yml` validates every issue on open/edit and, on
@@ -63,14 +61,83 @@ RECOMMENDED: dict[str, tuple[str, ...]] = {
 GATE = re.compile(
     r"(tests?/[\w./-]+\.py(::[\w:\[\]-]+)?"
     r"|\btest_[\w]+"
-    r"|\bpytest\b|\bnpm test\b|\bmake test\b"
+    r"|\bpytest\b|\b(?:python(?:3)?\s+-m\s+(?:unittest|pytest)\b)"
+    r"|\bnode\s+--test\b|\b(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
+    r"|\b(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
     r"|\bgh workflow run\b|\bgh run\b"
     r"|\bcurl\b|\bHTTP [1-5]\d\d\b"
     r"|\b(?:API|endpoint|request|response)\s+(?:returns?|responds with)\s+[1-5]\d\d(?:\s+status)?\b"
     r"|\bsmoke\b|\bverif\w*)",
     re.I,
 )
-BANNED_ADJECTIVES = ("clean", "nice", "good", "fast", "better", "intuitive", "polished")
+BANNED_ADJECTIVES = (
+    "clean",
+    "nice",
+    "good",
+    "fast",
+    "better",
+    "intuitive",
+    "polished",
+    "performant",
+)
+_TASK_CATEGORY = r"(?:file|function|class|method|path|config(?:uration)?|key|job|workflow|command)"
+_TASK_EXTENSION = (
+    r"py|js|jsx|ts|tsx|yml|yaml|json|toml|md|sh|go|rs|java|kt|rb|php|css|html|sql|"
+    r"xml|txt|ini|cfg|conf|lock|gradle|swift|c|cc|cpp|h|hpp|cs|fs|r|jl"
+)
+_TASK_KNOWN_BASENAME = (
+    r"(?:Dockerfile|Makefile|Justfile|Procfile|Gemfile|Rakefile|"
+    r"Cargo\.toml|pyproject\.toml|package\.json|go\.mod|go\.sum|pom\.xml|"
+    r"build\.gradle|CMakeLists\.txt|README(?:\.(?:md|rst|txt))?|"
+    r"LICENSE(?:\.(?:md|txt))?|\.gitignore|\.editorconfig)"
+)
+_TASK_COMMAND = (
+    r"(?:python(?:3)?|pytest|npm|pnpm|yarn|make|just|cargo|go|dotnet|gh|curl|"
+    r"node|vitest|jest|playwright)"
+)
+
+
+def _concrete_span(span: str) -> bool:
+    """Return True when a backticked/unquoted token names a real work target."""
+    span = span.strip()
+    if not span:
+        return False
+    if re.fullmatch(_TASK_CATEGORY, span, re.I):
+        return False
+    # Bare lowercase English words (`bugs`, `later`) are not actionable targets.
+    if re.fullmatch(r"[a-z]{2,24}", span):
+        return False
+    if "/" in span or span.startswith("."):
+        return True
+    if re.fullmatch(_TASK_KNOWN_BASENAME, span, re.I):
+        return True
+    if re.fullmatch(rf"[\w.-]+\.(?:{_TASK_EXTENSION})", span, re.I):
+        return True
+    if "_" in span or "." in span:
+        return True
+    # Multi-segment CamelCase / PascalCase symbols (e.g. IssueFormatter).
+    return re.fullmatch(r"[A-Z][a-zA-Z0-9]*(?:[A-Z][a-zA-Z0-9]+)+", span) is not None
+
+
+def _task_has_concrete_target(item: str) -> bool:
+    """True when a task checkbox names a file, path, symbol, config, job, or command."""
+    # Category word must be followed by a concrete identifier (not "file handling").
+    for match in re.finditer(rf"\b{_TASK_CATEGORY}\s+(`[^`]+`|[^\s]+)", item, re.I):
+        token = match.group(1)
+        span = token[1:-1] if token.startswith("`") and token.endswith("`") else token.strip("'\"")
+        if _concrete_span(span):
+            return True
+    for match in re.finditer(r"`([^`]+)`", item):
+        if _concrete_span(match.group(1)):
+            return True
+    if re.search(rf"(?:^|[\s])({_TASK_KNOWN_BASENAME})\b", item, re.I):
+        return True
+    if re.search(rf"(?:^|[\s])([\w.-]+\.(?:{_TASK_EXTENSION}))\b", item, re.I):
+        return True
+    # Unquoted path with a directory separator (src/main.go, .github/workflows/x.yml).
+    if re.search(r"(?:^|[\s])((?:\./)?[\w.-]+(?:/[\w./-]+)+)", item):
+        return True
+    return re.search(rf"\b{_TASK_COMMAND}\b", item, re.I) is not None
 
 
 def _headings(body: str) -> list[tuple[str, int, int]]:
@@ -165,12 +232,18 @@ def validate(body: str) -> Report:
             report.missing_recommended.append(name)
 
     tasks_at = _find(body, REQUIRED["Tasks"])
-    if tasks_at is not None and not re.search(
-        r"^\s*[-*]\s*\[[ xX]\]", _section_text(body, tasks_at), re.M
-    ):
-        report.problems.append(
-            "`Tasks` has no checkbox items (`- [ ] …`); agents track progress by them."
+    if tasks_at is not None:
+        task_items = re.findall(
+            r"^\s*[-*]\s*\[[ xX]\]\s*(.+)$", _section_text(body, tasks_at), re.M
         )
+        if not task_items:
+            report.problems.append(
+                "`Tasks` has no checkbox items (`- [ ] …`); agents track progress by them."
+            )
+        elif any(not _task_has_concrete_target(item) for item in task_items):
+            report.problems.append(
+                "`Tasks` must name a concrete file, symbol, path, config key, job, or command."
+            )
 
     acceptance_at = _find(body, REQUIRED["Acceptance Criteria"])
     if acceptance_at is not None:

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -16,8 +16,12 @@ permissions:
   issues: write
 
 concurrency:
-  group: issue-format-guard-${{ github.event.issue.number || inputs.issue_number }}
-  cancel-in-progress: true
+  # `inputs` only exists for workflow_dispatch/workflow_call.  Event inputs are
+  # null for issue events, so retain the manual fallback without making normal
+  # issue-triggered runs depend on the dispatch-only context.
+  group: issue-format-guard-${{ github.event.issue.number || github.event.inputs.issue_number || inputs.issue_number }}
+  # A skipped label event must never cancel an in-flight opened/edited check.
+  cancel-in-progress: false
 
 jobs:
   check:
@@ -111,32 +115,69 @@ jobs:
           NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' | grep -qx true; then
+          # Re-fetch before side effects: cancel-in-progress is false so a queued
+          # older run must not dispatch against a body a newer edit already fixed.
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,body,labels,state,author > live.json
+          jq -r '.body // ""' live.json > body.md
+          if jq -e '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' live.json >/dev/null; then
             echo "Issue is now held — skipping optimizer dispatch."
             exit 0
           fi
-          fingerprint="$(sha256sum body.md | cut -c1-12)"
-          if ! gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
-              --jq '.comments[].body' | grep -qF "format-guard:$fingerprint"; then
-            {
-              cat report.md
-              echo
-              echo "Dispatching the Agents Issue Optimizer format phase."
-              echo
-              echo "<!-- format-guard:$fingerprint -->"
-            } | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
+          if [[ -f .github/scripts/issue_format.py ]]; then
+            if python3 .github/scripts/issue_format.py body.md > report.md; then
+              echo "Live body now conforms — skipping optimizer dispatch."
+              exit 0
+            fi
           fi
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '.labels[].name' | grep -qx 'agents:formatted'; then
+          fingerprint="$(sha256sum body.md | cut -c1-12)"
+          marker="<!-- format-guard:$fingerprint -->"
+          # Only trust exact HTML markers authored by automation bots (not user text).
+          trusted_marker=false
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
+              --jq '.comments[] | select((.author.login // "") | test("\\[bot\\]$|github-actions"; "i")) | .body' \
+              | grep -qF "$marker"; then
+            trusted_marker=true
+          fi
+          has_format_label=false
+          if jq -e '[.labels[].name] | any(. == "agents:format")' live.json >/dev/null; then
+            has_format_label=true
+          fi
+          # Dedup completed handoffs, but retry when a prior dispatch/optimizer run
+          # left agents:format set (marker without a finished optimizer pass).
+          dispatch=true
+          if [[ "$trusted_marker" == true && "$has_format_label" != true ]]; then
+            echo "Identical invalid body was already routed; skipping duplicate dispatch."
+            dispatch=false
+          elif [[ "$trusted_marker" == true && "$has_format_label" == true ]]; then
+            echo "Prior format-guard marker present but agents:format still set — retrying optimizer dispatch."
+          fi
+          if jq -e '[.labels[].name] | any(. == "agents:formatted")' live.json >/dev/null; then
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted" \
               || echo "::warning::could not remove agents:formatted"
           fi
           gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "agents:format" \
             || echo "::warning::could not apply agents:format (label missing in this repo?)"
+          if [[ "$dispatch" != true ]]; then
+            exit 0
+          fi
           # GITHUB_TOKEN label edits do not start issues:labeled workflows; dispatch is explicit.
-          gh workflow run agents-issue-optimizer.yml --repo "$GITHUB_REPOSITORY" \
-            -f issue_number="$NUMBER" -f phase=format
+          # Persist the completion marker only after a successful workflow_dispatch so a
+          # failed run remains retryable on the next guard pass.
+          if ! gh workflow run agents-issue-optimizer.yml --repo "$GITHUB_REPOSITORY" \
+              -f issue_number="$NUMBER" -f phase=format; then
+            echo "::error::optimizer dispatch failed; no completion marker written so later runs can retry"
+            exit 1
+          fi
+          if [[ "$trusted_marker" != true ]]; then
+            {
+              cat report.md
+              echo
+              echo "Dispatched the Agents Issue Optimizer format phase."
+              echo
+              echo "$marker"
+            } | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
+          fi
 
       - name: Restore format completion after an unheld revalidation
         if: >-

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -126,6 +126,7 @@ jobs:
           repository: stranske/Workflows
           path: workflows-scripts
           sparse-checkout: |
+            .github/scripts/issue_format.py
             config
             scripts/langchain
             tools
@@ -466,6 +467,9 @@ jobs:
           print('Suggestions applied successfully')
           " || exit 1
 
+          # Keep agents:formatted truthful for apply-phase output too.
+          python workflows-scripts/.github/scripts/issue_format.py /tmp/updated_body.md
+
           # Update issue body
           gh issue edit "${ISSUE_NUMBER}" --body-file /tmp/updated_body.md
 
@@ -503,6 +507,11 @@ jobs:
               f.write(formatted)
           print('Issue formatted successfully')
           " || exit 1
+
+          # Keep the format-result label truthful: the generated issue must
+          # pass the canonical Workflows validator before it can be marked
+          # agents:formatted below.
+          python workflows-scripts/.github/scripts/issue_format.py /tmp/formatted_body.md
 
           # Update issue body with formatted version
           gh issue edit "${ISSUE_NUMBER}" --body-file /tmp/formatted_body.md


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-optimizer.yml: Issue optimizer - LangChain-based issue formatting and optimization (Phase 1)
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.
- issue_format.py: Pure-stdlib validator for AGENT_ISSUE_FORMAT compliance. Single fleet definition of agent-processable; used by agents-issue-format-guard.yml and callable directly by local filers to pre-flight before gh issue create (non-zero exit = unfit). Do not fork per repo.

### Files Skipped
- .github/workflows/pr-00-gate.yml: Maintains a fully custom Gate workflow; never overwrite (replaces the hard-coded custom_gate_repos list in maint-68).
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `01605f56ba17f3b9072fa187b7edd4f02e22e955`
**Template hash:** `573cba6a5604`
**Consumer-sync plan ID:** `sha256:573cba6a5604528742c2101ed19afa35774c176a0ed1b6aeda6f48a26a94402e`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-573cba6a5604`
**Consumer repo:** `stranske/Manager-Database`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Manager-Database","source_repository":"stranske/Workflows","source_sha":"01605f56ba17f3b9072fa187b7edd4f02e22e955","template_hash":"573cba6a5604","plan_id":"sha256:573cba6a5604528742c2101ed19afa35774c176a0ed1b6aeda6f48a26a94402e","sync_phase":"canary","sync_branch":"sync/workflows-573cba6a5604","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31241246350","run_attempt":"1","changes_count":3} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:573cba6a5604528742c2101ed19afa35774c176a0ed1b6aeda6f48a26a94402e","generation":"573cba6a5604","repository":"stranske/Manager-Database","desired_tree_hash":"4008d4a2fc036938c04ebf4321efc3e5544f24d2","source_commit":"01605f56ba17f3b9072fa187b7edd4f02e22e955","lease_expires_at":"2026-08-11T05:15:24Z","predecessor_prs":[],"successor_prs":[]} -->