### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.2
+RUFF_VERSION=0.16.3
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 26.5.1
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.3
+    rev: v0.16.3
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         args: ["--explicit-package-bases"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov==7.1.0",
     "black==26.5.1",
-    "ruff==0.16.2",
+    "ruff==0.16.3",
     "pre-commit",
     "mypy==2.3.0",
     "langchain>=1.2,<2.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -535,7 +535,7 @@ ruamel-yaml==0.19.1
     # via prefect
 ruamel-yaml-clib==0.2.15 ; platform_python_implementation == 'CPython'
     # via prefect
-ruff==0.16.2
+ruff==0.16.3
     # via manager-database (pyproject.toml)
 s3transfer==0.19.2
     # via boto3


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 5 version updates:
  - ruff: ==0.16.2 -> ==0.16.3
  - requirements.lock:ruff: 0.16.2 -> ==0.16.3
  - .pre-commit-config.yaml:psf/black: 24.3.0 -> 26.5.1
  - .pre-commit-config.yaml:astral-sh/ruff-pre-commit: v0.3.3 -> v0.16.3
  - .pre-commit-config.yaml:pre-commit/mirrors-mypy: v1.10.0 -> v2.3.0

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`
**Settled source commit:** `770c226a9eeb22be1dc8e1e33511f8aacd5434a8`

<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"dev-tool-02c0c6e3cd5f","generation":"02c0c6e3cd5f","repository":"stranske/Manager-Database","desired_tree_hash":"f7b831813efdc4e4bb201d2949f80d3135837c8e","source_commit":"770c226a9eeb22be1dc8e1e33511f8aacd5434a8","lease_expires_at":"2026-08-16T19:28:25Z","predecessor_prs":[],"successor_prs":[]} -->